### PR TITLE
Give Phase 0 outputs a third state, and fix the two that fail into a plausible value

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ version bumps change output formats about as often as they change behavior.
 python3 -m unittest discover -s tests -v
 ```
 
-111 cases, stdlib only, no network — they run offline and free. Every case
+113 cases, stdlib only, no network — they run offline and free. Every case
 corresponds to a defect that actually shipped, or to a failure the audit exists
 to detect. They fall into nine groups:
 
@@ -170,11 +170,12 @@ to detect. They fall into nine groups:
   inherits run one's edits and every comparison after it is fiction.
 - **Skill prose** — `SKILL.md` checked against itself: no phase may consume what
   a later phase creates, Phase 4 must measure on the merge base rather than the
-  PR's tree, the required-context list must be read from a Phase 0 artifact rather
-  than typed, every script and reference path the prose names must exist, the
-  phases that execute PR code must say so, and the frontmatter key that withholds
-  tools must be the one that works. Each corresponds to a defect that shipped in
-  the prose, where the other groups cannot reach.
+  PR's tree, the required contexts must come from the API rather than an authored
+  list — and specifically not from the two endpoints that fail into a plausible
+  answer — every script and reference path the prose names must exist, the phases
+  that execute PR code must say so, and the frontmatter key that withholds tools
+  must be the one that works. Each corresponds to a defect that shipped in the
+  prose, where the other groups cannot reach.
 
 The theme is **silent** failure. An audit that reports success while verifying
 less than it claimed is worse than one that crashes, so the assertions target
@@ -205,7 +206,8 @@ drift from.
 
 **Not covered:** whether the model *follows* the procedure. The prose group checks
 `SKILL.md` against itself — that no phase consumes what a later phase creates,
-that the required-context list is derived rather than typed. It cannot check
+that the required contexts come from the API rather than an authored list. It
+cannot check
 whether Phase 6 gets run at all, or whether an unexpected file in the diff
 actually stops the audit. That is behavioral and belongs in `claude plugin eval`,
 which is in early access and unavailable on this account.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ version bumps change output formats about as often as they change behavior.
 python3 -m unittest discover -s tests -v
 ```
 
-113 cases, stdlib only, no network — they run offline and free. Every case
+115 cases, stdlib only, no network — they run offline and free. Every case
 corresponds to a defect that actually shipped, or to a failure the audit exists
 to detect. They fall into nine groups:
 
@@ -212,7 +212,7 @@ whether Phase 6 gets run at all, or whether an unexpected file in the diff
 actually stops the audit. That is behavioral and belongs in `claude plugin eval`,
 which is in early access and unavailable on this account.
 
-That gap is real, and it is where the defects keep turning up. Five have now
+That gap is real, and it is where the defects keep turning up. Seven have now
 shipped in the prose and nowhere else:
 
 - Phase 6 improvised a check-name parse, mangling `Lint & type-check` into `Lint`.
@@ -228,12 +228,26 @@ shipped in the prose and nowhere else:
   behaviour change was real enough that a human had to deal with it. Found by
   auditing the exact bump this plugin's founding observation came from: six
   Markdown files on the merge base, nothing on the PR's tree.
+- **Phase 0 read the required checks from an `admin`-only endpoint.** Without
+  admin it returns a bare `404`, `gh` writes that body to *stdout*, and the
+  redirect produced a well-formed file that read as "no required checks" — about a
+  repo enforcing three. The report then said CI was verified.
+- **Phase 1's scope gate fired on a merge base that was not the branch point.**
+  A force-pushed base sends `git merge-base` back to a much older ancestor, so a
+  two-file bump presented as fourteen files and 3,682 deletions, and the gate
+  stopped the audit for a reason that was not true.
 
-That last one is the worst of the five. The others stalled a run or made noise;
-this one returned a confident "no change" from the highest-yield phase. Two are
-the same forward-reference shape, which is what turned the prose group from an
-idea into a necessity: a defect class that recurs is cheaper to gate than to keep
-finding, and prose was the only lever being spent on it.
+The last three are the ones that matter, and they share a shape the first four do
+not: each returned a **confident false statement** rather than stalling. Phase 4
+reported "no change" from the highest-yield phase; the other two reported on
+repository state they had not actually read. A run that stops is cheap. A row that
+is wrong is not, because the report's whole proposition is that its rows are
+things that were established.
+
+Two of the seven are the same forward-reference shape, and two are the same
+fail-into-a-plausible-value shape. That recurrence is what turned the prose group
+from an idea into a necessity: a defect class that repeats is cheaper to gate than
+to keep finding, and prose was the only lever being spent on it.
 
 ### Live checks
 

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -115,6 +115,29 @@ there. A phase that consumes what a later phase creates cannot be run in order,
 and that has now shipped twice — `tests/test_skill_prose.py` is what stops the
 third.
 
+**An output that could not be derived is not an output.** Every row above has
+*three* states, not two: derived; genuinely absent, which is often a finding in
+its own right; and **underivable**, where the call failed or its precondition did
+not hold. Record which one you got, and never let the third collapse into either
+of the others.
+
+That collapse is not hypothetical, and it is the shape both known defects take.
+These two fail into a *plausible* value rather than an error:
+
+| Output | How it fails quietly | What it then asserts |
+|---|---|---|
+| `$BASE_SHA` | the base branch was rewritten under the PR, so `git merge-base` walks back to a much older shared ancestor | a real commit, which is the wrong one — Phase 1 sees a diff full of files the bump never touched, and Phase 4 measures a tree the PR would never land on |
+| `$SCRATCH/required.txt` | the protection call failed and wrote its error body to **stdout** | a well-formed file that reads as "no required checks", which is indistinguishable from a repo that has none |
+
+Neither raises. Both travel downstream as fact, and the report says something
+false with full confidence — which costs more than a crash, because the shape of
+the report invites trust in every row.
+
+So: a phase handed an underivable input says so in its evidence row instead of
+proceeding on the value, and Phase 7 does not print a row whose input was never
+established. "Could not check" is a legitimate thing for this procedure to
+report. "Checked, found nothing" when you could not check is not.
+
 **Classify the PR before trusting it enough to run it.** Dependabot and Renovate
 push their branches *into* the repository, so a dependency bump arriving from a
 fork did not come from the bot:

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -79,10 +79,14 @@ BASE_SHA=$(git merge-base "$DEFAULT" "pr-<N>")
 git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
 
-# save the required contexts; Phase 6 reads the file rather than a list retyped
-# from memory, which verifies nothing while looking identical to a pass
-gh api "repos/:owner/:repo/branches/$DEFAULT/protection" \
-  --jq '.required_status_checks.contexts[]' > "$SCRATCH/required.txt"
+# owner and name, for the GraphQL query Phase 6 issues — `:owner/:repo` is a
+# REST-path convenience and does not expand in a GraphQL variable
+OWNER=$(gh repo view --json owner --jq .owner.login)
+NAME=$(gh repo view --json name  --jq .name)
+
+# what this account may do here: it decides the verdict's shape, and it is how
+# a failed permission-gated call is told apart from a real absence
+PERMS=$(gh api "repos/:owner/:repo" --jq '.permissions')
 ```
 
 If `git worktree add` refuses because the path already exists, a previous run
@@ -108,7 +112,8 @@ If either check fails, `git worktree remove` it and re-add.
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
 | `$SCRATCH/pr-<N>` | worktree at the PR's head — Phase 5 reproduces in it |
 | `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below |
-| `$SCRATCH/required.txt` | the required contexts, one per line; **empty is a finding**, not a blank |
+| `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
+| `$PERMS` | this account's permissions on the repo — `admin`, `maintain`, `push`, `triage`, `pull` |
 
 If a later phase needs something not on this list, it belongs here rather than
 there. A phase that consumes what a later phase creates cannot be run in order,
@@ -170,22 +175,39 @@ Use a harness-provided scratch directory for `SCRATCH` if you have one; otherwis
 `git status`, and a gate that walks the tree (a linter, a formatter, a test
 collector) will descend into a full second copy of the project and report on it.
 
-**Derive the branch name; never type it.** A failed protection call and a repo
-with no protection both leave `$SCRATCH/required.txt` **empty**, so if stderr is
-discarded or the file is skimmed only for its lines, they are indistinguishable —
-and Phase 6 then verifies nothing while the report still says CI is green. Read
-the status and message, which separate three genuinely different situations (all
-verified):
+**`$PERMS` decides two separate things, and conflating them gets both wrong.**
+The tier that can read branch protection is `admin`. The tier that can *merge* is
+`push`. They are different, and the common case — a maintainer with `push` but not
+`admin` — sits between them:
 
-| Response | Meaning |
+| `$PERMS` | Consequence |
 |---|---|
-| `404 Branch not found` | wrong branch name — your mistake, fix and re-run |
-| `404 Branch not protected` | correct branch, no protection configured |
-| `403 Upgrade to GitHub Pro…` | correct branch, but branch protection is unavailable on this plan (a private repo on a free plan) |
+| `admin: true` | branch protection is readable, if the plan offers it at all |
+| `push: true`, `admin: false` | can merge; **cannot** read protection. The ordinary case for a maintainer in an org |
+| `pull` only | cannot merge — so Phase 7's verdict is a recommendation, and the un-run merge command is a command this reader cannot run. Offer `--comment` text instead |
 
-Only the first is an error on your part. The other two are **findings**: the repo
-has no enforced required checks, which changes what a green CI run is worth. Say
-so explicitly in the report rather than omitting the row.
+**Do not call `branches/<b>/protection` to find the required checks.** It needs
+`admin`, and GitHub answers a bare `404 Not Found` without it rather than a 403,
+so on any repo you do not administer the call fails in a way that is
+indistinguishable from an unprotected branch — and `gh` writes that error body to
+**stdout**, so redirecting it to a file produces a well-formed artifact that reads
+as "no required checks". Verified: a repo whose `main` carries three required
+checks returns exactly that 404 to a `pull`-only account, while
+`branches/<b>` reports `"protected": true`.
+
+Phase 6 asks a different question that is readable at `pull` and answers this one
+directly. Two states remain worth naming when protection *is* readable, and both
+are findings rather than errors on your part: `404 Branch not protected` (no
+protection configured) and `403 Upgrade to GitHub Pro…` (a private repo on a free
+plan, where protection is unavailable). A `404 Branch not found` is the one that
+is your mistake — the branch name was wrong, so fix it and re-run.
+
+Also do not substitute `repos/:owner/:repo/rules/branches/<b>`. It is readable
+without `admin`, which makes it tempting, and it reports **only rulesets** —
+classic branch protection is invisible to it. The same repo above returns `[]`
+from both it and `/rulesets` while enforcing three required checks, so an empty
+result there would manufacture the exact false finding this section exists to
+prevent.
 
 Then read the CI workflow and the pre-commit config to learn the repo's **own**
 verification commands — do not assume `pytest`; it may be `uv run pytest`, `tox`,
@@ -429,7 +451,7 @@ is not.
 
 ## Phase 6 — CI verification
 
-*Requires from Phase 0: `$HEAD_SHA`, `$SCRATCH/required.txt`.*
+*Requires from Phase 0: `$HEAD_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*
 
 Confirm the green you are trusting belongs to **this** commit. Use the full
 40-character `$HEAD_SHA` pinned in Phase 0 — a short one matches nothing and
@@ -439,44 +461,57 @@ reads exactly like "CI never ran":
 gh run list --commit "$HEAD_SHA" --workflow <ci>.yml
 ```
 
-Then check the required contexts **individually** — a repo can have far more jobs
-than required checks, and only the required ones gate merge. The list comes from
-the file Phase 0 derived; **never retype it**, because a list that names checks
-this repo does not have matches nothing, prints nothing, and is indistinguishable
-from a repo with no required checks:
+Then ask GitHub **which checks are required**, rather than deriving a list and
+joining it by hand. `isRequired` is a field on the rollup contexts, it is
+evaluated for this PR against whatever enforces it — classic protection, a
+ruleset, a path-scoped rule — and it is readable at `pull`:
 
 ```bash
-gh pr view <N> --json statusCheckRollup --jq \
-  '.statusCheckRollup[] | "\(.conclusion // .state)\t\(.name // .context)"' \
-  > "$SCRATCH/rollup.tsv"
-
-while IFS= read -r req; do
-  awk -F'\t' -v r="$req" \
-    '$2 == r { print $1 "  " $2; found = 1 }
-     END { if (!found) print "NOT REPORTED  " r }' "$SCRATCH/rollup.tsv"
-done < "$SCRATCH/required.txt"
-
-# and the totals, to catch anything unsettled:
-gh pr view <N> --json statusCheckRollup --jq \
-  '[.statusCheckRollup[]|(.conclusion//.state)]|group_by(.)|map("\(.[0]): \(length)")|join("  ")'
+gh api graphql -f query='
+query($owner:String!, $name:String!, $number:Int!) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      mergeable mergeStateStatus reviewDecision
+      commits(last:1) { nodes { commit { statusCheckRollup { state
+        contexts(first:100) { nodes {
+          ... on CheckRun      { name    conclusion isRequired(pullRequestNumber:$number) }
+          ... on StatusContext { context state      isRequired(pullRequestNumber:$number) }
+        } } } } } }
+    }
+  }
+}' -F owner="$OWNER" -F name="$NAME" -F number=<N> > "$SCRATCH/checks.json"
 ```
 
-Every required context produces exactly one row, so a context that never reported
-says so rather than vanishing — which is the failure that made the previous recipe
-unsafe. Matching is on the whole second field, never `awk '{print $1}'`, which
-turns `Lint & type-check` into `Lint`.
+The join happens server-side, so there is no list to retype and no `awk` matching
+to get wrong. Read **three** fields, and never substitute one for another:
 
-What that looks like on a repo whose checks are named as awkwardly as this one's:
+| Field | What it settles |
+|---|---|
+| `isRequired`, per context | which checks gate merge — a repo can report far more than it requires |
+| `statusCheckRollup.state` | whether the checks that *reported* passed |
+| `mergeStateStatus` | whether anything still blocks, **including what never reported** |
 
-```text
-success       Lint & type-check
-success       Test (Python 3.11)
-NOT REPORTED  Test (Python 3.14)
-```
+**A green rollup is not a mergeable PR.** Verified on a real PR: 39 contexts, 3
+required, every one `SUCCESS`, rollup `SUCCESS` — and `mergeStateStatus: BLOCKED`
+with `reviewDecision: REVIEW_REQUIRED`. A procedure that stops at the required
+contexts reports all-green and recommends a merge GitHub will refuse. The old
+recipe could not see this at any permission tier.
 
-**An empty `$SCRATCH/required.txt` prints nothing at all**, and that is the
-Phase 0 finding — no enforced required checks, for one of the two reasons its
-table separates. Report it as a finding; do not report CI as verified.
+**`isRequired` only sees contexts that reported.** A required check that never ran
+is absent from the list entirely — the failure the hand-written join existed to
+catch. `mergeStateStatus` covers it, because an unsatisfied required check yields
+`BLOCKED` and never `CLEAN`. Two traps travel with it: it is `UNKNOWN` on a merged
+PR, and GitHub computes it lazily, so an open PR may need the query re-issued
+before it settles. `UNKNOWN` is underivable, not "nothing blocks".
+
+**Zero required contexts is a finding only when `mergeStateStatus` agrees.** Read
+them together:
+
+| Required contexts | `mergeStateStatus` | Reading |
+|---|---|---|
+| none | not `BLOCKED` | the repo enforces nothing — real, and it changes what a green run is worth |
+| none | `BLOCKED` | something gates this PR that you cannot see. **Underivable**, per Phase 0 — do not report it as "no enforced checks" |
+| some | `BLOCKED` | read `reviewDecision` and the unsettled contexts; the checks alone do not explain it |
 
 `references/traps.md` has the reasoning, plus stale `CLEAN`, `UNSTABLE` being
 mergeable, neutral CodeQL, and why a bot rebase does not re-trigger CI.

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -79,6 +79,12 @@ BASE_SHA=$(git merge-base "$DEFAULT" "pr-<N>")
 git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
 
+# prove the merge base is where the bot branched: a genuine bot PR is one commit
+# by the bot, so any other author above it means the base moved underneath
+git log --format='%h %an' "$BASE_SHA..pr-<N>"
+gh api "repos/:owner/:repo/issues/<N>/events" \
+  --jq '.[] | select(.event=="base_ref_force_pushed") | "\(.actor.login) \(.created_at)"'
+
 # owner and name, for the GraphQL query Phase 6 issues — `:owner/:repo` is a
 # REST-path convenience and does not expand in a GraphQL variable
 OWNER=$(gh repo view --json owner --jq .owner.login)
@@ -108,7 +114,7 @@ If either check fails, `git worktree remove` it and re-add.
 | `$DEFAULT` | the repo's default branch, derived |
 | `$SCRATCH` | scratch directory, outside the repo |
 | `$HEAD_SHA` | the full 40-character commit under audit |
-| `$BASE_SHA` | merge base of `$DEFAULT` and `pr-<N>` |
+| `$BASE_SHA` | merge base of `$DEFAULT` and `pr-<N>` — **and whether it is the bot's branch point**, which is a separate answer |
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
 | `$SCRATCH/pr-<N>` | worktree at the PR's head — Phase 5 reproduces in it |
 | `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below |
@@ -175,6 +181,43 @@ Use a harness-provided scratch directory for `SCRATCH` if you have one; otherwis
 `git status`, and a gate that walks the tree (a linter, a formatter, a test
 collector) will descend into a full second copy of the project and report on it.
 
+**Prove the merge base is where the bot branched.** `git merge-base` always
+returns *a* commit, and when the base branch has been rewritten under an open PR
+it returns one that is far too old — silently, with every later phase consuming it
+as fact. This is the `$BASE_SHA` row of the underivable table above, and either
+signal in the block settles it:
+
+| Signal | Meaning |
+|---|---|
+| any commit above `$BASE_SHA` whose author is not the bot | the base moved; `$BASE_SHA` is not the branch point |
+| a `base_ref_force_pushed` event on the PR | the same fact, stated by GitHub, with actor and timestamp |
+
+Observed: a two-file `Cargo.toml` / `Cargo.lock` bump whose merge-base diff was 14
+files and 3,682 deletions, appearing to delete the repo's entire vendored
+`supply-chain/` tree. The base branch had been force-pushed eleven minutes after
+the PR opened, and `merge-base` fell back to an ancestor nineteen months earlier.
+
+**Do not reach for `gh pr view --json files` as a cross-check.** GitHub computes
+the PR's file list from the merge base too, and reported the same 14 files. It
+agrees with the wrong answer rather than correcting it.
+
+When `$BASE_SHA` is not the branch point, report that as the finding and
+substitute:
+
+```bash
+git fetch origin "$DEFAULT"
+git worktree add --detach "$SCRATCH/tip-<N>" "origin/$DEFAULT"
+```
+
+- **Phase 1** takes its scope diff from `pr-<N>^..pr-<N>` — the bot's own commit.
+- **Phase 4** measures in `$SCRATCH/tip-<N>` rather than `$SCRATCH/base-<N>`,
+  because the tree this PR would land on is the default branch's tip, and the
+  merge base is no longer a tree that exists anywhere.
+
+Say both substitutions in the report. "The base branch was rewritten under this
+PR" is a true and useful finding; "this bump reaches beyond the manifest and
+lockfile" is not, and they are easy to confuse because they produce the same diff.
+
 **`$PERMS` decides two separate things, and conflating them gets both wrong.**
 The tier that can read branch protection is `admin`. The tier that can *merge* is
 `push`. They are different, and the common case — a maintainer with `push` but not
@@ -222,6 +265,13 @@ them). Treat those as leads to check, not as facts — verify before repeating.
 ## Phase 1 — Scope and provenance
 
 *Requires from Phase 0: `$SCRATCH`, `$BASE_SHA`, `pr-<N>`.*
+
+**Check the branch point before you read the diff.** If Phase 0 found the base
+rewritten, a merge-base diff shows the whole divergence and the gate below will
+fire on files the bump never touched — so take the diff from `pr-<N>^..pr-<N>`
+and report the rewritten base as its own finding. Firing the gate on a stale
+base is not a safe default: it stops the audit for a reason that is not true, and
+it reads in the report exactly like a bump that reaches into source.
 
 **This phase is a gate, not just a step.** The diff should touch **only** the
 manifest and the lockfile (or a single workflow file for an actions bump).
@@ -325,7 +375,8 @@ Python one in particular audits the wrong interpreter if invoked casually.
 
 ## Phase 4 — Behavior change (the highest-yield phase)
 
-*Requires from Phase 0: the `$SCRATCH/base-<N>` worktree, and the repo's own gates.*
+*Requires from Phase 0: the `$SCRATCH/base-<N>` worktree — or `$SCRATCH/tip-<N>`
+if Phase 0 found the base rewritten — and the repo's own gates.*
 *Executes code from the PR. Skipped under `--no-execute`; skip it if Phase 1
 found anything.*
 

--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -201,20 +201,38 @@ with whitespace-splitting tools mangles them — `awk '{print $1}'` turns
 that does not exist. Query structured output (`--json statusCheckRollup`) and
 match names as whole strings.
 
-**A check that never reported produces no row.** Filtering a rollup by name
-yields nothing for a context that was never posted, which looks identical to
-"not printed because it passed". Count returned rows against the required list
-and treat any absence as *unreported*, not green.
+**A check that never reported produces no row.** `isRequired` is a field on
+contexts that *reported*, so a required check that never ran is absent from the
+list entirely — indistinguishable from "not printed because it passed". Counting
+rows does not save you here, because there is no authored list to count against.
+`mergeStateStatus` is what closes it: an unsatisfied required check yields
+`BLOCKED` and never `CLEAN`. It is `UNKNOWN` on a merged PR, and computed lazily,
+so an open PR may need the query re-issued before it settles — `UNKNOWN` means
+*not established*, not "nothing blocks".
 
-**"No required checks" and "you asked the wrong question" look the same.**
-Querying branch protection for a branch that does not exist returns an empty
-context list, exactly like a branch with no protection — so a mistyped or
-guessed branch name silently turns the whole required-checks verification into a
-no-op. The HTTP status and message do separate the cases (`404 Branch not
-found` = wrong branch; `404 Branch not protected` = genuinely unprotected;
-`403 Upgrade to GitHub Pro…` = protection unavailable on that plan, e.g. a
-private repo on a free plan), but only if you read them instead of discarding
-stderr.
+**A permission-gated read fails into a plausible answer.** Branch protection
+(`branches/<b>/protection`) requires **admin**, and GitHub answers a bare
+`404 Not Found` without it rather than a `403`, so as not to confirm the resource
+exists. That 404 is indistinguishable from an unprotected branch — and `gh`
+writes the error body to *stdout*, so redirecting the call into a file yields a
+well-formed artifact asserting the opposite of the truth. Verified: a repo whose
+`main` enforces three required checks returns exactly that to a `pull`-only
+account, while `branches/<b>` reports `"protected": true`.
+
+Four states, not three, and only the first is your own mistake:
+
+| Response | Meaning |
+|---|---|
+| `404 Branch not found` | wrong branch name — fix and re-run |
+| `404 Branch not protected` | correct branch, no protection configured |
+| **`404 Not Found`** (bare) | **you lack `admin`** — protection may exist and be invisible to you |
+| `403 Upgrade to GitHub Pro…` | protection unavailable on this plan (a private repo on a free plan) |
+
+`repos/:o/:r/rules/branches/<b>` is not the way around it. It *is* readable
+without admin, which is precisely the trap: it reports **rulesets only**, so a
+repo using classic branch protection returns `[]` and manufactures a false
+"nothing enforced" finding. Ask per-PR instead — `isRequired` is evaluated against
+whatever actually enforces it, and needs only `pull`.
 
 **Neutral / "skipping" security-scan results are normal** on diffs that do not
 touch the scanned surface. Not a failure, and usually not a required check.

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -207,6 +207,44 @@ class TestNoRepoSpecificLiterals(SkillHarness):
                 f"it needs admin and fails into a plausible value without it",
             )
 
+    def test_phase_0_proves_the_merge_base_is_the_branch_point(self):
+        """`git merge-base` always returns a commit, even a badly wrong one.
+
+        When the base branch is force-pushed under an open PR the merge base
+        falls back to a much older shared ancestor, and every later phase
+        consumes it as fact: Phase 1's gate fires on files the bump never
+        touched, and Phase 4 measures a tree the PR would never land on.
+        Observed on a two-file bump whose merge-base diff was 14 files.
+
+        `gh pr view --json files` is not a cross-check — GitHub computes the PR's
+        file list from the merge base too, and agrees with the wrong answer.
+        """
+        self.assertIn(
+            "base_ref_force_pushed",
+            self.shell[0],
+            "Phase 0 must check whether the base branch was rewritten; merge-base "
+            "cannot tell you on its own",
+        )
+        self.assertRegex(
+            self.shell[0],
+            r"git log[^\n]*\$BASE_SHA\.\.pr-<N>",
+            "Phase 0 must attribute the commits above the merge base; a genuine "
+            "bot PR is one commit by the bot",
+        )
+
+    def test_a_rewritten_base_falls_back_to_the_bots_own_commit(self):
+        """The substitute has to be named, or the gate fires on a stale base.
+
+        Halting is the wrong response to a rewritten base: it stops the audit for
+        a reason that is not true, and reads in the report exactly like a bump
+        that reaches into source.
+        """
+        self.assertIn(
+            "pr-<N>^..pr-<N>",
+            self.text,
+            "the fallback diff for a rewritten base must be the bot's own commit",
+        )
+
     def test_no_phase_reads_required_checks_from_the_rules_endpoint(self):
         """Readable without admin, which is exactly what makes it a trap.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -175,18 +175,52 @@ class TestNoRepoSpecificLiterals(SkillHarness):
                     f"Phase 0 artifact belongs: {hit}",
                 )
 
-    def test_phase_6_reads_the_required_contexts_from_phase_0(self):
-        """The structural half: the list has to come from somewhere derived."""
+    def test_phase_6_asks_the_api_which_contexts_are_required(self):
+        """The structural half: the list is never authored, at any tier.
+
+        This replaces an assertion that Phase 0 wrote `$SCRATCH/required.txt` and
+        Phase 6 read it. That file is gone — it came from an `admin`-only call
+        whose failure `gh` writes to *stdout*, so on a repo the auditor does not
+        administer it held an error body that read as "no required checks". The
+        property being guarded is unchanged: the required set comes from GitHub,
+        not from the model. `isRequired` is that answer, and it is readable at
+        `pull`.
+        """
         self.assertIn(
-            "$SCRATCH/required.txt",
+            "isRequired",
             self.shell[6],
-            "Phase 6 must read the required contexts Phase 0 derived, not a typed list",
+            "Phase 6 must ask the API which contexts are required, not derive a list",
         )
-        self.assertIn(
-            "$SCRATCH/required.txt",
-            self.shell[0],
-            "Phase 0 must write the required contexts somewhere Phase 6 can read",
-        )
+
+    def test_no_phase_reads_required_checks_from_branch_protection(self):
+        """The `admin`-only endpoint 404s without admin, and the body is stdout.
+
+        A bare 404 is indistinguishable from an unprotected branch, so a redirect
+        of this call produces a well-formed artifact asserting the opposite of the
+        truth. Verified against a repo enforcing three required checks.
+        """
+        for number, code in sorted(self.shell.items()):
+            self.assertNotIn(
+                "/protection",
+                code,
+                f"Phase {number} calls branch protection for the required checks; "
+                f"it needs admin and fails into a plausible value without it",
+            )
+
+    def test_no_phase_reads_required_checks_from_the_rules_endpoint(self):
+        """Readable without admin, which is exactly what makes it a trap.
+
+        `/rules/branches/<b>` reports rulesets only. Classic branch protection is
+        invisible to it, so an empty result manufactures a false "nothing
+        enforced" finding on a repo that enforces plenty.
+        """
+        for number, code in sorted(self.shell.items()):
+            self.assertNotIn(
+                "/rules/branches",
+                code,
+                f"Phase {number} reads the rules endpoint, which cannot see "
+                f"classic branch protection and returns [] on a protected branch",
+            )
 
 
 class TestPhase4MeasuresTheRightTree(SkillHarness):


### PR DESCRIPTION
Closes #19. Closes #20.

Found by auditing `BIRSAx2/mdcat` — the first run against a repository this
account does not administer. Both defects are ecosystem-independent and hit
`uv.lock` audits identically; mdcat is only where they became visible.

## They are one defect, not two

Phase 0's outputs are contractual — *"every later phase consumes these and
nothing else"* — but the table had no way to say a value **could not be derived**.
Two rows fail into a *plausible* value rather than an error, and the missing state
is what lets both assert something false with full confidence:

| Output | How it fails quietly | What it then asserts |
|---|---|---|
| `$BASE_SHA` | the base branch was rewritten under the PR, so `merge-base` walks back to a much older ancestor | a real commit, which is the wrong one |
| `$SCRATCH/required.txt` | the protection call failed and `gh` wrote its error body to **stdout** | a well-formed file reading as "no required checks" |

Neither raises. A crash would be cheaper — the report's shape invites trust in
every row, so a false row costs more than a missing one.

Hence three commits: the contract first, then each instance. Fixing the two call
sites alone would have patched them and left the shape that produced them.

## `38ea0a4` — the contract

Adds the vocabulary (derived / genuinely absent / **underivable**) and the rule: a
phase handed an underivable input says so in its evidence row instead of
proceeding on the value, and Phase 7 does not print a row whose input was never
established. *"Could not check"* is a legitimate thing for this procedure to
report. *"Checked, found nothing"* when you could not check is not.

## `964d70d` — #20, the required checks

`branches/<b>/protection` needs **admin**, and GitHub answers a bare `404` without
it rather than a `403`. Verified on mdcat: the call 404s to a `pull`-only account
while `branches/main` reports `"protected": true` — about a repo enforcing three
required checks. The redirect produced a 138-byte `required.txt` that Phase 6's
`while read` loop iterated **zero** times.

Replaced rather than patched, because GraphQL `isRequired(pullRequestNumber:)` is
readable at `pull`, is evaluated per-PR against whatever enforces it, and does the
join server-side. That retires `required.txt`, the `awk` matching rule and the
"empty means two different things" hazard together.

It is better at **every** tier, not just as a non-admin fallback. On `cli/cli`
#14136 at `READ`:

```
contexts total   : 39   required: 3   (all SUCCESS)
rollup state     : SUCCESS
mergeStateStatus : BLOCKED
reviewDecision   : REVIEW_REQUIRED
```

The old recipe stops at the required contexts, reports all-green, and recommends
a merge GitHub will refuse.

Rejected explicitly in the prose: `repos/:o/:r/rules/branches/<b>`. It *is*
readable without admin, which is what makes it a trap — it reports rulesets only,
and mdcat returns `[]` from it while enforcing three required checks.

Phase 0 now derives `$OWNER`, `$NAME` and `$PERMS`. `$PERMS` separates two things
the old prose conflated: reading protection needs `admin`, merging needs `push`.

## `d2e30b1` — #19, the branch point

A two-file `Cargo.toml`/`Cargo.lock` bump presented as **14 files and 3,682
deletions**, appearing to delete a vendored `supply-chain/` tree, because the base
was force-pushed eleven minutes after the PR opened and `merge-base` fell back
nineteen months. Phase 1's gate fired and stopped the audit — a supply-chain-shaped
accusation against an ordinary bump.

Phase 0 now runs two probes: commit attribution above `$BASE_SHA`, and the
`base_ref_force_pushed` event. The prose also records that `gh pr view --json
files` is **not** a cross-check — GitHub computes it from the merge base too and
reported the same 14 files, so it agrees with the wrong answer.

Halting is the wrong response, so the substitutions are named: Phase 1 diffs
`pr-<N>^..pr-<N>`, and Phase 4 measures in `$SCRATCH/tip-<N>` at `origin/$DEFAULT`.
The quieter half is Phase 4 — had the gate not fired, it would have measured
against a nineteen-month-old tree and attributed the difference to the bump.

## Tests

**115 cases, up from 111.** `test_phase_6_reads_the_required_contexts_from_phase_0`
is **rewritten, not deleted** — the artifact changed, the property it guarded (the
required set is never authored) did not. Four join it: two forbidding the
endpoints that fail into a plausible answer, two guarding the branch-point check.

All five mutation-checked against deliberately broken prose. Worth recording that
my first attempt at that was **invalid** — the failures were `ModuleNotFoundError`
from the wrong path, so the tests never ran. Caught because the output said
`errors=1` rather than `failures=1`; re-run through `discover -s tests`, all five
produce genuine `AssertionError`s.

## What has not been verified

The suite passed locally on **Python 3.14.6 only** — the newest matrix leg, and by
`ci.yml`'s own comment the least informative one. The 3.11–3.13 legs on this PR
are the point of opening it.

CI is advisory here: branch protection is unavailable on this plan (`403 Upgrade
to GitHub Pro`, re-confirmed), so nothing blocks a merge on a red leg. Read the
result rather than relying on the gate — which is the state #17 is queued to fix
after the flip.

**Merge with rebase**, not squash: the three commits are deliberately separable,
and the repo's history is strictly linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
