### PR TITLE
feat: measure Phase 4 instead of predicting it, then reverse the prose ratchet

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the verdict, and the merge command **left un-run**.
 | 1 | Scope and provenance — every locked artifact's hash, size, URL, yank status vs. the live registry, read out of git at the pinned ref |
 | 2 | Currency — the registry's true latest, publish times vs. PR open time, and changelogs across the gap |
 | 3 | Known vulnerabilities — OSV batch plus the ecosystem's own auditor |
-| 4 | Behavior change — added rules and changed defaults against this repo's config and gate scopes |
+| 4 | Behavior change — each gate run at the old and new versions, comparing what they *do to the files* |
 | 5 | Independent reproduction — frozen install and the repo's own gates in an isolated worktree |
 | 6 | CI verification — the run for the exact head SHA, and the required contexts specifically |
 | 7 | Report |
@@ -73,6 +73,13 @@ it. npm, Cargo, Go, and GitHub Actions are covered as short per-registry
 procedures in `references/ecosystems.md` that the model runs directly — the same
 three questions in each registry's vocabulary.
 
+`scripts/gate_diff.py` (Phase 4) is **ecosystem-independent**, because it parses
+nothing. It runs a gate once per version in a disposable worktree and compares
+which files each run changed, and how. That works for any tool in any language —
+the operator supplies the invocations, and the tool's own output format is
+irrelevant, which is the point: version bumps change output formats about as
+often as they change behavior.
+
 This is deliberate. An unverified verifier is worse than none: it emits confident
 green output nobody checks. Don't extend the script to an ecosystem you don't
 have a repo to test it against.
@@ -83,9 +90,9 @@ have a repo to test it against.
 python3 -m unittest discover -s tests -v
 ```
 
-39 cases, stdlib only, no network — they run offline and free. Every case
+51 cases, stdlib only, no network — they run offline and free. Every case
 corresponds to a defect that actually shipped, or to a failure the audit exists
-to detect. They fall into four groups:
+to detect. They fall into five groups:
 
 - **Provenance** — a corrupted hash, a size mismatch, a yanked release, an
   artifact missing from the registry, and an sdist checked alongside the wheels.
@@ -100,6 +107,16 @@ to detect. They fall into four groups:
 - **Failure vs. finding** — an unreadable lockfile, an unreachable registry, and
   an OSV outage, each of which has to exit 2 rather than borrow the status that
   means "found something".
+- **Gate differential** — the three ways a bump moves a gate (widened scope,
+  narrowed scope, a changed fix), a deleted file counting as a change, and the
+  safety properties: a dirty tree is refused, and the worktree is restored
+  between runs. That last one matters most — without it run two inherits run
+  one's edits and every comparison after it is fiction.
+
+`gate_diff.py` is additionally validated end-to-end against a real historical
+bump: replaying Dependabot's ruff `0.15.22` → `0.16.0` PR against the tree as it
+stood that day reproduces the six Markdown files the newer version started
+formatting — while both versions exit 0.
 
 The theme is **silent** failure. An audit that reports success while verifying
 less than it claimed is worse than one that crashes, so the assertions target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,9 @@ select = [
 # E501: the lockfile fixture embeds a real-shaped URL and a 64-character sha256
 #       in one TOML inline table, which the format does not allow wrapping.
 #       Line length there is a property of the data, not of authored prose.
-"tests/*" = ["S101", "E501"]
+# S603/S607: the gate_diff tests build throwaway git repos to run against, which
+#       means invoking `git` from PATH. Same call shape the script itself uses.
+"tests/*" = ["S101", "E501", "S603", "S607"]
 
 # ── mypy (static type checker) ───────────────────────────────────────────────
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ strict = true
 # Test functions and their calls to each other are exempt, matching the policy
 # in the repos this plugin audits. The script itself is checked under full
 # strict, and passes.
-module = ["test_audit"]
+# List each test module explicitly. A `test_*` wildcard silently matches
+# nothing here — mypy's patterns work on dot-separated components — and the
+# override then disappears with no warning, not even under
+# --warn-unused-configs (tested: errors went 25 -> 175). Adding a test file
+# means adding it here; forgetting is loud, which is the safer direction.
+module = ["test_audit", "test_gate_diff"]
 disallow_untyped_defs = false
 disallow_untyped_calls = false

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -178,17 +178,48 @@ Python one in particular audits the wrong interpreter if invoked casually.
 
 ## Phase 4 — Behavior change (the highest-yield phase)
 
-Not "is it safe" but **"does it change what this repo's gates accept"**.
+Not "is it safe" but **"does it change what this repo's gates accept"**. Measure
+that; do not predict it from the changelog.
 
-1. From the changelog, list every **added rule, changed default, or widened file
-   scope** — not the bug fixes.
-2. Determine whether the repo's config is an **opt-in allow-list** or an
-   **opt-out disable-list**. Under a disable-list, a newly added rule is **live
-   immediately**. Under an allow-list it is inert. This single distinction decides
-   whether a new rule can break the build.
-3. Do not reason about it — **run the tool** at the CI's scope, and separately at
-   the hook's scope. Green CI on the PR is good evidence, but it only covers the
-   proposed version; if you are recommending a *newer* one, run that too.
+```bash
+G="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/gate_diff.py"
+
+python3 "$G" --tree "$SCRATCH/pr-<N>" \
+  --run locked   "uv run --no-project --with ruff==0.15.22 ruff format ." \
+  --run proposed "uv run --no-project --with ruff==0.16.0  ruff format ." \
+  --run latest   "uv run --no-project --with ruff==0.16.2  ruff format ."
+```
+
+**Give the tool's write mode, not `--check`** — the measurement is what each
+version does to the files, and `--check` does nothing to them. Run it once per
+gate from Phase 0, at *each* scope: a hook scoped to `types_or: [python, pyi]`
+and a CI step running the same tool over `.` are different gates, and this is
+the phase that turns on the difference. Add the `latest` run whenever Phase 2
+found a newer version, because that is the one you would be recommending.
+
+Read the result as three distinct findings:
+
+| Result | Meaning |
+|---|---|
+| only in the newer run | widened scope, or a rule that now fires |
+| only in the older run | narrowed scope |
+| both, different result | the fix itself behaves differently |
+
+The last is the one no security feed reports: a formatter that used to delete
+something and no longer does, in a write mode many repos run on every commit.
+
+**Do not read the exit codes as the answer** — see `references/traps.md`; both
+versions can exit 0 while the scope moves underneath them.
+
+`allow-list vs disable-list` is no longer something to work out in advance; the
+run settles it. Keep it for the *report*, to explain why a difference fired:
+under a config that disables specific rules a newly added rule is live the moment
+it lands, and under one that enables specific rules it is inert.
+
+A gate with no write mode — a type checker, a test suite — leaves the tree
+untouched and `gate_diff` says so. Exit code and output are then the only
+signals, which is the weaker measurement. Say so in the report rather than
+implying the same confidence as a tree diff.
 
 ## Phase 5 — Independent reproduction
 

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -19,19 +19,11 @@ withholding theatre.
 
 ## Why this procedure exists
 
-Dependency-bump PRs look trivial and usually are. The failure modes that actually
-bite are not "is this package malicious". They are:
-
-1. **The proposed version is not the current one.** Registries publish faster than
-   the bot ingests. A bump can land already stale, and the gap can matter.
-2. **The gap contains a fix no vulnerability database knows about.** A privately
-   disclosed fix has no CVE or GHSA, so OSV, `pip-audit`, and `npm audit` all
-   report clean while the changelog says "Security".
-3. **The bump changes a *default*, not just behavior.** A linter that gains a rule
-   or a formatter that widens its file scope can newly fail a *required* CI check
-   that the repo's own pre-commit hooks are scoped too narrowly to catch.
-
-All three are observed, not hypothetical. Phases 2 and 4 exist for them.
+The failure modes that bite are not "is this package malicious" — they are a
+proposal that is already stale, a gap containing a fix no vulnerability database
+knows about, and a bump that changes a *default* rather than a behavior. All
+three are observed, not hypothetical. Phases 2 and 4 exist for them, and
+`references/traps.md` has the cases.
 
 ## Phase 0 — Discover the repo (derive every run; never cache)
 
@@ -106,8 +98,7 @@ Verify every artifact the lockfile pins for the changed packages against the liv
 registry: sha256/integrity, size, URL, and yanked status.
 
 **Read both lockfiles out of git**, using the ref and merge base pinned in Phase
-0. A bare `uv.lock` path resolves against the user's checkout, which parses fine,
-derives *no* changed packages, and produces a confident audit of nothing:
+0 — never a bare `uv.lock` path, which resolves against the user's checkout:
 
 ```bash
 S="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py"
@@ -118,22 +109,15 @@ git show "$BASE_SHA:uv.lock" > "$SCRATCH/base.uv.lock"
 python3 "$S" "$SCRATCH/pr.uv.lock" --changed-vs "$SCRATCH/base.uv.lock"
 ```
 
-**Do not read the package names off the PR title.** A grouped bump is titled
-"with 3 updates" and names none of them, and a bot may group everything (check
-the `groups:` key you read in Phase 0). `--changed-vs` derives the set from the
-diff against the **merge base** — not the current default branch, or unrelated
-drift that landed after the PR branched gets attributed to this PR. Naming
-packages by hand (`--changed pkg-a,pkg-b`) is the fallback for a diff the script
-cannot read, not the default.
+**Do not read the package names off the PR title** — a grouped bump names none
+of them, and a bot may group everything (check the `groups:` key from Phase 0).
+`--changed-vs` derives the set from the diff against the **merge base**;
+`--changed pkg-a,pkg-b` is the fallback for a diff the script cannot read, not
+the default.
 
-The script will not look successful while verifying less than it should. **Exit 2
-means it could not run** — a name you asked for is not in the lockfile, the
-selected set came out empty, the lockfile is unreadable, or a registry was
-unreachable. **Exit 1 means it ran and found something.** Never read a 2 as a
-finding, or a 1 as an outage. Its `RESULT` line carries the package and artifact
-counts and names anything it could not reach (git, path, or a private-index
-dependency); quote those counts in the report rather than writing "verified"
-unqualified.
+**Exit 2 means it could not run; exit 1 means it ran and found something.** Never
+read one as the other. Quote its `RESULT` counts — and whatever it names as
+unreachable — in the report, rather than writing "verified" unqualified.
 
 For PyPI that one invocation covers this phase **plus the mechanical half of
 Phases 2 and 3** — it also reports the registry's true latest version with
@@ -265,13 +249,13 @@ is not.
 
 ## Phase 6 — CI verification
 
-Confirm the green you are trusting belongs to **this** commit:
+Confirm the green you are trusting belongs to **this** commit. Use the full
+40-character `$HEAD_SHA` pinned in Phase 0 — a short one matches nothing and
+reads exactly like "CI never ran":
 
 ```bash
-gh run list --commit <full-40-char-sha> --workflow <ci>.yml
+gh run list --commit "$HEAD_SHA" --workflow <ci>.yml
 ```
-
-A short SHA silently matches nothing and reads as "CI never ran".
 
 Then check the Phase 0 required contexts **individually** — a repo can have far
 more jobs than required checks, and only the required ones gate merge. Paste the
@@ -288,17 +272,13 @@ gh pr view <N> --json statusCheckRollup --jq \
   '[.statusCheckRollup[]|(.conclusion//.state)]|group_by(.)|map("\(.[0]): \(length)")|join("  ")'
 ```
 
-Two ways to misread that output. **A required context that never reported
-produces no line at all** — the `select` matches nothing — so count the lines
-against `$req` and treat a missing one as "not reported", never as green. And
-**do not post-process `gh pr checks` with whitespace-splitting tools**: real
-check names contain spaces and ampersands, so `awk '{print $1}'` turns
-`Lint & type-check` into `Lint` and quietly reports on a check that does not
-exist.
+**Count the returned lines against `$req`** — a context that never reported
+produces no line at all, which looks identical to one that passed. And match
+names as whole strings: never `awk '{print $1}'`, which turns `Lint & type-check`
+into `Lint`.
 
-`references/traps.md` covers the state-reporting gotchas: stale `CLEAN`,
-`UNSTABLE` being mergeable, neutral CodeQL, and why a bot rebase does not
-re-trigger CI.
+`references/traps.md` has the reasoning for both, plus stale `CLEAN`, `UNSTABLE`
+being mergeable, neutral CodeQL, and why a bot rebase does not re-trigger CI.
 
 ## Phase 7 — Report
 

--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -155,6 +155,13 @@ written.
 check sails straight through into the next command. Use `set -o pipefail`, or run
 the gate as its own call and read the exit code.
 
+**A lockfile path resolves against whatever happens to be checked out.** A bare
+`uv.lock` in a command reads the user's current branch, not the PR's — and the
+base branch's lockfile parses perfectly, yields no changed packages, and produces
+a confident audit of nothing. Read both sides out of git at a ref you pinned
+(`git show <ref>:uv.lock`) rather than off the working tree, and make the tool
+refuse an empty selection, so that failure cannot present itself as a pass.
+
 **Frozen installs prove the lockfile; unfrozen ones hide drift.** `uv sync
 --locked`, `npm ci`, `cargo build --locked`. Without the flag the resolver is
 free to paper over an inconsistent lockfile.

--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -34,6 +34,27 @@ so a rule *added* in the new version is live the moment it lands. If the config
 enables specific rules, new rules are inert. This one distinction is the
 difference between "no impact" and "blocks merge".
 
+**A green gate can stay green while its scope moves underneath it.** Comparing
+two versions of a tool by exit code is the obvious approach and it misses the
+most common shape of behaviour change. Observed on ruff 0.15.22 -> 0.16.0 in a
+repo already compliant with both: identical exit 0, while the newer version
+formatted **33 more files** — it had started formatting Python fences inside
+Markdown. Nothing in the pass/fail answer moved.
+
+**Nor can you diff the two versions' output.** The same pair prints
+`Would reformat: x.py` at 0.15 and an annotated diff at 0.16: the *renderer*
+changed, so a text comparison reports every line as different and the real
+finding drowns. Version bumps change output formats roughly as often as they
+change behaviour.
+
+**Diff what the tool did, not what it said.** Run each version in its **write**
+mode inside a disposable worktree and compare which files it changed and to
+what. That is stable across output formats, independent of the tool, and
+answers the question directly. On the case above it reports `0 files -> 6 files`
+and names them. `scripts/gate_diff.py` does this; the three results it
+distinguishes — acted-on-by-newer-only, by-older-only, and both-but-differently
+— are widened scope, narrowed scope, and a changed fix respectively.
+
 **A tool's formatter and its linter have different gates.** A version can leave
 the linter untouched and still change what the formatter rewrites — including
 widening to file types the repo never expected, such as code fences inside

--- a/skills/dependabot-audit/scripts/gate_diff.py
+++ b/skills/dependabot-audit/scripts/gate_diff.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Differential gate runner: what does a version bump change about this repo?
+
+Phase 4 asks whether a bump changes what the repo's gates *accept*. The obvious
+way to answer that is to read the changelog for added rules and reason about
+whether the repo's config is an allow-list or a disable-list. Both steps are
+predictions, and both are where the answer goes wrong.
+
+This measures instead. It runs the same gate once per version in a disposable
+worktree and compares what each run *did to the files*, not what it printed.
+
+Three findings drove that choice, all observed rather than assumed:
+
+  * Exit codes are not enough. ruff 0.15.22 and 0.16.2 both exit 0 on a repo
+    that is already compliant, while 0.16 formats 33 more files than 0.15 --
+    the gate stays green and the scope moves underneath it.
+  * Output text is not comparable across versions. 0.15 prints
+    "Would reformat: mod.py"; 0.16 prints an annotated diff. The renderer
+    changed, so a line-set diff reports everything as different.
+  * What the tool *touches* is stable and comparable. {mod.py} vs
+    {doc.md, mod.py} is the finding, in any output format.
+
+So: run each version in write mode, snapshot the files it changed and their
+contents, and report the delta between runs.
+
+    only in the newer run        widened scope, or a rule that now fires
+    only in the older run        narrowed scope
+    both, different content      the fix itself behaves differently
+
+The last is the one no vulnerability feed reports: a formatter that used to
+delete something and no longer does, or vice versa, in a mode many repos run
+automatically on every commit.
+
+Usage:
+    gate_diff.py --tree DIR --run LABEL CMD [--run LABEL CMD ...] [--json]
+
+The first --run is the baseline; every later one is compared against it. Give
+the tool's *write* mode where it has one (`ruff format .`, not
+`ruff format --check .`) -- the whole measurement is what it does to the tree.
+For a gate with no write mode (a type checker, a test suite) the tree delta is
+empty and only the exit code and output are available; that is a weaker
+measurement and is labelled as such.
+
+Exit status: 0 = the runs agree, 1 = they differ, 2 = could not run.
+Requires Python 3.11+ and a clean git worktree. No network of its own.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, NoReturn
+
+DEFAULT_TIMEOUT = 900
+
+
+def fail(what: str) -> NoReturn:
+    """Exit 2 — could not run. Never 1, which means the runs disagreed."""
+    print(f"error: {what}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _git(tree: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(tree), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+    if proc.returncode != 0:
+        fail(f"git {' '.join(args)} failed in {tree}: {proc.stderr.strip()}")
+    return proc.stdout
+
+
+def require_clean_worktree(tree: Path) -> None:
+    """Refuse to touch a tree that has anything to lose.
+
+    Every run mutates the tree and is undone with `checkout -- .` + `clean -fd`.
+    That restore is only safe if the tree started with nothing uncommitted and
+    nothing untracked, so this is the guard that makes the whole approach safe
+    to point at a real checkout by mistake. It is also the same check Phase 5
+    already makes before reusing a worktree.
+    """
+    if not (tree / ".git").exists():
+        fail(f"{tree} is not a git worktree (no .git); refusing to run")
+    dirty = _git(tree, "status", "--porcelain").strip()
+    if dirty:
+        fail(
+            f"{tree} has uncommitted or untracked files; refusing to run.\n"
+            "       Every run is undone with `git checkout -- . && git clean -fd`,\n"
+            "       which would discard them. Use the Phase 5 worktree, or commit\n"
+            "       and re-run."
+        )
+
+
+def snapshot_changes(tree: Path) -> dict[str, str]:
+    """What the tool just did: changed path -> sha256 of its new content.
+
+    Keyed on content rather than on the diff text so two runs are comparable
+    even when they touch the same file in different ways. A deleted file maps to
+    a sentinel rather than being dropped, since deleting a file is exactly the
+    kind of fix-mode behaviour worth catching.
+    """
+    changes: dict[str, str] = {}
+    for line in _git(tree, "status", "--porcelain", "-z").split("\0"):
+        if not line:
+            continue
+        # porcelain -z: XY then a space then the path, no quoting or renames to
+        # unpick for our purposes (a rename shows as delete + add).
+        path = line[3:]
+        if not path:
+            continue
+        blob = tree / path
+        if not blob.exists():
+            changes[path] = "<deleted>"
+        elif blob.is_file():
+            changes[path] = hashlib.sha256(blob.read_bytes()).hexdigest()
+    return changes
+
+
+def restore(tree: Path) -> None:
+    _git(tree, "checkout", "--", ".")
+    _git(tree, "clean", "-fdq")
+
+
+def run_gate(tree: Path, label: str, command: str, timeout: int) -> dict[str, Any]:
+    """One version's run: what it did, what it said, and how it exited."""
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,  # noqa: S602 — the command is supplied by the operator
+            cwd=tree,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=timeout,
+            check=False,
+        )
+        out, code = (proc.stdout or "") + (proc.stderr or ""), proc.returncode
+    except subprocess.TimeoutExpired:
+        restore(tree)
+        fail(f"run '{label}' exceeded {timeout}s: {command}")
+
+    changed = snapshot_changes(tree)
+    restore(tree)
+    return {"label": label, "command": command, "exit": code, "changed": changed, "output": out}
+
+
+def compare(base: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:
+    """The three ways a bump can move a gate."""
+    a, b = base["changed"], other["changed"]
+    return {
+        "base": base["label"],
+        "other": other["label"],
+        "only_in_other": sorted(set(b) - set(a)),
+        "only_in_base": sorted(set(a) - set(b)),
+        "different_result": sorted(p for p in set(a) & set(b) if a[p] != b[p]),
+        "exit_changed": base["exit"] != other["exit"],
+        "base_exit": base["exit"],
+        "other_exit": other["exit"],
+    }
+
+
+def render(report: dict[str, Any]) -> None:
+    print(f"tree: {report['tree']}\n")
+    for run in report["runs"]:
+        print(f"  {run['label']:<12} exit {run['exit']:<3} touched {len(run['changed'])} file(s)")
+        print(f"  {'':<12} {run['command']}")
+    print()
+
+    for cmp_ in report["comparisons"]:
+        head = f"=== {cmp_['other']} vs {cmp_['base']}"
+        print(head)
+        if cmp_["exit_changed"]:
+            print(f"  EXIT   {cmp_['base_exit']} -> {cmp_['other_exit']}  (the gate's answer changed)")
+        for path in cmp_["only_in_other"]:
+            print(f"  +      {path}   acted on by {cmp_['other']} only — widened scope or a new rule")
+        for path in cmp_["only_in_base"]:
+            print(f"  -      {path}   acted on by {cmp_['base']} only — narrowed scope")
+        for path in cmp_["different_result"]:
+            print(f"  ~      {path}   both act, different result — the fix itself changed")
+        if not any(
+            (cmp_["only_in_other"], cmp_["only_in_base"], cmp_["different_result"])
+        ):
+            print("  no difference in what the gate did to the tree")
+            if not cmp_["exit_changed"]:
+                print("  (and the exit code is unchanged)")
+        print()
+
+    if report["no_write_mode"]:
+        print("NOTE: no run changed any file. If these gates have a write mode, this")
+        print("      measured the wrong thing — re-run with it (`ruff format .`, not")
+        print("      `--check`). If they genuinely have none (a type checker, a test")
+        print("      suite), exit code is the only signal here, and it is the weaker one.\n")
+
+    print("RESULT:", "GATES AGREE" if report["agree"] else "GATES DIFFER")
+    print("This is the mechanical half of Phase 4. Whether a difference matters")
+    print("is a judgment about this repo, and belongs in the report.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tree", required=True, help="clean git worktree to run in")
+    parser.add_argument(
+        "--run",
+        nargs=2,
+        action="append",
+        metavar=("LABEL", "COMMAND"),
+        required=True,
+        help="a labelled gate invocation; the first is the baseline",
+    )
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if len(args.run) < 2:
+        fail("need at least two --run invocations to compare")
+
+    tree = Path(args.tree).resolve()
+    require_clean_worktree(tree)
+
+    runs = [run_gate(tree, label, cmd, args.timeout) for label, cmd in args.run]
+    comparisons = [compare(runs[0], other) for other in runs[1:]]
+
+    report: dict[str, Any] = {
+        "tree": str(tree),
+        "runs": runs,
+        "comparisons": comparisons,
+        "no_write_mode": all(not r["changed"] for r in runs),
+        "agree": all(
+            not c["only_in_other"]
+            and not c["only_in_base"]
+            and not c["different_result"]
+            and not c["exit_changed"]
+            for c in comparisons
+        ),
+    }
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        render(report)
+    return 0 if report["agree"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/dependabot-audit/scripts/gate_diff.py
+++ b/skills/dependabot-audit/scripts/gate_diff.py
@@ -65,8 +65,13 @@ def fail(what: str) -> NoReturn:
 
 
 def _git(tree: Path, *args: str) -> str:
-    proc = subprocess.run(
-        ["git", "-C", str(tree), *args],
+    # S603/S607: a fixed argv with `git` resolved from PATH, the only sane way to
+    # invoke it. Each directive has to sit on the line its own diagnostic is
+    # reported on — S603 on the call, S607 on the argv — because `ruff check
+    # --fix` deletes any code that is not reported exactly there. Grouping them
+    # on one line looks tidier and silently loses one of them.
+    proc = subprocess.run(  # noqa: S603
+        ["git", "-C", str(tree), *args],  # noqa: S607
         capture_output=True,
         text=True,
         encoding="utf-8",
@@ -131,9 +136,12 @@ def restore(tree: Path) -> None:
 def run_gate(tree: Path, label: str, command: str, timeout: int) -> dict[str, Any]:
     """One version's run: what it did, what it said, and how it exited."""
     try:
-        proc = subprocess.run(
+        # S602: `shell=True` is the feature. The command is a gate invocation the
+        # operator wrote, not user data — it needs a shell for the redirects and
+        # pipes real gate commands contain.
+        proc = subprocess.run(  # noqa: S602
             command,
-            shell=True,  # noqa: S602 — the command is supplied by the operator
+            shell=True,
             cwd=tree,
             capture_output=True,
             text=True,
@@ -177,16 +185,18 @@ def render(report: dict[str, Any]) -> None:
         head = f"=== {cmp_['other']} vs {cmp_['base']}"
         print(head)
         if cmp_["exit_changed"]:
-            print(f"  EXIT   {cmp_['base_exit']} -> {cmp_['other_exit']}  (the gate's answer changed)")
+            print(
+                f"  EXIT   {cmp_['base_exit']} -> {cmp_['other_exit']}  (the gate's answer changed)"
+            )
         for path in cmp_["only_in_other"]:
-            print(f"  +      {path}   acted on by {cmp_['other']} only — widened scope or a new rule")
+            print(
+                f"  +      {path}   acted on by {cmp_['other']} only — widened scope or a new rule"
+            )
         for path in cmp_["only_in_base"]:
             print(f"  -      {path}   acted on by {cmp_['base']} only — narrowed scope")
         for path in cmp_["different_result"]:
             print(f"  ~      {path}   both act, different result — the fix itself changed")
-        if not any(
-            (cmp_["only_in_other"], cmp_["only_in_base"], cmp_["different_result"])
-        ):
+        if not any((cmp_["only_in_other"], cmp_["only_in_base"], cmp_["different_result"])):
             print("  no difference in what the gate did to the tree")
             if not cmp_["exit_changed"]:
                 print("  (and the exit code is unchanged)")

--- a/tests/test_gate_diff.py
+++ b/tests/test_gate_diff.py
@@ -1,0 +1,184 @@
+"""Regression tests for gate_diff.py.
+
+No network and no real linters: the gate commands are shell one-liners that
+stand in for "a tool that touched these files". What is under test is the
+mechanics — snapshotting, restoring between runs, and the three ways a bump can
+move a gate — because those are what go wrong when improvised.
+
+    python3 -m unittest discover -s tests -v
+
+The safety-critical case is `test_the_tree_is_restored_between_runs`: without
+it, run two inherits run one's edits and every comparison after that is fiction.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
+)
+
+from gate_diff import main
+
+
+def git_repo(test: unittest.TestCase) -> pathlib.Path:
+    """A throwaway git repo with one committed file, removed when the test ends."""
+    directory = pathlib.Path(tempfile.mkdtemp())
+    test.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+    (directory / "tracked.txt").write_text("original\n", encoding="utf-8")
+    for args in (
+        ["init", "-q", "-b", "main"],
+        ["add", "-A"],
+        ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base"],
+    ):
+        subprocess.run(["git", "-C", str(directory), *args], check=True, capture_output=True)
+    return directory
+
+
+class GateDiffHarness(unittest.TestCase):
+    def _run(self, tree, runs, as_json=False):
+        argv = ["gate_diff.py", "--tree", str(tree)]
+        if as_json:
+            argv.append("--json")
+        for label, command in runs:
+            argv += ["--run", label, command]
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(err),
+        ):
+            try:
+                code: int | str | None = main()
+            except SystemExit as exc:  # fail() raises rather than returns
+                code = exc.code
+        return code, out.getvalue(), err.getvalue()
+
+
+class TestTheThreeWaysAGateMoves(GateDiffHarness):
+    def test_widened_scope_is_reported(self):
+        """The ruff 0.16 case: the newer version acts on a file the older ignores."""
+        tree = git_repo(self)
+        code, out, _ = self._run(
+            tree, [("locked", "true"), ("proposed", "printf x > doc.md")]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("doc.md", out)
+        self.assertIn("acted on by proposed only", out)
+
+    def test_narrowed_scope_is_reported(self):
+        tree = git_repo(self)
+        code, out, _ = self._run(
+            tree, [("locked", "printf x > doc.md"), ("proposed", "true")]
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("acted on by locked only", out)
+
+    def test_same_file_different_result_is_reported(self):
+        """The destructive-fix case: both versions rewrite it, differently."""
+        tree = git_repo(self)
+        code, out, _ = self._run(
+            tree,
+            [
+                ("locked", "printf 'kept\\n' > tracked.txt"),
+                ("proposed", "printf 'deleted\\n' > tracked.txt"),
+            ],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("different result", out)
+        self.assertIn("tracked.txt", out)
+
+    def test_a_deleted_file_counts_as_a_change(self):
+        """Deleting a file is exactly the fix-mode behaviour worth catching."""
+        tree = git_repo(self)
+        code, out, _ = self._run(tree, [("locked", "true"), ("proposed", "rm tracked.txt")])
+        self.assertEqual(code, 1)
+        self.assertIn("tracked.txt", out)
+
+    def test_identical_runs_agree(self):
+        tree = git_repo(self)
+        code, out, _ = self._run(
+            tree,
+            [("locked", "printf same > f.txt"), ("proposed", "printf same > f.txt")],
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("GATES AGREE", out)
+
+    def test_an_exit_code_change_is_reported_even_with_no_file_change(self):
+        tree = git_repo(self)
+        code, out, _ = self._run(tree, [("locked", "true"), ("proposed", "false")])
+        self.assertEqual(code, 1)
+        self.assertIn("the gate's answer changed", out)
+
+
+class TestSafety(GateDiffHarness):
+    def test_the_tree_is_restored_between_runs(self):
+        """Without this every comparison after the first run is fiction.
+
+        Run one leaves a stray file behind; run two asserts it is gone. A failed
+        restore shows up as run two exiting non-zero.
+        """
+        tree = git_repo(self)
+        _, out, _ = self._run(
+            tree,
+            [("first", "printf x > stray.txt"), ("second", "test ! -e stray.txt")],
+            as_json=True,
+        )
+        second = json.loads(out)["runs"][1]
+        self.assertEqual(second["exit"], 0, "run two saw run one's leftovers")
+        self.assertFalse((tree / "stray.txt").exists(), "tree left dirty after the run")
+
+    def test_the_tree_is_clean_when_the_tool_finishes(self):
+        tree = git_repo(self)
+        self._run(tree, [("a", "printf x > f.txt"), ("b", "printf 'edited' > tracked.txt")])
+        left = subprocess.run(
+            ["git", "-C", str(tree), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertEqual(left.stdout.strip(), "", "the worktree must be left as found")
+
+    def test_a_dirty_tree_is_refused(self):
+        """The restore would discard uncommitted work, so it never starts."""
+        tree = git_repo(self)
+        (tree / "precious.txt").write_text("unsaved\n", encoding="utf-8")
+        code, _, err = self._run(tree, [("a", "true"), ("b", "true")])
+        self.assertEqual(code, 2)
+        self.assertIn("refusing to run", err)
+        self.assertTrue((tree / "precious.txt").exists(), "must not touch it")
+
+    def test_a_non_git_tree_is_refused(self):
+        directory = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        code, _, err = self._run(directory, [("a", "true"), ("b", "true")])
+        self.assertEqual(code, 2)
+        self.assertIn("not a git worktree", err)
+
+    def test_a_single_run_is_refused(self):
+        tree = git_repo(self)
+        code, _, err = self._run(tree, [("only", "true")])
+        self.assertEqual(code, 2)
+        self.assertIn("at least two", err)
+
+
+class TestNoWriteMode(GateDiffHarness):
+    def test_a_check_only_gate_says_so(self):
+        """Measuring a --check invocation measures the weaker signal; say it."""
+        tree = git_repo(self)
+        _, out, _ = self._run(tree, [("locked", "echo a"), ("proposed", "echo b")])
+        self.assertIn("no run changed any file", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gate_diff.py
+++ b/tests/test_gate_diff.py
@@ -69,18 +69,14 @@ class TestTheThreeWaysAGateMoves(GateDiffHarness):
     def test_widened_scope_is_reported(self):
         """The ruff 0.16 case: the newer version acts on a file the older ignores."""
         tree = git_repo(self)
-        code, out, _ = self._run(
-            tree, [("locked", "true"), ("proposed", "printf x > doc.md")]
-        )
+        code, out, _ = self._run(tree, [("locked", "true"), ("proposed", "printf x > doc.md")])
         self.assertEqual(code, 1)
         self.assertIn("doc.md", out)
         self.assertIn("acted on by proposed only", out)
 
     def test_narrowed_scope_is_reported(self):
         tree = git_repo(self)
-        code, out, _ = self._run(
-            tree, [("locked", "printf x > doc.md"), ("proposed", "true")]
-        )
+        code, out, _ = self._run(tree, [("locked", "printf x > doc.md"), ("proposed", "true")])
         self.assertEqual(code, 1)
         self.assertIn("acted on by locked only", out)
 


### PR DESCRIPTION
The two items deferred from the review. Phase 4 first, because mechanising it
*creates* dedup opportunity rather than consuming it.

## Phase 4 — `gate_diff.py`

Phase 4 asked the model to read the changelog for added rules, reason about
allow-list vs disable-list, then run the tool. The first two are predictions and
were carrying most of the weight. Now it runs each gate once per version in a
disposable worktree and compares **what each run did to the files**.

Diffing the tree rather than the output was not the first design. Replaying a
real bump changed it — Dependabot's ruff `0.15.22` → `0.16.0` PR against
`fpga-board-sim`, at the tree as it stood that day:

- **Exit codes miss it.** Both versions exit 0 on an already-compliant repo while
  the newer formats **33 more files**. An exit-code differential reports "no
  change" on exactly the case worth catching.
- **Output isn't comparable across versions.** 0.15 prints `Would reformat: x.py`;
  0.16 prints an annotated diff. The *renderer* changed, so a text diff marks
  every line different.
- **What the tool touches is stable.** `0 files → 6 files`, naming
  `CONTRIBUTING.md` and five docs — in any output format.

That replay is the end-to-end test: it reproduces the six Markdown files the
newer ruff started formatting, which is the finding a human recorded at the time.

Three results, one taxonomy: acted on by the newer run only (widened scope / a
rule that now fires), by the older only (narrowed scope), by both with a
different result (**the fix itself changed** — the shape no security feed
reports). Ecosystem-independent, because it parses nothing.

Safety was the part that had to be right, since every run mutates the tree and is
undone with `checkout -- . && clean -fd`: it refuses a non-git tree, refuses one
with anything uncommitted or untracked to lose, and restores between runs. Tests
for each — the restore one most of all, since without it run two inherits run
one's edits and every comparison after is fiction.

## The prose ratchet

SKILL.md went 178 → 332 over nine commits, **every growth step a fix, never once
down**. The cause is that prose was the only lever: when Phase 6 improvised a
check-name parse, the response was to say it again, louder.

There are stronger levers — a trap a script *refuses* can't be skipped; one on a
checklist is visibly skipped; prose is the weakest. Hence the rule: **a trap whose
enforcement moved into a script can have its explanation live in `traps.md`; one
still resting on the reader stays inline.**

Deduped (all now enforced by `audit.py`): Phase 1's wrong-lockfile paragraph, the
PR-title warning, the exit-code contract, Phase 6's two misreads, and the
motivational preamble duplicated verbatim from the README.

Kept inline (nothing enforces them): branch protection's 404-vs-403 table,
pipefail, worktree isolation, never pushing to the bot's branch.

**Net 290 → 343 for the session.** Phase 4 gained a script and a result table;
the dedup took 20 back. The honest read: SKILL.md is mostly instruction rather
than explanation, so there's less to recover than the duplication count suggests.
The standing rule matters more than this pass — a new inline trap is a signal
that something wants mechanising.

## Also

Enabling ruff's `S` rules on the new script surfaced a mechanic worth recording
in place: a `# noqa` only suppresses diagnostics reported on **its own line**, and
`ruff check --fix` silently deletes any code that isn't. `S603` belongs on the
call, `S607` on the argv one line below. Grouping them reads better and quietly
loses one — which is how the first attempt lost `S602` entirely.

Tests 39 → 51. `mypy` clean; the test-module override now lists each module
explicitly, because a `test_*` wildcard matches nothing and disables the override
with no warning, not even under `--warn-unused-configs` (25 → 175 errors when
tried).

🤖 Generated with [Claude Code](https://claude.com/claude-code)