### PR TITLE
fix: correct the audit's verdict path, then gate it (Units 1–6)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": {
     "name": "Richard Graham"
   }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # The only dependency surfaces this repo has. audit.py imports nothing outside
+  # the standard library on purpose, so there is no manifest to watch — just the
+  # workflow's SHA-pinned actions and the pinned pre-commit hook revisions.
+  #
+  # These PRs are also the only end-to-end exercise this plugin gets: running
+  # /dependabot-audit on them is the closest thing to a live test available
+  # without `claude plugin eval`. That is a reason to keep the cadence low but
+  # non-zero rather than to disable it.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # audit.py runs under whatever bare `python3` the repo under audit happens to
+    # have, and tomllib puts the floor at 3.11. The maintainer's machine is the
+    # newest of these, so the older legs are the ones carrying information — and
+    # cross-version coverage is the one thing the local hooks cannot provide.
+    name: Test (Python ${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+      # No install step. The suite is stdlib-only and reaches no network, which
+      # is what keeps this job hermetic and cheap on a free org's minutes.
+      - run: python -m unittest discover -s tests -v
+
+  lint:
+    name: Lint & type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      # Runs the pre-commit hooks themselves, so the ruff and mypy versions here
+      # are the ones pinned in .pre-commit-config.yaml. A second `pip install
+      # ruff mypy` would be a second pin, and the two would drift.
+      - run: pip install pre-commit
+      - run: pre-commit run --all-files --show-diff-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 __pycache__/
 *.pyc
+
+# Not a real lockfile. This repo has no dependencies — audit.py is stdlib-only
+# so it runs under whatever bare python3 the repo under audit has. uv writes an
+# empty one anyway whenever `uv run` is invoked here without --no-project,
+# purely because pyproject.toml exists to configure the linters.
+uv.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+# Local gates, and the only enforcing ones. Branch protection and rulesets are
+# both unavailable on this repo's plan (private repo, free org), so a CI check
+# can never be made required — CI here is advisory, and these hooks are what can
+# actually stop a bad commit. Install with: pre-commit install
+#
+# The pinned `rev:`s are the single source of truth for tool versions: CI runs
+# `pre-commit run --all-files` rather than its own `pip install ruff mypy`, so
+# there is no second pin to drift from. (The sibling fpga-board-sim repo uses
+# local `uv run` hooks for exactly the same reason inverted — there a uv.lock
+# already owns the versions, so a mirror `rev:` would be the competing pin. This
+# repo has no lockfile and no dependencies by design, so the rev is the only one.)
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.2
+    hooks:
+      # Lint before format, per Astral's ordering guidance, so `--fix` output is
+      # then reformatted.
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.3.0
+    hooks:
+      # mirrors-mypy builds an isolated environment, which is normally the reason
+      # to avoid it: a project's own dependencies are missing from it and
+      # expressions silently degrade to Any. audit.py imports nothing outside the
+      # stdlib, so there is nothing to miss.
+      - id: mypy
+        args: []
+        pass_filenames: false     # `files` in pyproject.toml picks the scope
+
+  - repo: local
+    hooks:
+      # Hooks see only staged files, but the suite is stdlib-only, reaches no
+      # network, and finishes in milliseconds — and a change to the skill prose
+      # can invalidate a test's premise just as a change to the script can. So it
+      # always runs, rather than only when a .py file happens to be staged.
+      - id: unittest
+        name: unittest (stdlib, no network)
+        entry: python3 -m unittest discover -s tests
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ the verdict, and the merge command **left un-run**.
 | 5 | Independent reproduction — frozen install and the repo's own gates in an isolated worktree |
 | 6 | CI verification — the run for the exact head SHA, and the required contexts specifically |
 | 7 | Report |
-| 8 | Learning loop — persist anything that could not have been derived |
+| 8 | Learning loop — hand back anything that could not have been derived |
 
 Phase 0 derives repo specifics **every run and never caches them** — a cached
-profile silently audits a repo that no longer exists. Phase 8 persists only what
-cannot be derived: the landmines you can otherwise learn only by getting bitten
-twice. Nothing derivable is cached; nothing hard-won is re-derived.
+profile silently audits a repo that no longer exists. Phase 8 writes out only what
+cannot be derived — the landmines you otherwise learn by getting bitten twice —
+and hands it to you rather than saving it itself. Nothing derivable is cached;
+nothing hard-won is re-derived.
 
 ## Ecosystem coverage
 
@@ -119,10 +120,25 @@ on an empty selection.
 
 ## Read-only
 
-The skill declares `tools: Read, Grep, Glob, Bash`. That withholds `Edit` and
-`Write`, but `Bash` could reach `gh pr merge` — so "reports, never merges" is a
-**contract, not a sandbox**. It is stated in the skill, and the report ends with
-the merge command printed rather than executed.
+The skill declares `disallowed-tools: Edit, Write, NotebookEdit`, which removes
+those from Claude's pool while it is active. `Bash` remains and could reach
+`gh pr merge`, so "reports, never merges" is still a **contract, not a sandbox**.
+It is stated at the top of the skill, and the report ends with the merge command
+printed rather than executed.
+
+Two caveats worth knowing, since both were wrong here until `0.1.9`:
+
+- **`tools:` is not a skill frontmatter field.** Earlier releases declared it and
+  it withheld nothing — an unrecognized key that read like a control. The field
+  that grants is `allowed-tools`; the field that removes is `disallowed-tools`.
+  Reaching for the wrong one gives you the opposite of what you meant.
+- **`disallowed-tools` is a Claude Code extension, not part of the [Agent Skills]
+  (https://agentskills.io) spec's six fields.** So it takes a recent Claude Code
+  to have any effect — older builds ignore unrecognized frontmatter silently, and
+  `plugin.json` has no way to enforce a floor — and it means this skill cannot be
+  packaged for claude.ai upload or the Skills API, which reject non-spec keys with
+  a hard error. That is a deliberate trade: enforcement in the channel this plugin
+  actually ships through beats portability to one it doesn't.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ what gets *reported*, not just what gets returned.
 Each test was mutation-checked against the original buggy implementation to
 confirm it discriminates — a suite that only ever passes proves nothing.
 
+### Gates
+
+```
+pre-commit install          # ruff, mypy and the suite, on every commit
+pre-commit run --all-files  # exactly what CI runs
+```
+
+**The hooks are the enforcing gate; CI is advisory.** This repo is private on a
+free org, where branch protection and repository rulesets are both unavailable
+(`403 Upgrade to GitHub Pro or make this repository public`), so no check can be
+marked required. CI earns its place on the one thing the hooks cannot do: run the
+suite on Python 3.11 through 3.14, because `audit.py` runs under whatever bare
+`python3` the repo under audit happens to have, and `tomllib` puts the floor at
+3.11. The maintainer's machine is the newest of those, so the older legs are the
+ones carrying information.
+
+Tool versions live in `.pre-commit-config.yaml` and nowhere else — CI invokes the
+hooks rather than installing its own ruff and mypy, so there is no second pin to
+drift from.
+
 **Not covered:** the skill's prose. These tests exercise `audit.py`, the
 deterministic half. Whether the model actually *follows* Phase 6, or stops on an
 unexpected file in the diff, is behavioral and belongs in `claude plugin eval`

--- a/README.md
+++ b/README.md
@@ -82,17 +82,23 @@ have a repo to test it against.
 python3 -m unittest discover -s tests -v
 ```
 
-30 cases, stdlib only, no network — they run offline and free. Every case
+39 cases, stdlib only, no network — they run offline and free. Every case
 corresponds to a defect that actually shipped, or to a failure the audit exists
-to detect: a corrupted hash, a size mismatch, a yanked release, an artifact
-missing from the registry, a lagging version, a package pinned at two versions
-under different resolution-markers, the *held-back* fork of that pair which must
-not read as stale alongside the *live* one which must still be checked, a
-publish time taken from the earliest artifact rather than an arbitrary one, a
-pre-release that has no business in the gap next to a post-release that does, a
-requested name that isn't in the lockfile, an empty selection that must not
-report `CLEAN`, a lockfile compared against itself, and a non-PyPI package that
-has to be named rather than dropped.
+to detect. They fall into four groups:
+
+- **Provenance** — a corrupted hash, a size mismatch, a yanked release, an
+  artifact missing from the registry, and an sdist checked alongside the wheels.
+- **Currency** — a lagging version; a package pinned at two versions under
+  different resolution-markers, where the *held-back* fork must not read as stale
+  and the *live* one must still be checked; a publish time taken from the earliest
+  artifact rather than an arbitrary one; and a pre-release that has no business in
+  the gap, next to a post-release that does.
+- **Under-auditing** — a requested name that isn't in the lockfile, an empty
+  selection that must not report `CLEAN`, a lockfile compared against itself, and
+  a non-PyPI package that has to be named rather than dropped.
+- **Failure vs. finding** — an unreadable lockfile, an unreachable registry, and
+  an OSV outage, each of which has to exit 2 rather than borrow the status that
+  means "found something".
 
 The theme is **silent** failure. An audit that reports success while verifying
 less than it claimed is worse than one that crashes, so the assertions target

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ the verdict, and the merge command **left un-run**.
 
 | Phase | |
 |---|---|
-| 0 | Discover the repo — required checks, bot config, the repo's own CI gates and their scopes |
-| 1 | Scope and provenance — every locked artifact's hash, size, URL, yank status vs. the live registry |
+| 0 | Discover the repo — required checks, bot config, the repo's own CI gates and their scopes; pin the PR's head SHA and fetch it once |
+| 1 | Scope and provenance — every locked artifact's hash, size, URL, yank status vs. the live registry, read out of git at the pinned ref |
 | 2 | Currency — the registry's true latest, publish times vs. PR open time, and changelogs across the gap |
 | 3 | Known vulnerabilities — OSV batch plus the ecosystem's own auditor |
 | 4 | Behavior change — added rules and changed defaults against this repo's config and gate scopes |
@@ -82,12 +82,14 @@ have a repo to test it against.
 python3 -m unittest discover -s tests -v
 ```
 
-18 cases, stdlib only, no network — they run offline and free. Every case
+22 cases, stdlib only, no network — they run offline and free. Every case
 corresponds to a defect that actually shipped, or to a failure the audit exists
 to detect: a corrupted hash, a size mismatch, a yanked release, an artifact
 missing from the registry, a lagging version, a marker-constrained pin that must
 *not* read as stale, a package pinned at two versions under different
-resolution-markers, and a requested name that isn't in the lockfile.
+resolution-markers, a requested name that isn't in the lockfile, an empty
+selection that must not report `CLEAN`, a lockfile compared against itself, and a
+non-PyPI package that has to be named rather than dropped.
 
 The theme is **silent** failure. An audit that reports success while verifying
 less than it claimed is worse than one that crashes, so the assertions target
@@ -99,9 +101,12 @@ confirm it discriminates — a suite that only ever passes proves nothing.
 **Not covered:** the skill's prose. These tests exercise `audit.py`, the
 deterministic half. Whether the model actually *follows* Phase 6, or stops on an
 unexpected file in the diff, is behavioral and belongs in `claude plugin eval`
-— which is in early access and unavailable on this account. That gap is real:
-the one defect found by running the skill end-to-end (Phase 6 improvising a
-check-name parse) lived in the prose, where these tests cannot reach.
+— which is in early access and unavailable on this account. That gap is real, and
+it is where the defects keep turning up: Phase 6 once improvised a check-name
+parse, and Phase 1 referenced a branch that Phase 5 created, so a literal reading
+audited the base branch instead of the PR. Both lived in the prose, where these
+tests cannot reach — the second is why the script now refuses to report `CLEAN`
+on an empty selection.
 
 ## Read-only
 

--- a/README.md
+++ b/README.md
@@ -82,14 +82,17 @@ have a repo to test it against.
 python3 -m unittest discover -s tests -v
 ```
 
-22 cases, stdlib only, no network — they run offline and free. Every case
+30 cases, stdlib only, no network — they run offline and free. Every case
 corresponds to a defect that actually shipped, or to a failure the audit exists
 to detect: a corrupted hash, a size mismatch, a yanked release, an artifact
-missing from the registry, a lagging version, a marker-constrained pin that must
-*not* read as stale, a package pinned at two versions under different
-resolution-markers, a requested name that isn't in the lockfile, an empty
-selection that must not report `CLEAN`, a lockfile compared against itself, and a
-non-PyPI package that has to be named rather than dropped.
+missing from the registry, a lagging version, a package pinned at two versions
+under different resolution-markers, the *held-back* fork of that pair which must
+not read as stale alongside the *live* one which must still be checked, a
+publish time taken from the earliest artifact rather than an arbitrary one, a
+pre-release that has no business in the gap next to a post-release that does, a
+requested name that isn't in the lockfile, an empty selection that must not
+report `CLEAN`, a lockfile compared against itself, and a non-PyPI package that
+has to be named rather than dropped.
 
 The theme is **silent** failure. An audit that reports success while verifying
 less than it claimed is worse than one that crashes, so the assertions target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,54 @@
+# This plugin has no build step and no dependencies: audit.py is stdlib-only so
+# it runs under whatever bare `python3` the repo under audit happens to have.
+# There is deliberately no [project] table — this file exists to configure the
+# linters, and to give the `# noqa` directives in the source something to mean.
+#
+# Note for anyone reaching for uv here: the mere presence of this file makes
+# `uv run` treat the directory as a project and write a uv.lock that locks
+# nothing, with requires-python taken from whichever interpreter you happened to
+# invoke rather than this script's real 3.11 floor. Use `uv run --no-project`,
+# which is the only thing that suppresses it — `[tool.uv] managed = false` does
+# not (tested). The stray lockfile is gitignored either way.
+
+# ── Ruff (linter + formatter) ────────────────────────────────────────────────
+[tool.ruff]
+target-version = "py311"        # tomllib
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+    "E", "W",   # pycodestyle
+    "F",        # pyflakes
+    "I",        # isort
+    "UP",       # pyupgrade
+    "B",        # flake8-bugbear
+    "SIM",      # flake8-simplify
+    "RUF",      # ruff's own rules
+    # The whole job of this script is fetching URLs and comparing what comes
+    # back, so the security rules are the relevant ones -- and S310 in
+    # particular is already annotated in the source. Without S selected that
+    # annotation silences nothing while reading as a considered decision.
+    "S",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# S101: assert is how a test asserts.
+# E501: the lockfile fixture embeds a real-shaped URL and a 64-character sha256
+#       in one TOML inline table, which the format does not allow wrapping.
+#       Line length there is a property of the data, not of authored prose.
+"tests/*" = ["S101", "E501"]
+
+# ── mypy (static type checker) ───────────────────────────────────────────────
+[tool.mypy]
+python_version = "3.11"
+files = ["skills/dependabot-audit/scripts", "tests"]
+mypy_path = "skills/dependabot-audit/scripts"
+strict = true
+
+[[tool.mypy.overrides]]
+# Test functions and their calls to each other are exempt, matching the policy
+# in the repos this plugin audits. The script itself is checked under full
+# strict, and passes.
+module = ["test_audit"]
+disallow_untyped_defs = false
+disallow_untyped_calls = false

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -44,7 +44,30 @@ DEFAULT=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
 gh api "repos/:owner/:repo/branches/$DEFAULT/protection" --jq '.required_status_checks.contexts[]'
 
 cat .github/dependabot.yml 2>/dev/null || cat renovate.json 2>/dev/null
+
+# pin the commit under audit and fetch it once, for every later phase
+SCRATCH=${SCRATCH:-$(mktemp -d)}          # any directory OUTSIDE the repo
+HEAD_SHA=$(gh pr view <N> --json headRefOid --jq .headRefOid)   # full 40 chars
+git fetch origin "pull/<N>/head:pr-<N>"
+BASE_SHA=$(git merge-base "$DEFAULT" "pr-<N>")
 ```
+
+**Pin the head SHA here and audit that one commit everywhere.** The lockfile
+Phase 1 reads, the worktree Phase 5 builds, and the CI run Phase 6 checks must all
+describe the *same* commit, or the report's evidence table asserts a coherence it
+does not have. Bots rebase, so this is not hypothetical: a rebase mid-audit leaves
+Phases 1–5 describing a commit that no longer exists while Phase 6 reports on the
+new one. Fetching once and working from `pr-<N>` makes them consistent by
+construction, and Phase 7 re-checks the SHA before you write.
+
+**Never audit the working tree.** Whatever branch the user happens to have checked
+out is not the PR, and a lockfile read from it is indistinguishable from one read
+from the PR — it just quietly reports no changes.
+
+Use a harness-provided scratch directory for `SCRATCH` if you have one; otherwise
+`mktemp -d`. **Never place it inside the repo under audit** — it pollutes
+`git status`, and a gate that walks the tree (a linter, a formatter, a test
+collector) will descend into a full second copy of the project and report on it.
 
 **Derive the branch name; never type it.** A failed protection call and a repo
 with no protection both yield *no contexts*, so if stderr is discarded or the
@@ -79,29 +102,33 @@ workflow file for an actions bump). Anything else is a finding — say so and st
 Verify every artifact the lockfile pins for the changed packages against the live
 registry: sha256/integrity, size, URL, and yanked status.
 
+**Read both lockfiles out of git**, using the ref and merge base pinned in Phase
+0. A bare `uv.lock` path resolves against the user's checkout, which parses fine,
+derives *no* changed packages, and produces a confident audit of nothing:
+
 ```bash
 S="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py"
 
-# grouped bumps are the common case — audit every package together
-python3 "$S" uv.lock --changed pkg-a,pkg-b,pkg-c
+git show "pr-<N>:uv.lock"    > "$SCRATCH/pr.uv.lock"
+git show "$BASE_SHA:uv.lock" > "$SCRATCH/base.uv.lock"
 
-# better: derive the set instead of naming it (see below)
-python3 "$S" uv.lock --changed-vs base.uv.lock
+python3 "$S" "$SCRATCH/pr.uv.lock" --changed-vs "$SCRATCH/base.uv.lock"
 ```
 
 **Do not read the package names off the PR title.** A grouped bump is titled
 "with 3 updates" and names none of them, and a bot may group everything (check
-the `groups:` key you read in Phase 0). Derive the set from the lockfile diff
-against the **merge base** — not the current default branch, or unrelated drift
-that landed after the PR branched gets attributed to this PR:
+the `groups:` key you read in Phase 0). `--changed-vs` derives the set from the
+diff against the **merge base** — not the current default branch, or unrelated
+drift that landed after the PR branched gets attributed to this PR. Naming
+packages by hand (`--changed pkg-a,pkg-b`) is the fallback for a diff the script
+cannot read, not the default.
 
-```bash
-git show "$(git merge-base <default> pr-<N>):uv.lock" > base.uv.lock
-python3 "$S" uv.lock --changed-vs base.uv.lock
-```
-
-The script exits **2** if a name you asked for is not in the lockfile, rather
-than auditing the rest and looking successful.
+The script will not look successful while verifying less than it should. It exits
+**2** if a name you asked for is not in the lockfile, and **2** if the selected
+set comes out empty — a run that verifies nothing must never print `CLEAN`. Its
+`RESULT` line carries the package and artifact counts and names anything it could
+not reach (git, path, or a private-index dependency); quote those counts in the
+report rather than writing "verified" unqualified.
 
 For PyPI that one invocation covers this phase **plus the mechanical half of
 Phases 2 and 3** — it also reports the registry's true latest version with
@@ -160,26 +187,21 @@ Not "is it safe" but **"does it change what this repo's gates accept"**.
 
 ## Phase 5 — Independent reproduction
 
-In an isolated worktree, so the user's working tree is untouched:
+In an isolated worktree, so the user's working tree is untouched. `SCRATCH` and
+the `pr-<N>` ref both come from Phase 0:
 
 ```bash
-SCRATCH=${SCRATCH:-$(mktemp -d)}          # any directory OUTSIDE the repo
-git fetch origin pull/<N>/head:pr-<N>
-git worktree add "$SCRATCH/pr-<N>" pr-<N>
+git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 ```
-
-Use a harness-provided scratch directory if you have one; otherwise `mktemp -d`.
-**Never place it inside the repo under audit** — it pollutes `git status`, and a
-gate that walks the tree (a linter, a formatter, a test collector) will descend
-into a full second copy of the project and report on it.
 
 If a worktree from an earlier run is already there, **prove it still points at
 this PR's head before reusing it** — a stale worktree silently audits the wrong
-commit and every result downstream is wrong:
+commit and every result downstream is wrong. Compare it against the pinned SHA
+rather than eyeballing a log line:
 
 ```bash
-git -C "$SCRATCH/pr-<N>" log --oneline -1     # must be the PR head
-git -C "$SCRATCH/pr-<N>" status --porcelain   # must be empty
+test "$(git -C "$SCRATCH/pr-<N>" rev-parse HEAD)" = "$HEAD_SHA"   # from Phase 0
+git -C "$SCRATCH/pr-<N>" status --porcelain                       # must be empty
 ```
 
 If either check fails, `git worktree remove` it and recreate.
@@ -191,17 +213,19 @@ own gates from Phase 0, and its full test suite.
 Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing suite sails
 through; use `set -o pipefail` or separate calls.
 
-**Close the loop.** A worktree is registered in the *user's* repo, so an audit
-that walks away leaves litter behind — and they accumulate, one per PR audited.
-Either remove it when finished, or keep it deliberately and say so in the report
-so the user knows it is there:
+**Close the loop.** The worktree *and* the `pr-<N>` branch Phase 0 fetched are
+both registered in the **user's** repo, so an audit that walks away leaves litter
+behind — and it accumulates, one per PR audited. The branch outlives an audit that
+stopped before Phase 5, too. Either remove them when finished, or keep them
+deliberately and say so in the report so the user knows they are there:
 
 ```bash
-git worktree remove "$SCRATCH/pr-<N>"     # and: git branch -D pr-<N>
+git worktree remove "$SCRATCH/pr-<N>"
+git branch -D "pr-<N>"
 ```
 
-Keeping it is reasonable when a follow-up run is likely; silently keeping it is
-not.
+Keeping them is reasonable when a follow-up run is likely; silently keeping them
+is not.
 
 ## Phase 6 — CI verification
 
@@ -241,6 +265,17 @@ exist.
 re-trigger CI.
 
 ## Phase 7 — Report
+
+**Re-check the head SHA before you write anything.** Every row above describes the
+commit pinned in Phase 0. If the bot rebased mid-audit, Phases 1–5 now describe a
+commit that no longer exists while Phase 6 reports on the new one — and the table
+silently asserts that they agree:
+
+```bash
+test "$(gh pr view <N> --json headRefOid --jq .headRefOid)" = "$HEAD_SHA"
+```
+
+If it moved, say so and re-run from Phase 1. Do not reconcile the two by hand.
 
 Use the exact shape in `references/report-template.md`: verdict, confidence,
 evidence table, reasoning, what would change the verdict, and the **un-run** merge

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -123,12 +123,14 @@ drift that landed after the PR branched gets attributed to this PR. Naming
 packages by hand (`--changed pkg-a,pkg-b`) is the fallback for a diff the script
 cannot read, not the default.
 
-The script will not look successful while verifying less than it should. It exits
-**2** if a name you asked for is not in the lockfile, and **2** if the selected
-set comes out empty — a run that verifies nothing must never print `CLEAN`. Its
-`RESULT` line carries the package and artifact counts and names anything it could
-not reach (git, path, or a private-index dependency); quote those counts in the
-report rather than writing "verified" unqualified.
+The script will not look successful while verifying less than it should. **Exit 2
+means it could not run** — a name you asked for is not in the lockfile, the
+selected set came out empty, the lockfile is unreadable, or a registry was
+unreachable. **Exit 1 means it ran and found something.** Never read a 2 as a
+finding, or a 1 as an outage. Its `RESULT` line carries the package and artifact
+counts and names anything it could not reach (git, path, or a private-index
+dependency); quote those counts in the report rather than writing "verified"
+unqualified.
 
 For PyPI that one invocation covers this phase **plus the mechanical half of
 Phases 2 and 3** — it also reports the registry's true latest version with

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dependabot-audit
 description: Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation — verify lockfile artifact hashes against the registry, cross-check the true latest version, read changelogs for security and behavior changes, reproduce the repo's own checks in an isolated worktree, and report. Use when the user asks to review, audit, check, or decide on a Dependabot or Renovate PR, a dependency bump, a lockfile PR, or asks "is this safe to merge".
-tools: Read, Grep, Glob, Bash
+disallowed-tools: Edit, Write, NotebookEdit
 ---
 
 # Dependabot Audit
@@ -10,9 +10,12 @@ tools: Read, Grep, Glob, Bash
 evidence behind it, and stops. Do not merge, approve, close, comment on, rebase,
 or push to the PR. Print the merge command; do not run it.
 
-`tools:` withholds `Edit` and `Write`, but `Bash` can reach `gh pr merge`. That
-restraint is a **contract, not a sandbox** — honor it. The one exception is the
-learning loop in Phase 8, which appends to the user's project memory.
+`disallowed-tools` removes `Edit`, `Write`, and `NotebookEdit` from the pool while
+this skill is active, but `Bash` remains and can reach `gh pr merge`. That
+restraint is a **contract, not a sandbox** — honor it. There is no exception:
+Phase 8 hands its memory entry back rather than writing it, precisely because
+reaching for `Bash` to do what the withheld tools would have done makes the
+withholding theatre.
 
 ## Why this procedure exists
 
@@ -318,10 +321,12 @@ are worth writing down.
 
 If this audit surfaced a repo-specific landmine — a tool whose defaults collide
 with this repo's config, a hook whose scope hides a CI failure, an invocation that
-silently measures the wrong thing — append it to the user's **project memory** as
-a `project` memory, with the evidence and how it was caught. If no memory
-directory is available, propose the equivalent addition to the repo's
-`CONTRIBUTING.md` gotchas section instead.
+silently measures the wrong thing — **write it out and hand it over**: the
+filename, the frontmatter, and the body of a `project` memory, with the evidence
+and how it was caught. Do not create the file; the session that invoked this skill
+can, and it is the one that owns the decision. If no memory directory exists,
+offer the same text as an addition to the repo's `CONTRIBUTING.md` gotchas
+section.
 
 A generally portable trap belongs in `references/traps.md` in this plugin, not in
 one project's memory. Say which you are proposing, and why.

--- a/skills/dependabot-audit/references/ecosystems.md
+++ b/skills/dependabot-audit/references/ecosystems.md
@@ -34,8 +34,9 @@ Metadata by hand: `https://pypi.org/pypi/<pkg>/json` →
 **`uv.lock` can contain several `[[package]]` blocks with the same name**, each
 carrying its own `resolution-markers` — typically the last release supporting an
 older Python alongside the current one. The script handles this; if you verify by
-hand, do not assume one block per name, and do not report a marker-constrained
-block as stale.
+hand, do not assume one block per name. Do not report the *lower* block as stale
+— but do check the highest one, which carries markers just the same and is still
+expected to track the registry.
 
 **Auditor trap.** `pip-audit` audits the environment of the interpreter it runs
 under. Activating a virtualenv does **not** redirect a `pip-audit` installed

--- a/skills/dependabot-audit/references/ecosystems.md
+++ b/skills/dependabot-audit/references/ecosystems.md
@@ -18,8 +18,14 @@ that nobody checks.
 Covered by the script:
 
 ```bash
-python3 scripts/audit.py path/to/uv.lock --changed <pkg> [--json]
+S="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py"
+python3 "$S" "$SCRATCH/pr.uv.lock" --changed-vs "$SCRATCH/base.uv.lock"
 ```
+
+Both lockfiles come out of git at the ref Phase 0 pinned, never off the working
+tree. The script reports how many packages and artifacts it checked, and names
+anything it could not reach — a package resolved from git, a path, or a private
+index is outside its scope and is listed rather than dropped.
 
 Metadata by hand: `https://pypi.org/pypi/<pkg>/json` →
 `.info.version` (latest), `.releases["<ver>"][]` with `.digests.sha256`, `.size`,

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -20,7 +20,7 @@ turns on.
 | Phase | Result | Observed |
 |---|---|---|
 | **Scope** | Which files the diff touches. | this run |
-| **Provenance** | N/N artifacts verified: hash, size, URL, yanked status. | this run |
+| **Provenance** | N package(s), M artifact(s): hash, size, URL, yanked status — quote the script's own counts, plus anything it reported as unreachable. | this run |
 | **Currency** | Registry latest vs. proposed, with publish time vs. PR open time. Yank and ignore-rule status. | this run |
 | **Security** | Changelog `Security` sections across the gap — including their absence. | this run *or* reused — release notes immutable |
 | **Vulnerabilities** | OSV result and the ecosystem auditor's, over N packages. | this run |

--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -57,10 +57,18 @@ Observed: a `uv.lock` pinning `rpds-py` at both `0.30.0` (Python < 3.11) and
 `2026.6.3` — 231 artifacts across the two entries, of which a name-keyed audit
 checked 116.
 
-**A constrained pin is not a stale pin.** An entry held back by an environment
-marker — the last release supporting an older interpreter — trails the registry
-permanently and by design. Reporting it as "not current" invites a follow-up bump
-that can never be made. Check for the constraint before calling it stale.
+**A constrained pin is not a stale pin — but only the *lower* fork is
+constrained.** An entry held back by an environment marker (the last release
+supporting an older interpreter) trails the registry permanently and by design,
+and reporting it as "not current" invites a follow-up bump that can never be
+made. The trap is the correction: uv stamps `resolution-markers` on **every**
+block of a forked package, including the highest one — the pin that actually gets
+installed on a current interpreter and *is* expected to track the registry. Treat
+the presence of markers as an exemption and you exempt the only pin a bump could
+ever move, so staleness on it becomes invisible.
+
+Compare against the package's other pins, not against the markers alone: the
+highest pin is live, the rest are held back.
 
 ## Registry and pinning
 

--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -145,5 +145,14 @@ normal, just describes something else. Make the scanner run *inside* the project
 environment and sanity-check that the package names in its output belong to the
 project.
 
+**A check that failed and a check that found something exit the same way unless
+you make them differ.** An unhandled exception exits 1, which is also the
+conventional "found something" status — so a verifier whose registry lookup times
+out reports exactly as though it had found a vulnerability, and one handed an
+unreadable file reports as though the file was bad. Give "could not run" its own
+status (2 by convention) and route every foreseeable failure through it. The same
+applies in reverse when you consume someone else's tool: before treating its
+non-zero exit as a finding, check that it distinguishes the two at all.
+
 **Reproduce in an isolated worktree.** Never mutate the user's working tree to
 audit a branch.

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -19,8 +19,10 @@ says "with 3 updates" and names none of them.
 
 Exit status: 0 = nothing to report, 1 = at least one discrepancy, stale version,
 or known vulnerability, 2 = usage/lookup error — including a requested package
-that is not in the lockfile, and an empty selection. Never audit fewer packages
-than asked in silence, and never print CLEAN on a run that verified nothing.
+that is not in the lockfile, an empty selection, an unreadable lockfile, and a
+registry that could not be reached. Never audit fewer packages than asked in
+silence, never print CLEAN on a run that verified nothing, and never let a failed
+lookup exit as though it were a finding.
 Requires Python 3.11+ (tomllib) and network access.
 """
 
@@ -30,23 +32,57 @@ import argparse
 import json
 import re
 import sys
+import time
 import tomllib
 import urllib.error
 import urllib.request
-from typing import Any
+from typing import Any, NoReturn
 
 PYPI = "https://pypi.org/pypi/{name}/json"
 OSV_BATCH = "https://api.osv.dev/v1/querybatch"
 TIMEOUT = 60
+# One retry. An audit makes a call per changed package plus the OSV batch, and
+# losing a dozen good calls to one transient 502 is worse than waiting 2s.
+ATTEMPTS = 2
+BACKOFF = 2.0
+UA = "dependabot-audit (+https://github.com/Machai-Kydoimos/dependabot-audit)"
+
+
+def fail(what: str) -> NoReturn:
+    """Exit 2 — the audit could not run.
+
+    Distinct from exit 1, which means the audit ran and found something. An
+    unhandled exception exits 1, so every foreseeable failure has to come through
+    here: otherwise a registry outage is indistinguishable from a finding, and
+    the caller reads "OSV unreachable" as "OSV reported a vulnerability".
+    """
+    print(f"error: {what}", file=sys.stderr)
+    raise SystemExit(2)
 
 
 def _get_json(url: str, payload: bytes | None = None) -> Any:
     req = urllib.request.Request(url)
+    req.add_header("User-Agent", UA)
     if payload is not None:
         req.data = payload
         req.add_header("Content-Type", "application/json")
-    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:  # noqa: S310
-        return json.load(resp)
+    for attempt in range(ATTEMPTS):
+        try:
+            with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:  # noqa: S310
+                return json.load(resp)
+        except urllib.error.HTTPError as exc:
+            # A 4xx is an answer, not a hiccup: "no such package" is information
+            # the caller needs now, and retrying only delays it.
+            if exc.code < 500 or attempt == ATTEMPTS - 1:
+                raise
+            time.sleep(BACKOFF)
+        except (OSError, json.JSONDecodeError):
+            # OSError covers URLError and TimeoutError both; a read that times
+            # out mid-body raises TimeoutError, which is not a URLError.
+            if attempt == ATTEMPTS - 1:
+                raise
+            time.sleep(BACKOFF)
+    raise AssertionError("unreachable: the loop returns or raises")
 
 
 def _normalize(name: str) -> str:
@@ -103,7 +139,10 @@ def _sortable(version: str) -> tuple[int, ...]:
 
 def load_lock(path: str) -> list[dict[str, Any]]:
     with open(path, "rb") as fh:
-        return tomllib.load(fh)["package"]
+        data = tomllib.load(fh)
+    if "package" not in data:
+        raise ValueError("no [[package]] entries — is this a lockfile?")
+    return list(data["package"])
 
 
 def _is_pypi(pkg: dict[str, Any]) -> bool:
@@ -347,15 +386,25 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
     args = parser.parse_args()
 
-    locked = load_lock(args.lock)
+    try:
+        locked = load_lock(args.lock)
+    except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
+        fail(f"cannot read {args.lock}: {exc}")
+
     packages = pypi_sourced(locked)
     skipped = non_pypi(locked)
 
     if args.changed_vs:
-        changed = derive_changed(packages, args.changed_vs)
+        try:
+            changed = derive_changed(packages, args.changed_vs)
+        except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
+            fail(f"cannot read baseline {args.changed_vs}: {exc}")
+        # Diagnostic, so stderr: on stdout it would sit in front of --json output
+        # and make the documented machine-readable mode unparseable.
         print(
             f"derived {len(changed)} changed package(s) vs {args.changed_vs}: "
-            f"{', '.join(changed) or '(none)'}\n"
+            f"{', '.join(changed) or '(none)'}\n",
+            file=sys.stderr,
         )
     else:
         changed = [n.strip() for n in args.changed.split(",") if n.strip()]
@@ -409,10 +458,8 @@ def main() -> int:
         if key not in meta_cache:
             try:
                 meta_cache[key] = _get_json(PYPI.format(name=entry["name"]))
-            except urllib.error.URLError as exc:
-                print(f"error: PyPI lookup failed for {entry['name']}: {exc}",
-                      file=sys.stderr)
-                return 2
+            except (OSError, json.JSONDecodeError) as exc:
+                fail(f"PyPI lookup failed for {entry['name']}: {exc}")
         meta = meta_cache[key]
         n_pins, newest = fork_context(entry, pins)
         report["provenance"].append(check_provenance(entry, meta))
@@ -420,7 +467,12 @@ def main() -> int:
             check_currency(entry, meta, pins=n_pins, newest=newest)
         )
 
-    report["vulns"] = check_vulns(packages)
+    try:
+        report["vulns"] = check_vulns(packages)
+    except (OSError, json.JSONDecodeError) as exc:
+        # Left unhandled this exits 1, which the contract reserves for findings —
+        # an outage would read as "OSV reported a vulnerability".
+        fail(f"OSV query failed: {exc}")
     report["clean"] = (
         all(p["ok"] for p in report["provenance"])
         and all(c["current"] or c["held_back"] for c in report["currency"])

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -166,32 +166,81 @@ def check_provenance(entry: dict[str, Any], meta: dict[str, Any]) -> dict[str, A
     return result
 
 
-def check_currency(entry: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
-    """Report the registry's true latest version alongside the locked one."""
+_PRERELEASE = re.compile(r"(a|b|c|rc|alpha|beta|pre|preview|dev)\d*$", re.IGNORECASE)
+
+
+def _is_prerelease(version: str) -> bool:
+    """Crude PEP 440 pre-release / dev test; `packaging` is not available here.
+
+    Tail-anchored on purpose, so `1.0.post1` — a real release a bot can propose —
+    survives while `1.3.0rc1`, which one never will, is dropped.
+    """
+    return bool(_PRERELEASE.search(version))
+
+
+def fork_context(entry: dict[str, Any], pins: dict[str, list[str]]) -> tuple[int, bool]:
+    """How often this package is pinned in the lock, and whether this is the highest.
+
+    uv forks a package into several `[[package]]` blocks when different parts of
+    the resolution need different versions.
+    """
+    versions = pins.get(_normalize(entry["name"])) or [entry["version"]]
+    highest = max(_sortable(v) for v in versions)
+    return len(versions), _sortable(entry["version"]) >= highest
+
+
+def check_currency(
+    entry: dict[str, Any],
+    meta: dict[str, Any],
+    *,
+    pins: int = 1,
+    newest: bool = True,
+) -> dict[str, Any]:
+    """Report the registry's true latest version alongside the locked one.
+
+    `pins` and `newest` place the entry among the lockfile's pins of the same
+    package, which is what decides whether `resolution-markers` excuse a gap.
+    """
     name, locked = entry["name"], entry["version"]
     latest = meta["info"]["version"]
-
     releases = meta.get("releases", {})
+
+    def published(version: str) -> str | None:
+        # The *earliest* artifact, not an arbitrary one. The currency question is
+        # whether this version existed before the PR was opened, and wheels built
+        # by CI can land hours after the sdist they accompany.
+        stamps = [
+            f["upload_time_iso_8601"]
+            for f in releases.get(version) or []
+            if f.get("upload_time_iso_8601")
+        ]
+        return min(stamps, default=None)
+
     gap = [
         v
         for v in releases
-        if releases[v] and _sortable(locked) < _sortable(v) <= _sortable(latest)
+        if releases[v]
+        and not _is_prerelease(v)
+        and _sortable(locked) < _sortable(v) <= _sortable(latest)
     ]
-    gap.sort(key=_sortable)
+    # Ordered by publish time, because that is the comparison the report asks the
+    # reader to make. _sortable breaks ties and covers an absent timestamp.
+    gap.sort(key=lambda v: (published(v) or "", _sortable(v)))
 
-    def published(version: str) -> str | None:
-        files = releases.get(version) or []
-        return files[0].get("upload_time_iso_8601") if files else None
-
+    constrained = bool(entry.get("resolution-markers"))
     return {
         "name": name,
         "locked": locked,
         "latest": latest,
         "current": locked == latest,
-        # An entry pinned under resolution-markers (e.g. the last release that
-        # supported an older Python) is *expected* to trail the registry. Flagging
-        # it as stale invites a follow-up bump that can never be made.
-        "constrained": bool(entry.get("resolution-markers")),
+        "constrained": constrained,
+        "pins": pins,
+        # uv stamps resolution-markers on *every* block of a forked package, so
+        # the markers alone cannot say which pin is expected to trail. A lower
+        # fork is held back by design; the highest is the live pin, and its
+        # markers excuse nothing. Exempting both hides staleness on the one that
+        # matters — the failure this key exists to avoid.
+        "held_back": constrained and not newest,
         "locked_published": published(locked),
         "latest_published": published(latest),
         "gap": [
@@ -242,17 +291,24 @@ def render(report: dict[str, Any]) -> None:
         if cur["current"]:
             print(f"=== {cur['name']}: locked {cur['locked']} IS the latest\n")
             continue
-        if cur["constrained"]:
+        if cur["held_back"]:
             print(f"=== {cur['name']}: locked {cur['locked']}, registry latest "
-                  f"{cur['latest']} — CONSTRAINED by resolution-markers")
-            print("      expected to trail the registry; not a staleness finding\n")
+                  f"{cur['latest']} — HELD BACK by resolution-markers")
+            print(f"      behind a higher pin of the same package ({cur['pins']} in "
+                  "the lock); expected to")
+            print("      trail the registry, so not a staleness finding\n")
             continue
         print(f"=== {cur['name']}: locked {cur['locked']}, "
               f"registry latest {cur['latest']}  <-- NOT CURRENT")
+        if cur["constrained"]:
+            print(f"      pinned under resolution-markers, but this is the newest of "
+                  f"{cur['pins']} pin(s):")
+            print("      the markers excuse the gap only if they exclude the "
+                  "environment you target")
         for rel in cur["gap"]:
             mark = " (yanked)" if rel["yanked"] else ""
             print(f"      {rel['version']:12s} published {rel['published']}{mark}")
-        print("      compare the earliest of these against the PR's createdAt\n")
+        print("      earliest first; compare it against the PR's createdAt\n")
 
     vulns = report["vulns"]
     if vulns["hits"]:
@@ -341,6 +397,12 @@ def main() -> int:
         "currency": [],
         "skipped": skipped,
     }
+    # Fork structure comes from the whole lockfile, not just the selected set: a
+    # bump can move one fork of a package while its sibling stays where it is.
+    pins: dict[str, list[str]] = {}
+    for pkg in packages:
+        pins.setdefault(_normalize(pkg["name"]), []).append(pkg["version"])
+
     meta_cache: dict[str, Any] = {}
     for entry in targets:
         key = _normalize(entry["name"])
@@ -352,13 +414,16 @@ def main() -> int:
                       file=sys.stderr)
                 return 2
         meta = meta_cache[key]
+        n_pins, newest = fork_context(entry, pins)
         report["provenance"].append(check_provenance(entry, meta))
-        report["currency"].append(check_currency(entry, meta))
+        report["currency"].append(
+            check_currency(entry, meta, pins=n_pins, newest=newest)
+        )
 
     report["vulns"] = check_vulns(packages)
     report["clean"] = (
         all(p["ok"] for p in report["provenance"])
-        and all(c["current"] or c["constrained"] for c in report["currency"])
+        and all(c["current"] or c["held_back"] for c in report["currency"])
         and not report["vulns"]["hits"]
     )
 

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -35,6 +35,7 @@ import sys
 import time
 import tomllib
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, NoReturn
 
@@ -61,7 +62,13 @@ def fail(what: str) -> NoReturn:
 
 
 def _get_json(url: str, payload: bytes | None = None) -> Any:
-    req = urllib.request.Request(url)
+    # Callers build URLs from the module constants above, but asserting the scheme
+    # is cheaper than trusting it: a `file:` or custom scheme is what S310 warns
+    # about, and part of these URLs comes from a lockfile written by the PR under
+    # audit, which is exactly the input not to trust.
+    if not url.startswith("https://"):
+        raise ValueError(f"refusing a non-https URL: {url}")
+    req = urllib.request.Request(url)  # noqa: S310 — scheme checked above
     req.add_header("User-Agent", UA)
     if payload is not None:
         req.data = payload
@@ -99,16 +106,15 @@ def derive_changed(packages: list[dict[str, Any]], baseline_path: str) -> list[s
     Removals are not reported — there is nothing left to verify for them.
     """
     base_pairs = {
-        (_normalize(p["name"]), p["version"])
-        for p in pypi_sourced(load_lock(baseline_path))
+        (_normalize(p["name"]), p["version"]) for p in pypi_sourced(load_lock(baseline_path))
     }
     seen: set[str] = set()
     changed: list[str] = []
     for p in packages:
-        if (_normalize(p["name"]), p["version"]) not in base_pairs:
-            if p["name"] not in seen:
-                seen.add(p["name"])
-                changed.append(p["name"])
+        pair = (_normalize(p["name"]), p["version"])
+        if pair not in base_pairs and p["name"] not in seen:
+            seen.add(p["name"])
+            changed.append(p["name"])
     return changed
 
 
@@ -198,9 +204,7 @@ def check_provenance(entry: dict[str, Any], meta: dict[str, Any]) -> dict[str, A
         }
         ok = all(checks.values())
         result["ok"] &= ok
-        result["artifacts"].append(
-            {"kind": kind, "filename": filename, "ok": ok, "checks": checks}
-        )
+        result["artifacts"].append({"kind": kind, "filename": filename, "ok": ok, "checks": checks})
 
     return result
 
@@ -295,9 +299,7 @@ def check_currency(
 
 def check_vulns(packages: list[dict[str, Any]]) -> dict[str, Any]:
     pkgs = [(p["name"], p["version"]) for p in packages]
-    queries = [
-        {"package": {"name": n, "ecosystem": "PyPI"}, "version": v} for n, v in pkgs
-    ]
+    queries = [{"package": {"name": n, "ecosystem": "PyPI"}, "version": v} for n, v in pkgs]
     results = _get_json(OSV_BATCH, json.dumps({"queries": queries}).encode())["results"]
 
     hits = [
@@ -323,27 +325,38 @@ def render(report: dict[str, Any]) -> None:
                 f"{k} {'match' if v else 'MISMATCH'}" for k, v in art["checks"].items()
             )
             print(f"  {flag} {art['kind']:5s} {art['filename']}\n      {detail}")
-        print(f"  -> {len(prov['artifacts'])} artifact(s), "
-              f"{'all match' if prov['ok'] else 'DISCREPANCIES'}\n")
+        print(
+            f"  -> {len(prov['artifacts'])} artifact(s), "
+            f"{'all match' if prov['ok'] else 'DISCREPANCIES'}\n"
+        )
 
     for cur in report["currency"]:
         if cur["current"]:
             print(f"=== {cur['name']}: locked {cur['locked']} IS the latest\n")
             continue
         if cur["held_back"]:
-            print(f"=== {cur['name']}: locked {cur['locked']}, registry latest "
-                  f"{cur['latest']} — HELD BACK by resolution-markers")
-            print(f"      behind a higher pin of the same package ({cur['pins']} in "
-                  "the lock); expected to")
+            print(
+                f"=== {cur['name']}: locked {cur['locked']}, registry latest "
+                f"{cur['latest']} — HELD BACK by resolution-markers"
+            )
+            print(
+                f"      behind a higher pin of the same package ({cur['pins']} in "
+                "the lock); expected to"
+            )
             print("      trail the registry, so not a staleness finding\n")
             continue
-        print(f"=== {cur['name']}: locked {cur['locked']}, "
-              f"registry latest {cur['latest']}  <-- NOT CURRENT")
+        print(
+            f"=== {cur['name']}: locked {cur['locked']}, "
+            f"registry latest {cur['latest']}  <-- NOT CURRENT"
+        )
         if cur["constrained"]:
-            print(f"      pinned under resolution-markers, but this is the newest of "
-                  f"{cur['pins']} pin(s):")
-            print("      the markers excuse the gap only if they exclude the "
-                  "environment you target")
+            print(
+                f"      pinned under resolution-markers, but this is the newest of "
+                f"{cur['pins']} pin(s):"
+            )
+            print(
+                "      the markers excuse the gap only if they exclude the environment you target"
+            )
         for rel in cur["gap"]:
             mark = " (yanked)" if rel["yanked"] else ""
             print(f"      {rel['version']:12s} published {rel['published']}{mark}")
@@ -457,15 +470,16 @@ def main() -> int:
         key = _normalize(entry["name"])
         if key not in meta_cache:
             try:
-                meta_cache[key] = _get_json(PYPI.format(name=entry["name"]))
+                # The name comes out of the lockfile under audit, so it does not
+                # get to shape the URL path.
+                safe = urllib.parse.quote(entry["name"], safe="")
+                meta_cache[key] = _get_json(PYPI.format(name=safe))
             except (OSError, json.JSONDecodeError) as exc:
                 fail(f"PyPI lookup failed for {entry['name']}: {exc}")
         meta = meta_cache[key]
         n_pins, newest = fork_context(entry, pins)
         report["provenance"].append(check_provenance(entry, meta))
-        report["currency"].append(
-            check_currency(entry, meta, pins=n_pins, newest=newest)
-        )
+        report["currency"].append(check_currency(entry, meta, pins=n_pins, newest=newest))
 
     try:
         report["vulns"] = check_vulns(packages)

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -18,8 +18,9 @@ lockfile, which is the reliable way to handle a grouped bump — a grouped PR ti
 says "with 3 updates" and names none of them.
 
 Exit status: 0 = nothing to report, 1 = at least one discrepancy, stale version,
-or known vulnerability, 2 = usage/lookup error (including a requested package
-that is not in the lockfile — never audit fewer packages than asked in silence).
+or known vulnerability, 2 = usage/lookup error — including a requested package
+that is not in the lockfile, and an empty selection. Never audit fewer packages
+than asked in silence, and never print CLEAN on a run that verified nothing.
 Requires Python 3.11+ (tomllib) and network access.
 """
 
@@ -105,12 +106,22 @@ def load_lock(path: str) -> list[dict[str, Any]]:
         return tomllib.load(fh)["package"]
 
 
+def _is_pypi(pkg: dict[str, Any]) -> bool:
+    return str(pkg.get("source", {}).get("registry", "")).startswith("https://pypi.org")
+
+
 def pypi_sourced(packages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [
-        p
-        for p in packages
-        if str(p.get("source", {}).get("registry", "")).startswith("https://pypi.org")
-    ]
+    return [p for p in packages if _is_pypi(p)]
+
+
+def non_pypi(packages: list[dict[str, Any]]) -> list[str]:
+    """Names of packages this script cannot verify: git, path, or a private index.
+
+    Reported rather than dropped. A bumped git dependency that never appears in
+    the output is an under-audit indistinguishable from a clean one — the same
+    failure `select_targets` guards against, one level up.
+    """
+    return [p["name"] for p in packages if not _is_pypi(p)]
 
 
 def check_provenance(entry: dict[str, Any], meta: dict[str, Any]) -> dict[str, Any]:
@@ -251,7 +262,18 @@ def render(report: dict[str, Any]) -> None:
     else:
         print(f"OSV: no known vulnerabilities across {vulns['queried']} packages")
 
-    print("\nRESULT:", "CLEAN" if report["clean"] else "NEEDS REVIEW")
+    # The counts ride in the verdict line so it cannot overstate itself: a
+    # reader who skims to RESULT must see the size of the evidence behind it.
+    checked = sum(len(p["artifacts"]) for p in report["provenance"])
+    print(
+        f"\nRESULT: {'CLEAN' if report['clean'] else 'NEEDS REVIEW'}"
+        f" — {len(report['provenance'])} package(s), {checked} artifact(s) checked"
+    )
+    if report["skipped"]:
+        print(
+            f"        {len(report['skipped'])} package(s) NOT checked "
+            f"(not PyPI-sourced): {', '.join(report['skipped'])}"
+        )
     print("This is the mechanical half only — changelog, behavior-change, and")
     print("reproduction phases are not covered here.")
 
@@ -269,7 +291,9 @@ def main() -> int:
     parser.add_argument("--json", action="store_true", help="emit JSON instead of text")
     args = parser.parse_args()
 
-    packages = pypi_sourced(load_lock(args.lock))
+    locked = load_lock(args.lock)
+    packages = pypi_sourced(locked)
+    skipped = non_pypi(locked)
 
     if args.changed_vs:
         changed = derive_changed(packages, args.changed_vs)
@@ -292,7 +316,31 @@ def main() -> int:
         )
         return 2
 
-    report: dict[str, Any] = {"lock": args.lock, "provenance": [], "currency": []}
+    # Auditing nothing is the same failure as auditing too little, and it is the
+    # likelier one: point --changed-vs at the wrong lockfile and every version
+    # matches, which reads as "no changes" rather than "wrong input".
+    if not targets:
+        reason = (
+            f"{args.lock} and {args.changed_vs} pin identical (name, version) pairs"
+            " — either this lockfile did not change, or it is being compared"
+            " against itself"
+            if args.changed_vs
+            else "no package names were given"
+        )
+        print(
+            f"error: nothing selected to audit: {reason}.\n"
+            f"       {args.lock} pins {len(packages)} PyPI package(s), none selected.\n"
+            "       A run that verifies nothing must not report CLEAN.",
+            file=sys.stderr,
+        )
+        return 2
+
+    report: dict[str, Any] = {
+        "lock": args.lock,
+        "provenance": [],
+        "currency": [],
+        "skipped": skipped,
+    }
     meta_cache: dict[str, Any] = {}
     for entry in targets:
         key = _normalize(entry["name"])

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -21,6 +21,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+import urllib.error
 from unittest import mock
 
 sys.path.insert(
@@ -28,6 +29,7 @@ sys.path.insert(
 )
 
 from audit import (  # noqa: E402
+    _get_json,
     _normalize,
     check_currency,
     check_provenance,
@@ -374,14 +376,8 @@ class TestForkContext(unittest.TestCase):
         self.assertEqual(fork_context(entry("rumdl", "0.2.53"), FORK_PINS), (1, True))
 
 
-class TestMainContract(unittest.TestCase):
-    """The documented exit status, and the counts behind the verdict line.
-
-    `main()` owns the 0/1/2 contract and was untested, which is how a run that
-    selected no packages came to print CLEAN and exit 0 — the same silent
-    under-audit `select_targets` guards against, at the point where the whole
-    audit is empty rather than merely short.
-    """
+class _MainHarness(unittest.TestCase):
+    """Shared harness for the tests that drive main() with the network stubbed."""
 
     LOCK = f"""
 [[package]]
@@ -398,10 +394,17 @@ version = "0.20.0"
 source = {{ editable = "." }}
 """
 
-    def _run(self, argv, meta=None):
-        """Run main() with the network stubbed. Returns (exit code, stdout, stderr)."""
+    def _run(self, argv, meta=None, fails=None):
+        """Run main() with the network stubbed. Returns (exit code, stdout, stderr).
+
+        `fails` maps a host fragment to the exception the stubbed fetch should
+        raise for it, so an outage is simulated without touching the network.
+        """
 
         def fake_get_json(url, payload=None):
+            for fragment, exc in (fails or {}).items():
+                if fragment in url:
+                    raise exc
             if "osv.dev" in url:
                 queries = json.loads(payload)["queries"]
                 return {"results": [{} for _ in queries]}
@@ -414,11 +417,24 @@ source = {{ editable = "." }}
             contextlib.redirect_stdout(out),
             contextlib.redirect_stderr(err),
         ):
-            code = main()
+            try:
+                code = main()
+            except SystemExit as exc:  # fail() raises rather than returns
+                code = exc.code
         return code, out.getvalue(), err.getvalue()
 
     def _meta(self):
         return pypi_meta("0.2.53", [pypi_file("rumdl-0.2.53-py3-none-any.whl")])
+
+
+class TestMainContract(_MainHarness):
+    """The documented exit status, and the counts behind the verdict line.
+
+    `main()` owns the 0/1/2 contract and was untested, which is how a run that
+    selected no packages came to print CLEAN and exit 0 — the same silent
+    under-audit `select_targets` guards against, at the point where the whole
+    audit is empty rather than merely short.
+    """
 
     def test_empty_changed_set_exits_2_instead_of_reporting_clean(self):
         code, out, err = self._run([write_lock(self, self.LOCK), "--changed", ""])
@@ -453,6 +469,108 @@ source = {{ editable = "." }}
         )
         self.assertIn("NOT checked", out)
         self.assertIn("fpga-simulator", out)
+
+    def test_json_mode_stays_parseable_alongside_changed_vs(self):
+        """--changed-vs is the mode the skill recommends, so its diagnostic line
+        must not land on stdout in front of the JSON."""
+        base = write_lock(
+            self, self.LOCK.replace('version = "0.2.53"', 'version = "0.2.52"', 1)
+        )
+        code, out, _ = self._run(
+            [write_lock(self, self.LOCK), "--changed-vs", base, "--json"],
+            meta=self._meta(),
+        )
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)["skipped"], ["fpga-simulator"])
+
+
+class TestFailuresAreNotFindings(_MainHarness):
+    """Exit 2 means the audit could not run; exit 1 means it found something.
+
+    An unhandled exception exits 1, so any failure left unhandled borrows the
+    status reserved for findings — a registry outage reads as a vulnerability.
+    """
+
+    def test_a_missing_lockfile_exits_2(self):
+        code, _, err = self._run(["/nonexistent/uv.lock", "--changed", "p"])
+        self.assertEqual(code, 2)
+        self.assertIn("cannot read", err)
+
+    def test_malformed_toml_exits_2(self):
+        code, _, err = self._run([write_lock(self, "not toml [[[\n"), "--changed", "p"])
+        self.assertEqual(code, 2)
+        self.assertIn("cannot read", err)
+
+    def test_a_lockfile_with_no_package_entries_exits_2(self):
+        code, _, err = self._run([write_lock(self, "version = 1\n"), "--changed", "p"])
+        self.assertEqual(code, 2)
+        self.assertIn("lockfile", err)
+
+    def test_an_unreadable_baseline_exits_2(self):
+        code, _, err = self._run(
+            [write_lock(self, self.LOCK), "--changed-vs", "/nonexistent/base.lock"]
+        )
+        self.assertEqual(code, 2)
+        self.assertIn("baseline", err)
+
+    def test_an_osv_outage_exits_2_not_1(self):
+        code, _, err = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"],
+            meta=self._meta(),
+            fails={"osv.dev": urllib.error.URLError("simulated outage")},
+        )
+        self.assertEqual(code, 2, "an outage must not read as a vulnerability")
+        self.assertIn("OSV", err)
+
+    def test_a_pypi_outage_exits_2(self):
+        code, _, err = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"],
+            fails={"pypi.org": urllib.error.URLError("simulated outage")},
+        )
+        self.assertEqual(code, 2)
+        self.assertIn("PyPI", err)
+
+
+class TestRetry(unittest.TestCase):
+    """One retry, and only for the failures worth retrying."""
+
+    URL = "https://example.test/x"
+
+    def _http_error(self, code):
+        # HTTPError is a file object; closing it keeps the suite ResourceWarning-free.
+        exc = urllib.error.HTTPError(self.URL, code, "simulated", {}, None)
+        self.addCleanup(exc.close)
+        return exc
+
+    def _urlopen(self, script):
+        calls = []
+
+        def fake(req, timeout=None):
+            calls.append(getattr(req, "full_url", req))
+            item = script.pop(0)
+            if isinstance(item, Exception):
+                raise item
+            return contextlib.closing(io.StringIO(item))
+
+        return fake, calls
+
+    def test_a_server_error_is_retried_once(self):
+        fake, calls = self._urlopen([self._http_error(503), '{"ok": true}'])
+        with mock.patch("urllib.request.urlopen", fake), mock.patch("time.sleep"):
+            self.assertEqual(_get_json(self.URL), {"ok": True})
+        self.assertEqual(len(calls), 2, "one transient 502 must not lose the audit")
+
+    def test_a_404_is_not_retried(self):
+        """A 4xx is an answer, not a hiccup: retrying delays a message that is
+        already the information the caller needs."""
+        fake, calls = self._urlopen([self._http_error(404)])
+        with (
+            mock.patch("urllib.request.urlopen", fake),
+            mock.patch("time.sleep"),
+            self.assertRaises(urllib.error.HTTPError),
+        ):
+            _get_json(self.URL)
+        self.assertEqual(len(calls), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -32,6 +32,7 @@ from audit import (  # noqa: E402
     check_currency,
     check_provenance,
     derive_changed,
+    fork_context,
     main,
     pypi_sourced,
     select_targets,
@@ -242,18 +243,107 @@ class TestCurrency(unittest.TestCase):
         self.assertEqual([r["version"] for r in result["gap"]], ["1.1", "1.2"])
         self.assertEqual(result["gap"][0]["published"], "2026-02-01T00:00:00Z")
 
-    def test_marker_constrained_pin_is_not_reported_as_stale(self):
-        """A pin held back by an environment marker trails the registry by design."""
-        pkg = entry("rpds-py", "0.30.0", markers=["python_full_version < '3.11'"])
-        meta = pypi_meta(
-            "0.30.0",
+    def _split(self):
+        """A package uv forked: rpds-py's real shape, both blocks marker-stamped."""
+        return pypi_meta(
+            "2020.1.1",
             [],
             latest="2026.6.3",
-            releases={"0.30.0": [pypi_file("x.whl")], "2026.6.3": [pypi_file("y.whl")]},
+            releases={
+                "0.30.0": [pypi_file("a.whl", uploaded="2019-01-01T00:00:00Z")],
+                "2020.1.1": [pypi_file("b.whl", uploaded="2020-01-01T00:00:00Z")],
+                "2026.6.3": [pypi_file("c.whl", uploaded="2026-06-03T00:00:00Z")],
+            },
         )
-        result = check_currency(pkg, meta)
+
+    def test_held_back_fork_is_not_reported_as_stale(self):
+        """The lower fork of a split package trails the registry by design."""
+        pkg = entry("rpds-py", "0.30.0", markers=["python_full_version < '3.11'"])
+        result = check_currency(pkg, self._split(), pins=2, newest=False)
         self.assertFalse(result["current"])
-        self.assertTrue(result["constrained"], "must not read as a staleness finding")
+        self.assertTrue(result["held_back"], "must not read as a staleness finding")
+
+    def test_newest_fork_is_still_checked_for_staleness(self):
+        """Shipped bug: uv stamps markers on *every* fork, so both were exempted.
+
+        The highest pin is the one that actually gets installed on a current
+        interpreter. Letting its markers excuse a gap hides staleness on the only
+        pin a follow-up bump could ever move.
+        """
+        pkg = entry("rpds-py", "2020.1.1", markers=["python_full_version >= '3.11'"])
+        result = check_currency(pkg, self._split(), pins=2, newest=True)
+        self.assertTrue(result["constrained"])
+        self.assertFalse(result["held_back"], "markers must not excuse the live pin")
+        self.assertEqual([r["version"] for r in result["gap"]], ["2026.6.3"])
+
+    def test_publish_time_is_the_earliest_artifact_not_an_arbitrary_one(self):
+        """PyPI lists a version's files in no useful order.
+
+        The currency question is whether the version existed before the PR was
+        opened, and a wheel built by CI can land hours after its sdist — so the
+        wrong artifact's timestamp answers the question wrongly.
+        """
+        pkg = entry("p", "1.0")
+        meta = pypi_meta(
+            "1.0",
+            [
+                pypi_file("p-1.0-py3-none-any.whl", uploaded="2026-03-01T12:00:00Z"),
+                pypi_file("p-1.0.tar.gz", uploaded="2026-03-01T09:00:00Z"),
+            ],
+        )
+        self.assertEqual(
+            check_currency(pkg, meta)["locked_published"], "2026-03-01T09:00:00Z"
+        )
+
+    def test_prereleases_are_not_listed_in_the_gap(self):
+        """A bot never proposes an rc, so listing one sends the reader to a
+        changelog that cannot be the answer."""
+        pkg = entry("p", "1.2.3")
+        meta = pypi_meta(
+            "1.2.3",
+            [],
+            latest="1.3.0",
+            releases={
+                "1.2.3": [pypi_file("a.whl", uploaded="2026-01-01T00:00:00Z")],
+                "1.3.0rc1": [pypi_file("b.whl", uploaded="2026-02-01T00:00:00Z")],
+                "1.3.0": [pypi_file("c.whl", uploaded="2026-03-01T00:00:00Z")],
+            },
+        )
+        gap = check_currency(pkg, meta)["gap"]
+        self.assertEqual([r["version"] for r in gap], ["1.3.0"])
+
+    def test_post_releases_still_enter_the_gap(self):
+        """The pre-release filter must not swallow a release a bot can propose."""
+        pkg = entry("p", "1.0")
+        meta = pypi_meta(
+            "1.0",
+            [],
+            latest="1.0.post1",
+            releases={
+                "1.0": [pypi_file("a.whl", uploaded="2026-01-01T00:00:00Z")],
+                "1.0.post1": [pypi_file("b.whl", uploaded="2026-02-01T00:00:00Z")],
+            },
+        )
+        gap = check_currency(pkg, meta)["gap"]
+        self.assertEqual([r["version"] for r in gap], ["1.0.post1"])
+
+    def test_gap_is_ordered_by_publish_time_not_version(self):
+        """The report tells the reader to compare the *earliest* against the PR's
+        createdAt, so the first row has to be the earliest — and a patch on an
+        older line can be published after a higher version."""
+        pkg = entry("p", "1.0")
+        meta = pypi_meta(
+            "1.0",
+            [],
+            latest="1.10",
+            releases={
+                "1.0": [pypi_file("a.whl", uploaded="2026-01-01T00:00:00Z")],
+                "1.10": [pypi_file("c.whl", uploaded="2026-02-01T00:00:00Z")],
+                "1.9": [pypi_file("b.whl", uploaded="2026-03-01T00:00:00Z")],
+            },
+        )
+        gap = check_currency(pkg, meta)["gap"]
+        self.assertEqual([r["version"] for r in gap], ["1.10", "1.9"])
 
     def test_unconstrained_pin_is_not_marked_constrained(self):
         pkg = entry("p", "1.0")
@@ -266,6 +356,22 @@ class TestCurrency(unittest.TestCase):
         result = check_currency(pkg, meta)
         self.assertTrue(result["current"])
         self.assertEqual(result["gap"], [])
+
+
+FORK_PINS = {"rpds-py": ["0.30.0", "2026.6.3"], "rumdl": ["0.2.53"]}
+
+
+class TestForkContext(unittest.TestCase):
+    """Which pin of a forked package is the live one."""
+
+    def test_highest_pin_of_a_fork_is_the_newest(self):
+        self.assertEqual(fork_context(entry("rpds-py", "2026.6.3"), FORK_PINS), (2, True))
+
+    def test_lower_pin_of_a_fork_is_not(self):
+        self.assertEqual(fork_context(entry("rpds-py", "0.30.0"), FORK_PINS), (2, False))
+
+    def test_a_lone_pin_is_its_own_newest(self):
+        self.assertEqual(fork_context(entry("rumdl", "0.2.53"), FORK_PINS), (1, True))
 
 
 class TestMainContract(unittest.TestCase):

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -14,6 +14,7 @@ assert on what gets reported, not just on what gets returned.
 from __future__ import annotations
 
 import contextlib
+import email.message
 import io
 import json
 import pathlib
@@ -28,7 +29,7 @@ sys.path.insert(
     0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
 )
 
-from audit import (  # noqa: E402
+from audit import (
     _get_json,
     _normalize,
     check_currency,
@@ -213,9 +214,7 @@ class TestProvenance(unittest.TestCase):
         self.assertIn("not present on PyPI", result["error"])
 
     def test_sdist_is_verified_too_not_only_wheels(self):
-        pkg = entry(
-            "p", "1.0", sdist=artifact("p-1.0.tar.gz", digest="b" * 64), wheels=[]
-        )
+        pkg = entry("p", "1.0", sdist=artifact("p-1.0.tar.gz", digest="b" * 64), wheels=[])
         meta = pypi_meta("1.0", [pypi_file("p-1.0.tar.gz", digest="a" * 64)])
         result = check_provenance(pkg, meta)
         self.assertFalse(result["ok"])
@@ -293,9 +292,7 @@ class TestCurrency(unittest.TestCase):
                 pypi_file("p-1.0.tar.gz", uploaded="2026-03-01T09:00:00Z"),
             ],
         )
-        self.assertEqual(
-            check_currency(pkg, meta)["locked_published"], "2026-03-01T09:00:00Z"
-        )
+        self.assertEqual(check_currency(pkg, meta)["locked_published"], "2026-03-01T09:00:00Z")
 
     def test_prereleases_are_not_listed_in_the_gap(self):
         """A bot never proposes an rc, so listing one sends the reader to a
@@ -418,7 +415,7 @@ source = {{ editable = "." }}
             contextlib.redirect_stderr(err),
         ):
             try:
-                code = main()
+                code: int | str | None = main()
             except SystemExit as exc:  # fail() raises rather than returns
                 code = exc.code
         return code, out.getvalue(), err.getvalue()
@@ -473,9 +470,7 @@ class TestMainContract(_MainHarness):
     def test_json_mode_stays_parseable_alongside_changed_vs(self):
         """--changed-vs is the mode the skill recommends, so its diagnostic line
         must not land on stdout in front of the JSON."""
-        base = write_lock(
-            self, self.LOCK.replace('version = "0.2.53"', 'version = "0.2.52"', 1)
-        )
+        base = write_lock(self, self.LOCK.replace('version = "0.2.53"', 'version = "0.2.52"', 1))
         code, out, _ = self._run(
             [write_lock(self, self.LOCK), "--changed-vs", base, "--json"],
             meta=self._meta(),
@@ -538,7 +533,8 @@ class TestRetry(unittest.TestCase):
 
     def _http_error(self, code):
         # HTTPError is a file object; closing it keeps the suite ResourceWarning-free.
-        exc = urllib.error.HTTPError(self.URL, code, "simulated", {}, None)
+        hdrs = email.message.Message()
+        exc = urllib.error.HTTPError(self.URL, code, "simulated", hdrs, None)
         self.addCleanup(exc.close)
         return exc
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -13,10 +13,15 @@ assert on what gets reported, not just on what gets returned.
 
 from __future__ import annotations
 
+import contextlib
+import io
+import json
 import pathlib
+import shutil
 import sys
 import tempfile
 import unittest
+from unittest import mock
 
 sys.path.insert(
     0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
@@ -27,11 +32,21 @@ from audit import (  # noqa: E402
     check_currency,
     check_provenance,
     derive_changed,
+    main,
     pypi_sourced,
     select_targets,
 )
 
 PYPI_SRC = {"registry": "https://pypi.org/simple"}
+
+
+def write_lock(test: unittest.TestCase, body: str) -> str:
+    """A temp lockfile that removes itself when the test finishes."""
+    directory = tempfile.mkdtemp()
+    test.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+    path = pathlib.Path(directory) / "uv.lock"
+    path.write_text(body, encoding="utf-8")
+    return str(path)
 
 
 def entry(name, version, *, wheels=(), sdist=None, markers=None):
@@ -108,10 +123,7 @@ class TestSelectTargets(unittest.TestCase):
 
 class TestDeriveChanged(unittest.TestCase):
     def _lock(self, body: str) -> str:
-        tmp = tempfile.NamedTemporaryFile("w", suffix=".lock", delete=False)
-        tmp.write(body)
-        tmp.close()
-        return tmp.name
+        return write_lock(self, body)
 
     BASE = """
 [[package]]
@@ -254,6 +266,87 @@ class TestCurrency(unittest.TestCase):
         result = check_currency(pkg, meta)
         self.assertTrue(result["current"])
         self.assertEqual(result["gap"], [])
+
+
+class TestMainContract(unittest.TestCase):
+    """The documented exit status, and the counts behind the verdict line.
+
+    `main()` owns the 0/1/2 contract and was untested, which is how a run that
+    selected no packages came to print CLEAN and exit 0 — the same silent
+    under-audit `select_targets` guards against, at the point where the whole
+    audit is empty rather than merely short.
+    """
+
+    LOCK = f"""
+[[package]]
+name = "rumdl"
+version = "0.2.53"
+source = {{ registry = "https://pypi.org/simple" }}
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/rumdl-0.2.53-py3-none-any.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+
+[[package]]
+name = "fpga-simulator"
+version = "0.20.0"
+source = {{ editable = "." }}
+"""
+
+    def _run(self, argv, meta=None):
+        """Run main() with the network stubbed. Returns (exit code, stdout, stderr)."""
+
+        def fake_get_json(url, payload=None):
+            if "osv.dev" in url:
+                queries = json.loads(payload)["queries"]
+                return {"results": [{} for _ in queries]}
+            return meta
+
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch("audit._get_json", fake_get_json),
+            mock.patch.object(sys, "argv", ["audit.py", *argv]),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(err),
+        ):
+            code = main()
+        return code, out.getvalue(), err.getvalue()
+
+    def _meta(self):
+        return pypi_meta("0.2.53", [pypi_file("rumdl-0.2.53-py3-none-any.whl")])
+
+    def test_empty_changed_set_exits_2_instead_of_reporting_clean(self):
+        code, out, err = self._run([write_lock(self, self.LOCK), "--changed", ""])
+        self.assertEqual(code, 2, "an audit of nothing is a failed audit")
+        self.assertNotIn("CLEAN", out)
+        self.assertIn("nothing selected", err)
+
+    def test_changed_vs_an_identical_lockfile_exits_2(self):
+        """The likely shape: --changed-vs aimed at the wrong lockfile.
+
+        Comparing a lockfile against itself — or against the branch it was read
+        from — makes every (name, version) pair match, which reads as "no
+        changes" rather than "wrong input".
+        """
+        lock = write_lock(self, self.LOCK)
+        code, out, _ = self._run([lock, "--changed-vs", lock])
+        self.assertEqual(code, 2)
+        self.assertNotIn("CLEAN", out)
+
+    def test_verdict_line_carries_the_counts(self):
+        code, out, _ = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"], meta=self._meta()
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("CLEAN", out)
+        self.assertIn("1 package(s), 1 artifact(s) checked", out)
+
+    def test_non_pypi_packages_are_named_not_silently_dropped(self):
+        """A git or private-index dependency is outside the audit; say so."""
+        _, out, _ = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"], meta=self._meta()
+        )
+        self.assertIn("NOT checked", out)
+        self.assertIn("fpga-simulator", out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The full review plan, ordered by effect on the verdict. Five commits,
`0.1.6` → `0.1.10`; tests 18 → 39.

## Verdict-changing (`0.1.6`–`0.1.8`)

**Phase 1 audited the base branch, and the script hid it.** `SKILL.md:99` used the
`pr-<N>` ref; `SKILL.md:167` created it. Phase 1 also passed a bare `uv.lock` —
cwd-relative, so it resolved against whatever branch the user had open. Both sides
on the base branch means every `(name, version)` pair matches, nothing is
selected, and `main()` printed `RESULT: CLEAN` and exited 0. Phase 0 now pins
`HEAD_SHA` and fetches once; Phase 1 reads both lockfiles out of git at that ref;
Phase 7 re-checks the SHA before writing, so a rebase mid-audit can't leave
Phases 1–5 and Phase 6 describing different commits. The script exits 2 on an
empty selection and carries package/artifact counts in `RESULT`.

**`resolution-markers` excused the pin that matters.** uv stamps them on *every*
block of a forked package, so treating their presence as an exemption exempted the
highest pin — the one that installs on a current interpreter and the only one a
bump could move. Also: publish time now comes from the earliest artifact rather
than an arbitrary one (it answers a *time* question), pre-releases are out of the
gap, and the gap is ordered by publish time.

**Failures exited 1, the status reserved for findings.** Four paths, including an
unreachable OSV — so an outage read as a vulnerability. All route through `fail()`
→ 2. The handler widened to `OSError`, which catches `TimeoutError`; a mid-body
read timeout is not a `URLError`, so the script's own timeout could escape its own
handler. `--json` is parseable again.

## Trust and gates (`0.1.9`–`0.1.10`)

**`tools:` is not a skill frontmatter field.** It withheld nothing while reading
like a control. Now `disallowed-tools: Edit, Write, NotebookEdit`. Phase 8 changed
with it — it hands its memory entry back rather than writing it, since shelling out
to do what the withheld tools would have done makes the withholding theatre.

**The plugin had no gates**, while Phase 5 tells everyone else to run theirs. Adds
`pyproject.toml`, `.pre-commit-config.yaml`, CI, and `dependabot.yml`. The hooks
enforce; CI is advisory, because branch protection and rulesets are both `403` on
this repo's plan. CI's real job is the 3.11–3.14 matrix — the one thing the hooks
cannot do. It runs `pre-commit run --all-files` rather than its own `pip install`,
so there is one pin per tool rather than two that drift.

Selecting ruff's `S` rules made the pre-existing `# noqa: S310` mean something for
the first time, and showed S310 firing on `Request()` too. Rather than silence it
twice, `_get_json` refuses a non-https URL and the package name is percent-encoded
before it reaches the URL — that name comes out of the lockfile written by the PR
under audit.

## Verification

Run verbatim against a real Dependabot PR (`fpga-board-sim#360`), against this
repo's live `rpds-py` double-pin, and against live PyPI. Every behavioural fix was
mutation-checked **one behaviour at a time** — reverting the whole file only proved
the imports broke. The commits say which cases discriminate and which are guards
protecting a property the old code already had.

CI green on all five jobs. `mypy` clean, and `audit.py` now passes `--strict` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)