### PR TITLE
0.10.0: the last three mdcat findings

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,10 +119,15 @@ shape: a row that is accurate and asserts more than it established.
   the case that is not — the same substitution #19 established for Phase 1's
   scope diff.
 
-  The replay also surfaced a second cause for the underivable state: check names
-  drift. `mdcat`'s `main` now reports `test` and `test-windows` where the PR
-  reports `test (ubuntu-latest)`, so a name match against a distant commit finds
-  nothing and reads as "never ran".
+  Two more causes of the underivable state came out of the same replay and out
+  of dogfooding the query on this repo's own PR #26. Check names drift —
+  `mdcat`'s `main` now reports `test` and `test-windows` where the PR reports
+  `test (ubuntu-latest)`, so a name match against a distant commit finds nothing
+  and reads as "never ran". And an intermediate commit of a multi-commit branch
+  is often never built at all: `pr-26^` carries zero check runs, because CI ran
+  on the head and nowhere else. Phase 6 falls back to `$BASE_SHA` there and says
+  which question it answered — red *before this branch* is a weaker claim than
+  red *before this commit*, and passing one off as the other is the failure.
 
   **The obvious query for this is wrong in the same direction as the defect.**
   `gh run list --commit <sha> --json name` returns the *workflow* name, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,107 @@ patch.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-08-15
+
+The last three findings from the `BIRSAx2/mdcat` run. All three are the same
+shape: a row that is accurate and asserts more than it established.
+
+### Fixed
+
+- **`audit.py` blamed itself for a bug when handed a lockfile it does not
+  support.** Pointed at a `Cargo.lock` it printed `unexpected AttributeError:
+  'str' object has no attribute 'get'` followed by `This is a bug, not a
+  finding` — everything right except the diagnosis. Exit 2 was correct and no
+  false `CLEAN` was printed; the failure-versus-finding contract held against an
+  input it was never designed to see. But Cargo writes `source` as a *string*
+  where uv writes a table, so the run reached `_is_pypi` and died, and the
+  message sent the reader hunting for a defect that does not exist.
+
+  It got more important with 0.8.0, not less: `uv.lock` and GitHub Actions are
+  now the entire supported surface, so this message is the **boundary of the
+  tool** and the first thing anyone arriving with a different lockfile sees.
+  Phase 1 leads with the script, so arriving there innocently is the ordinary
+  path.
+
+  The script now sniffs before parsing and names what it found — `Cargo.lock`,
+  `poetry.lock`, `package-lock.json`, `Pipfile.lock`, `go.sum`, `yarn.lock`,
+  `pnpm-lock.yaml`, `pyproject.toml` — and refuses anything else whose
+  `[[package]]` blocks are not uv-shaped without guessing a name. Exit stays 2;
+  `This is a bug` is reserved for exceptions that are one, which is what makes
+  the phrase worth anything when it appears.
+
+  **`poetry.lock` was worse than the Rust case**, and is why the list is longer
+  than the three formats the issue named. It parses, yields zero PyPI-sourced
+  packages, and exits 2 saying *"either this lockfile did not change, or it is
+  being compared against itself"* — a confident false diagnosis, in this
+  plugin's own vocabulary, on Python's other lockfile.
+
+  Two ordering traps found while building it, both now the reason the sniffer is
+  shaped as it is. Identifying uv *first* and diagnosing second — the apparently
+  safe order — lets a real `poetry.lock` through, because poetry writes a
+  `[package.source]` table too; the invariant that works is that every foreign
+  signature must be one a `uv.lock` **cannot** produce, checked against a real
+  uv.lock's keys. And sniffing only after a `TOMLDecodeError` never sees a yarn
+  v1 lockfile, whose two-line comment header is valid TOML.
+
+### Added
+
+- **Phase 5 says which interpreter and which fork produced its row.**
+  `uv sync --locked` asserts the whole lockfile is consistent with the manifest,
+  across every `resolution-markers` fork, and Phase 1 verifies **every** fork's
+  artifacts against the registry. The install then materialises only the
+  resolution matching the interpreter present — which need not be the highest
+  pin. A green row on 3.14 therefore said nothing about whether the 3.11 fork's
+  artifacts fetch or its older release installs, and nothing distinguished the
+  two.
+
+  Phase 5 already required the row to name *which install* ran. The same rule now
+  applies to the interpreter, where it matters more, and `audit.py` prints the
+  fork list for any selected package pinned more than once — mechanised rather
+  than left to prose, per CONTRIBUTING's rule that a disclosure the report is
+  merely asked to remember is one it can omit. A second `uv sync --locked
+  --python <floor>` is documented as the thorough answer and as a deliberate
+  escalation, worth its interpreter download only when the un-installed fork
+  belongs to a package under audit.
+
+  The Cargo instance is what made it visible — `cargo build --locked` passing on
+  1.97.1 against a repo declaring `rust-version = "1.83"` — and the uv analogue
+  is narrower, because uv honours `requires-python` and forks rather than
+  breaking the floor. What survives the scope cut is the reproduction claim, not
+  a resolution failure.
+
+- **Phase 6 establishes whether a red required check is the bump's fault.** It
+  reported conclusions and never asked. Observed on `mdcat` #6:
+  `test (ubuntu-latest)` red beside two green siblings, which reads exactly like
+  a dependency bump breaking one platform. It was `unresolved link to
+  pulldown-cmark-mdcat` — a rustdoc intra-doc-link error under
+  `#[deny(warnings)]`, failing identically on the base commit, with nothing to do
+  with the dependency.
+
+  A Hold driven by that row would have been **correct by accident and
+  unfalsifiable in the report**: every cell true, the causal claim never
+  established. Same family as the rewritten base (#19) and the hand-joined
+  required list (#20). It is also the direction that costs least to be wrong in
+  and so draws the least scrutiny — a false Hold looks conservative, so nobody
+  goes back to check whether the bump was the cause.
+
+  A red check is now labelled **attributable**, **pre-existing**, or
+  **underivable** against the base commit Phase 0 already pinned. A pre-existing
+  failure stays a finding — the repo's default branch is red — but a different
+  one, and it must not produce a Hold on a bump. A red check on a workflow the
+  diff never touched is a strong prior for pre-existing, and shares its input
+  with the PR-reachability check added in 0.9.0.
+
+  **The obvious query for this is wrong in the same direction as the defect.**
+  `gh run list --commit <sha> --json name` returns the *workflow* name, so a
+  per-check match against it is empty for every matrix job — and empty reads as
+  "no run at the base", marking every matrix failure underivable. Measured on a
+  repo whose five contexts are `Test (Python 3.11)` through `Lint & type-check`:
+  `gh run list --json name` returns a single `CI`, while
+  `commits/<sha>/check-runs` returns all five by context name. Phase 6 uses the
+  latter, and `commits/<sha>/status` for a `StatusContext` rather than a
+  `CheckRun`, since the two live in separate lists.
+
 ## [0.9.0] — 2026-08-14
 
 Two releases' worth of findings from the `BIRSAx2/mdcat` run, and a correction.
@@ -789,7 +890,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.6.0...v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,11 +96,33 @@ shape: a row that is accurate and asserts more than it established.
   goes back to check whether the bump was the cause.
 
   A red check is now labelled **attributable**, **pre-existing**, or
-  **underivable** against the base commit Phase 0 already pinned. A pre-existing
-  failure stays a finding — the repo's default branch is red — but a different
-  one, and it must not produce a Hold on a bump. A red check on a workflow the
-  diff never touched is a strong prior for pre-existing, and shares its input
-  with the PR-reachability check added in 0.9.0.
+  **underivable** against the commit the bot branched from. A pre-existing
+  failure stays a finding — the tree the bump landed on was already red — but a
+  different one, and it must not produce a Hold on a bump. A red check on a
+  workflow the diff never touched is a strong prior for pre-existing, and shares
+  its input with the PR-reachability check added in 0.9.0.
+
+  **The comparison point is `pr-<N>^`, not `$BASE_SHA`,** and replaying the
+  original PR is what settled it. `mdcat` #6 carries a human commit under the
+  bot's — a #19 case — so its four candidate comparison points disagree:
+
+  | Commit | `test (ubuntu-latest)` |
+  |---|---|
+  | the bot's commit, the PR head | `failure` |
+  | `pr-6^`, the human commit below it | `failure` — pre-existing, and the answer |
+  | `git merge-base main pr-6` | the check does not exist there at all |
+  | the base branch's tip | `success` — which would say **attributable** |
+
+  Two of those four produce the false Hold this change exists to prevent, and
+  one of them is the merge base. `pr-<N>^` *is* `$BASE_SHA` for a genuine
+  one-commit bot PR, so it costs nothing in the ordinary case and is right in
+  the case that is not — the same substitution #19 established for Phase 1's
+  scope diff.
+
+  The replay also surfaced a second cause for the underivable state: check names
+  drift. `mdcat`'s `main` now reports `test` and `test-windows` where the PR
+  reports `test (ubuntu-latest)`, so a name match against a distant commit finds
+  nothing and reads as "never ran".
 
   **The obvious query for this is wrong in the same direction as the defect.**
   `gh run list --commit <sha> --json name` returns the *workflow* name, so a

--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ lockfiles this plugin will read.
 Other Python lockfiles are out of scope too. The script reads `uv.lock`
 specifically, not Poetry, pip-tools or PDM.
 
+The boundary is enforced rather than stated. Handed another ecosystem's lockfile
+the script exits 2 naming the format — `is a Cargo.lock (Rust)`, `is a
+poetry.lock (Python, Poetry)` — and points at `references/ecosystems.md`. That
+message is the edge of the tool and the first thing a reader arriving with a
+different lockfile sees, so it says what they found rather than blaming itself:
+before 0.10.0 a real `Cargo.lock` produced `unexpected AttributeError ... This is
+a bug`, and a real `poetry.lock` produced a confident *"either this lockfile did
+not change, or it is being compared against itself"*.
+
 `scripts/gate_diff.py` (Phase 4) is the exception: it is
 **ecosystem-independent**, because it parses nothing. It runs a gate once per
 version in a disposable worktree and compares which files each run changed, and

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -337,6 +337,11 @@ the shape of the ones that are here: an unverified verifier reports green rather
 than erroring, which is why npm, Cargo and Go were removed rather than left as
 sketches. `references/ecosystems.md` has the case that settled it.
 
+This phase leads with the script, so reaching for it on an unfamiliar repo is
+the ordinary path rather than a careless one. It now refuses by name — `is a
+Cargo.lock (Rust)`, `is a poetry.lock` — at exit 2. Report that as the boundary
+it is, not as a failed audit: the ecosystem-independent phases still ran.
+
 ## Phase 2 — Currency
 
 *Requires: the Phase 1 script output, and the PR's `createdAt` from Phase 0.*
@@ -564,6 +569,42 @@ and the reasoning.
 
 Then run the repo's own gates from Phase 0, and its full test suite.
 
+**`--locked` checks the whole lockfile; the install materialises one resolution
+out of it.** Those are different claims and the row must not merge them. A
+`uv.lock` can carry several `[[package]]` blocks for the same name under
+different `resolution-markers` — typically the last release supporting an older
+Python alongside the current one. Phase 1 verifies **every** fork's artifacts
+against the registry. `uv sync` then installs only the resolution matching the
+interpreter and platform in front of it, which need not be the highest pin.
+
+So a green row here on 3.14 says nothing about whether the 3.11 fork's artifacts
+still fetch or its older release still installs. **Ask the environment which one
+it built**, rather than the auditor's own `python3`, which may not be the
+interpreter uv chose:
+
+```bash
+uv run python -V                  # inside the synced environment
+uv pip list --format=freeze       # the versions actually materialised
+```
+
+The Phase 1 script prints the fork list — `forked packages: every pin verified,
+one of them installed` — so the names and versions to reconcile against are
+already in the output. Name the interpreter and the fork in the reproduction
+row; do not report the install as though it covered every pin.
+
+**When the bumped package is itself forked, a second sync is the thorough
+version** and it is a deliberate escalation, not the default:
+
+```bash
+uv sync --locked --python <floor>   # the floor from requires-python
+```
+
+It costs an interpreter download and can fail for reasons that have nothing to
+do with the bump. The cheap version — installing once and disclosing which fork
+that was — is honest and is what this phase requires. The second sync is worth
+it when the fork you did *not* install is one of the packages under audit, and
+the report should say which of the two you did.
+
 ### GitHub Actions — substitute run history
 
 There is nothing to install and no way to execute an action outside GitHub's
@@ -591,11 +632,20 @@ alongside a `download-artifact` pin two majors behind. Nothing in the PR could
 show whether the pair still interoperated — seven green release runs over the
 following month did.
 
-**Record which install you ran.** The script-suppressing flags are the documented
-default and they weaken the proof: a package that genuinely needs its install
-script is not exercised. Re-running without them is a legitimate choice, and the
-report has to say which one produced the row rather than asserting "frozen install
-passed" for either.
+**Three things qualify this phase's row, and "reproduced" alone asserts past all
+of them.** Each has a green result that is true of *one* configuration and reads
+as true of every one:
+
+| Qualifier | Why the bare row overstates it |
+|---|---|
+| **which install** | the script-suppressing flags are the documented default and they weaken the proof: a package that genuinely needs its install script is not exercised. Re-running without them is a legitimate choice — say which produced the row |
+| **which interpreter** | the install materialised one fork of a forked lockfile. `uv run python -V`, not the auditor's `python3` |
+| **which forks were only verified** | Phase 1 checked all of them and Phase 5 installed one. Name the others rather than letting the install stand for them |
+
+None of the three is a failure to disclose. "Frozen install passed under
+`--no-build --no-install-project` on CPython 3.14; the 3.11 fork of `rpds-py` was
+verified but not installed" is a stronger row than "frozen install passed",
+because it is one a reader can falsify.
 
 Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing suite sails
 through; use `set -o pipefail` or separate calls.

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -806,10 +806,25 @@ Then label the row, in three states and never two:
 | the same check is red | **pre-existing** | the tree the bump landed on was already red. A real finding, a *different* one, and it must not produce a Hold on this bump |
 | **no run at the base**, or no check by that name | **underivable**, per Phase 0 | say so rather than defaulting to attributable |
 
-**The third row has two causes and they look identical.** The commit may predate
-the workflow or its run may have aged out — or the check may simply be *named*
-something else there. Names drift: `mdcat`'s `main` now reports `test` and
-`test-windows` where the PR reports `test (ubuntu-latest)`, so a name match
+**When `pr-<N>^` has no runs at all, fall back to `$BASE_SHA` and weaken the
+claim out loud.** An intermediate commit of a multi-commit branch is often never
+built — CI ran on the head and nowhere else — so the parent has nothing to
+compare against while the merge base, being on the default branch, does. That
+fallback answers a *different* question and the label has to say so:
+
+| Compared against | What a red result establishes |
+|---|---|
+| `pr-<N>^` | it was red **before this commit** — attribution to the bump |
+| `$BASE_SHA` | it was red **before this branch** — everything below the bump is inside the claim |
+
+Reaching for the second is legitimate and better than reporting nothing; passing
+it off as the first is the failure. Observed on this plugin's own PR #26:
+`pr-26^` is an intermediate commit of the branch and carries zero check runs.
+
+**The third row has two more causes and they look identical.** The commit may
+predate the workflow or its run may have aged out — or the check may simply be
+*named* something else there. Names drift: `mdcat`'s `main` now reports `test`
+and `test-windows` where the PR reports `test (ubuntu-latest)`, so a name match
 against a distant commit finds nothing and reads as "never ran". Compare the
 whole name list, not just the one you are chasing.
 

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -755,31 +755,63 @@ verdict — so it is the one that must not assert more than it established. "Thi
 check is red" is established. "This bump broke it" is a *causal* claim, and
 nothing above tests it.
 
-Ask whether it was already red at the base, which Phase 0 pinned:
+Ask whether it was already red **on the commit the bot branched from** — which is
+the parent of the bot's own commit, not the merge base:
 
 ```bash
-gh api "repos/$OWNER/$NAME/commits/$BASE_SHA/check-runs" --paginate \
+PARENT=$(git rev-parse "pr-<N>^")
+gh api "repos/$OWNER/$NAME/commits/$PARENT/check-runs" --paginate \
   --jq '.check_runs[] | "\(.name)\t\(.conclusion)"'
 ```
+
+**`pr-<N>^` and `$BASE_SHA` are the same commit for a genuine one-commit bot PR**,
+which is the ordinary case — so this costs nothing there and is the right answer
+when they differ. When they differ, `$BASE_SHA` attributes to the bump
+everything that happened on the branch beneath it, which is the same mistake as
+diffing scope against a rewritten base and gets the same substitution (#19).
+
+Measured on `BIRSAx2/mdcat` #6, the PR this section comes from. Its branch
+carries a *human* commit under the bot's, so the four candidate comparison
+points disagree:
+
+| Commit | `test (ubuntu-latest)` |
+|---|---|
+| the bot's commit — the PR head | `failure` |
+| `pr-<N>^`, the human commit below it | `failure` — **pre-existing**, and the answer |
+| `git merge-base` | the check does not exist there at all |
+| the base branch's tip | `success` — which would have said **attributable** |
+
+Two of those four produce the false Hold this section exists to prevent, and one
+of them is the merge base. Read `$BASE_SHA` as a cross-check, not as the input:
+if it disagrees with `pr-<N>^`, the branch has commits the bot did not write, and
+that is worth reporting on its own.
 
 **Use the check-runs endpoint, not `gh run list`.** `gh run list --json name`
 returns the *workflow* name — one row reading `CI` — while the contexts in the
 rollup above are **job** names like `test (ubuntu-latest)`. Matching a job name
 against a workflow name yields nothing, for every matrix job, and an empty result
-here reads as "no run at the base" — which lands in the third state below and
-marks every matrix failure underivable. Verified: on a repo whose five contexts
-are `Test (Python 3.11)` … `Lint & type-check`, `gh run list --json name` returns
-a single `CI`, and `check-runs` returns all five by their context names. Add
-`commits/$BASE_SHA/status` if the red context is a `StatusContext` rather than a
-`CheckRun` — the two live in separate lists, and Phase 6's GraphQL reads both.
+here is indistinguishable from no run at the base — which lands in the third
+state below and marks every matrix failure underivable. Verified: on a repo whose
+five contexts are `Test (Python 3.11)` … `Lint & type-check`, `gh run list --json
+name` returns a single `CI`, and `check-runs` returns all five by their context
+names. Add `commits/$PARENT/status` if the red context is a `StatusContext`
+rather than a `CheckRun` — the two live in separate lists, and Phase 6's GraphQL
+reads both.
 
 Then label the row, in three states and never two:
 
-| At the base | Label | What it means for the verdict |
+| At `pr-<N>^` | Label | What it means for the verdict |
 |---|---|---|
 | the same check is green | **attributable** | the bump is implicated; this row can carry a Hold |
-| the same check is red | **pre-existing** | the repo's default branch is red. A real finding, a *different* one, and it must not produce a Hold on this bump |
-| no run at the base | **underivable**, per Phase 0 | the base may predate the workflow, or the run may have aged out. Say so rather than defaulting to attributable |
+| the same check is red | **pre-existing** | the tree the bump landed on was already red. A real finding, a *different* one, and it must not produce a Hold on this bump |
+| **no run at the base**, or no check by that name | **underivable**, per Phase 0 | say so rather than defaulting to attributable |
+
+**The third row has two causes and they look identical.** The commit may predate
+the workflow or its run may have aged out — or the check may simply be *named*
+something else there. Names drift: `mdcat`'s `main` now reports `test` and
+`test-windows` where the PR reports `test (ubuntu-latest)`, so a name match
+against a distant commit finds nothing and reads as "never ran". Compare the
+whole name list, not just the one you are chasing.
 
 **A red check on a workflow the diff never touched is a strong prior for
 pre-existing**, and Phase 6 already derives which workflows the diff touched for

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -667,11 +667,12 @@ is not.
 
 ## Phase 6 — CI verification
 
-*Requires from Phase 0: `$HEAD_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*
+*Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*
 
 Confirm the green you are trusting belongs to **this** commit, **and that it
 exercised the change**. Those are two questions, and an actions bump routinely
-passes the first while failing the second.
+passes the first while failing the second. A third follows whenever something is
+red: whether the bump is why.
 
 **Check that the changed file is reachable from a pull request.** A workflow
 triggered only by `push: tags:` or `schedule:` never runs on a PR, so every check
@@ -747,6 +748,60 @@ them together:
 | none | not `BLOCKED` | the repo enforces nothing — real, and it changes what a green run is worth |
 | none | `BLOCKED` | something gates this PR that you cannot see. **Underivable**, per Phase 0 — do not report it as "no enforced checks" |
 | some | `BLOCKED` | read `reviewDecision` and the unsettled contexts; the checks alone do not explain it |
+
+**A red check is not evidence that the bump caused it.** Phase 6 reports check
+conclusions, and a failing required context is the row most likely to carry the
+verdict — so it is the one that must not assert more than it established. "This
+check is red" is established. "This bump broke it" is a *causal* claim, and
+nothing above tests it.
+
+Ask whether it was already red at the base, which Phase 0 pinned:
+
+```bash
+gh api "repos/$OWNER/$NAME/commits/$BASE_SHA/check-runs" --paginate \
+  --jq '.check_runs[] | "\(.name)\t\(.conclusion)"'
+```
+
+**Use the check-runs endpoint, not `gh run list`.** `gh run list --json name`
+returns the *workflow* name — one row reading `CI` — while the contexts in the
+rollup above are **job** names like `test (ubuntu-latest)`. Matching a job name
+against a workflow name yields nothing, for every matrix job, and an empty result
+here reads as "no run at the base" — which lands in the third state below and
+marks every matrix failure underivable. Verified: on a repo whose five contexts
+are `Test (Python 3.11)` … `Lint & type-check`, `gh run list --json name` returns
+a single `CI`, and `check-runs` returns all five by their context names. Add
+`commits/$BASE_SHA/status` if the red context is a `StatusContext` rather than a
+`CheckRun` — the two live in separate lists, and Phase 6's GraphQL reads both.
+
+Then label the row, in three states and never two:
+
+| At the base | Label | What it means for the verdict |
+|---|---|---|
+| the same check is green | **attributable** | the bump is implicated; this row can carry a Hold |
+| the same check is red | **pre-existing** | the repo's default branch is red. A real finding, a *different* one, and it must not produce a Hold on this bump |
+| no run at the base | **underivable**, per Phase 0 | the base may predate the workflow, or the run may have aged out. Say so rather than defaulting to attributable |
+
+**A red check on a workflow the diff never touched is a strong prior for
+pre-existing**, and Phase 6 already derives which workflows the diff touched for
+the PR-reachability check above. Share that input rather than deriving it twice.
+
+Matching on name and conclusion establishes that the check was *already
+failing*, not that it is failing for the same reason. Where the distinction
+decides the verdict, read the failing step's log at both commits.
+
+Observed on `BIRSAx2/mdcat` #6: `test (ubuntu-latest)` red beside two green
+siblings, which reads exactly like a dependency bump breaking one platform. The
+failure was `unresolved link to pulldown-cmark-mdcat` — a rustdoc intra-doc-link
+error under `#[deny(warnings)]`, failing identically on the base commit and
+having nothing to do with the dependency. A Hold driven by that row would have
+been **correct by accident and unfalsifiable in the report**: every cell in it
+true, the causal claim never established. That is the same family as the
+rewritten base and the hand-joined required list — rows that are individually
+accurate and collectively misleading.
+
+It is also the direction that costs least to be wrong in, and therefore gets
+least scrutiny: a false Hold looks conservative, so nobody goes back to check
+whether the bump was the cause.
 
 `references/traps.md` has the reasoning, plus stale `CLEAN`, `UNSTABLE` being
 mergeable, neutral CodeQL, and why a bot rebase does not re-trigger CI.

--- a/skills/dependabot-audit/references/ecosystems.md
+++ b/skills/dependabot-audit/references/ecosystems.md
@@ -42,6 +42,14 @@ the removals exist to prevent, and it produces a green result rather than an
 error. Report what the ecosystem-independent phases established — Phase 0's
 classification, Phase 6's CI state — and name plainly what was not checked.
 
+`audit.py` enforces its half of that rather than leaving it to this file. Handed
+a `Cargo.lock`, `poetry.lock`, `package-lock.json`, `Pipfile.lock`, `go.sum`,
+`yarn.lock`, `pnpm-lock.yaml`, or a `pyproject.toml`, it exits 2 naming the
+format and pointing back here. Anything else with `[[package]]` blocks that are
+not uv-shaped is refused without a guess. Exit 2 was always the answer; before
+0.10.0 the message was `unexpected AttributeError ... This is a bug`, which sent
+the first reader to arrive with a Rust repo hunting for a defect in the script.
+
 ## Installing is executing
 
 A frozen install runs code the PR controls. This is not a footnote; it is the
@@ -170,6 +178,23 @@ older Python alongside the current one. The script handles this; if you verify b
 hand, do not assume one block per name. Do not report the *lower* block as stale
 — but do check the highest one, which carries markers just the same and is still
 expected to track the registry.
+
+**A fork is verified in full and installed in part**, and the two halves of the
+audit disagree about how much they covered:
+
+| Step | Scope |
+|---|---|
+| `audit.py` provenance | **every** fork's artifacts, against the registry |
+| `uv sync --locked` | asserts the whole lockfile is consistent with the manifest |
+| the install that follows | **one** resolution — the interpreter and platform present |
+
+So a green Phase 5 on 3.14 says nothing about whether the 3.11 fork's artifacts
+fetch or its older release installs. The script prints the pins for any forked
+package it selected; the report names the interpreter (`uv run python -V` from
+inside the synced environment, not the auditor's `python3`) and says which forks
+were verified without being installed. A second `uv sync --locked --python
+<floor>` is the thorough answer and is worth the interpreter download only when
+the un-installed fork belongs to a package under audit.
 
 **Auditor trap.** `pip-audit` audits the environment of the interpreter it runs
 under. Activating a virtualenv does **not** redirect a `pip-audit` installed

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -26,7 +26,7 @@ turns on.
 | **Vulnerabilities** | OSV result and the ecosystem auditor's, over N packages. | this run |
 | **Behavior change** | Added rules / changed defaults, whether config is opt-in or opt-out, and what running the tool actually showed. | this run *or* reused — head `<sha>` unchanged |
 | **Local reproduction** | Frozen install *in the form that ran*, the interpreter it ran under, any fork verified but not installed, each repo gate with its exit code, test count. | this run *or* reused — head `<sha>` unchanged, worktree verified |
-| **CI** | Run ID and conclusion against the full head SHA; required contexts; job count. | this run |
+| **CI** | Run ID and conclusion against the full head SHA; required contexts; job count. Every red check labelled **attributable**, **pre-existing**, or **underivable** against the base. | this run |
 
 An unmarked table asserts that everything in it was observed this run. If that is
 not true, the table is lying — see the reuse rules in Phase 7.
@@ -51,6 +51,13 @@ Where an install ran, name the form: `uv sync --locked --no-build
 too, and any fork the install did not materialise — `--locked` checks the whole
 lockfile, the install covers one resolution out of it, and the bare row asserts
 both.
+
+**A red check needs its attribution in the cell, not just its conclusion.**
+"Required check `test (ubuntu-latest)` FAILURE" is true and does not say whether
+this bump caused it; "FAILURE — **pre-existing**, red on the base commit too" is
+a different finding with a different verdict. A Hold that rests on an
+unattributed red row is correct only by accident, and the report gives the reader
+no way to tell which.
 
 ## Reasoning
 

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -25,7 +25,7 @@ turns on.
 | **Security** | Changelog `Security` sections across the gap — including their absence. | this run *or* reused — release notes immutable |
 | **Vulnerabilities** | OSV result and the ecosystem auditor's, over N packages. | this run |
 | **Behavior change** | Added rules / changed defaults, whether config is opt-in or opt-out, and what running the tool actually showed. | this run *or* reused — head `<sha>` unchanged |
-| **Local reproduction** | Frozen install, each repo gate with its exit code, test count. | this run *or* reused — head `<sha>` unchanged, worktree verified |
+| **Local reproduction** | Frozen install *in the form that ran*, the interpreter it ran under, any fork verified but not installed, each repo gate with its exit code, test count. | this run *or* reused — head `<sha>` unchanged, worktree verified |
 | **CI** | Run ID and conclusion against the full head SHA; required contexts; job count. | this run |
 
 An unmarked table asserts that everything in it was observed this run. If that is
@@ -47,7 +47,10 @@ and an apology.
 
 Where an install ran, name the form: `uv sync --locked --no-build
 --no-install-project` and a plain `uv sync --locked` prove different things, and
-"frozen install passed" is not the same claim in both.
+"frozen install passed" is not the same claim in both. Name the **interpreter**
+too, and any fork the install did not materialise — `--locked` checks the whole
+lockfile, the install covers one resolution out of it, and the bare row asserts
+both.
 
 ## Reasoning
 

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -21,10 +21,11 @@ alone is selected and said out loud rather than passing as "no changes".
 
 Exit status: 0 = nothing to report, 1 = at least one discrepancy, stale version,
 or known vulnerability, 2 = usage/lookup error — including a requested package
-that is not in the lockfile, an empty selection, an unreadable lockfile, and a
-registry that could not be reached. Never audit fewer packages than asked in
-silence, never print CLEAN on a run that verified nothing, and never let a failed
-lookup exit as though it were a finding.
+that is not in the lockfile, an empty selection, an unreadable lockfile, a
+lockfile belonging to an ecosystem this plugin does not cover, and a registry
+that could not be reached. Never audit fewer packages than asked in silence,
+never print CLEAN on a run that verified nothing, and never let a failed lookup
+exit as though it were a finding.
 Requires Python 3.11+ (tomllib) and network access.
 """
 
@@ -40,6 +41,7 @@ import tomllib
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Sequence
 from typing import Any, NoReturn
 
 # The Simple API's JSON form (PEP 691/700/714), not the legacy
@@ -403,12 +405,164 @@ def _version_key(version: str) -> tuple[Any, ...]:
     )
 
 
+class UnsupportedLockfile(ValueError):
+    """A file this script recognised, and does not audit.
+
+    A ValueError, so every handler that already catches a bad lockfile catches
+    this too — but raised separately, because exit 2 is the right answer for
+    both and the *reason* is not. "Cannot read this file" sends the reader
+    looking for corruption; "this is a Cargo.lock" sends them to the ecosystem
+    boundary, which is where they actually are.
+    """
+
+
+# Signatures for the lockfiles this plugin does **not** audit. Since 0.8.0 the
+# supported surface is `uv.lock` and GitHub Actions, so this message is the edge
+# of the tool and the first thing anyone arriving with a different lockfile
+# sees. Pointed at a real `Cargo.lock` it used to say `unexpected AttributeError
+# ... This is a bug, not a finding` — every part of that right except the
+# diagnosis, and it sent the reader hunting for a defect that does not exist.
+#
+# Listed: the three ecosystems whose recipes were removed in 0.8.0, Python's
+# other lockfiles, and the manifest that sits beside `uv.lock`. Each signature
+# was checked against a real file from a public repository. Anything not on the
+# list keeps the generic message — a wrong name is worse than no name.
+GO_SUM = re.compile(r"^\S+ v\S+ h1:[A-Za-z0-9+/=]+$", re.MULTILINE)
+# Yarn v1 writes a banner; Berry writes a `__metadata:` block instead.
+YARN_LOCK = re.compile(r"^# yarn lockfile v1$|^__metadata:$", re.MULTILINE)
+PNPM_LOCK = re.compile(r"^lockfileVersion: ", re.MULTILINE)
+
+
+def _boundary(path: str, what: str) -> str:
+    return (
+        f"{path} is {what}.\n"
+        "       This plugin audits uv.lock and GitHub Actions, and nothing else.\n"
+        "       npm, Cargo and Go recipes were removed rather than left as sketches:\n"
+        "       an unverified verifier reports green instead of erroring. Report what\n"
+        "       the ecosystem-independent phases established and say what was not\n"
+        "       checked — see references/ecosystems.md."
+    )
+
+
+def _sniff_text(raw: str) -> str | None:
+    """Formats identified from the bytes, before anything tries to parse them.
+
+    Most of these reach `tomllib` and die on a syntax error, which names a
+    column rather than a format — true and useless. Yarn v1 is the one that does
+    not: its two-line header is valid TOML, so a sniff that only ran after a
+    parse failure never saw it.
+    """
+    if GO_SUM.search(raw):
+        return "a go.sum (Go)"
+    if YARN_LOCK.search(raw):
+        return "a yarn.lock (JavaScript, Yarn)"
+    if PNPM_LOCK.search(raw):
+        return "a pnpm-lock.yaml (JavaScript, pnpm)"
+    return None
+
+
+def _sniff_json(raw: str) -> str | None:
+    try:
+        data = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    if "lockfileVersion" in data:
+        return "a package-lock.json (JavaScript, npm)"
+    meta = data.get("_meta")
+    if isinstance(meta, dict) and "pipfile-spec" in meta:
+        return "a Pipfile.lock (Python, Pipenv)"
+    return None
+
+
+def _sniff_toml(data: dict[str, Any], packages: list[Any]) -> str | None:
+    """TOML that parses cleanly and is not a uv.lock.
+
+    `Cargo.lock` is the dangerous one: it is TOML, it has `[[package]]` blocks,
+    and its `source` is a **string** where uv writes a table — so it got all the
+    way to `_is_pypi` before failing with an `AttributeError`.
+
+    **Every signature here must be one a uv.lock cannot produce**, because this
+    runs before the positive identification below and a misfire refuses a
+    lockfile the plugin does support. Checked against a real uv.lock: top-level
+    keys are `package`, `requires-python`, `resolution-markers`, `revision`,
+    `version` — no `metadata` — and no `[[package]]` block carries `checksum`,
+    `python-versions`, `files`, or a `source` that is not a table.
+
+    The first draft ordered these the other way, on the theory that identifying
+    uv first was the safe direction. It was not: poetry writes a `[package.source]`
+    table too, so a real `poetry.lock` read as uv-shaped and fell through to the
+    message claiming it was being compared against itself.
+    """
+    entries = [p for p in packages if isinstance(p, dict)]
+    if any("checksum" in p or isinstance(p.get("source"), str) for p in entries):
+        return "a Cargo.lock (Rust)"
+    metadata = data.get("metadata")
+    if (isinstance(metadata, dict) and "lock-version" in metadata) or any(
+        "python-versions" in p and "files" in p for p in entries
+    ):
+        return "a poetry.lock (Python, Poetry)"
+    if not entries and ("build-system" in data or "project" in data):
+        return "a pyproject.toml — a manifest, not a lockfile (the lockfile is uv.lock)"
+    return None
+
+
+def _looks_like_uv(packages: list[Any]) -> bool:
+    """Whether these `[[package]]` blocks are uv's.
+
+    Deliberately broad — it runs after every foreign signature has already been
+    ruled out, so its job is to admit anything uv might write rather than to
+    discriminate. uv puts a `source` table on every block; `sdist` and `wheels`
+    are its artifact keys.
+    """
+    return any(
+        isinstance(p, dict) and (isinstance(p.get("source"), dict) or "sdist" in p or "wheels" in p)
+        for p in packages
+    )
+
+
 def load_lock(path: str) -> list[dict[str, Any]]:
+    """The `[[package]]` blocks of a uv.lock — or a refusal that names the file.
+
+    Raises `UnsupportedLockfile` for a format this script recognises and does not
+    audit, and plain `ValueError`/`TOMLDecodeError` for one it cannot read at
+    all. Both exit 2 through `main`; only the message differs.
+    """
     with open(path, "rb") as fh:
-        data = tomllib.load(fh)
-    if "package" not in data:
+        # Decoded here rather than handing the handle to `tomllib` so the same
+        # bytes can be sniffed. `errors="replace"` turns invalid UTF-8 into a
+        # TOML syntax error, which is caught, instead of a UnicodeDecodeError,
+        # which is not — and would print "this is a bug".
+        raw = fh.read().decode("utf-8", errors="replace")
+
+    # Sniff before parsing, not only after a parse failure. A yarn v1 lockfile
+    # opens with two comment lines, which is *valid TOML*, so an
+    # only-on-TOMLDecodeError sniff never looked at it. Every signature here is
+    # one a uv.lock cannot produce, which is what makes running them first safe.
+    found = _sniff_text(raw) or _sniff_json(raw)
+    if found:
+        raise UnsupportedLockfile(_boundary(path, found))
+
+    # A TOMLDecodeError from here is a real parse error on a file nothing
+    # recognised, and its line and column are the useful part. Let it out.
+    data = tomllib.loads(raw)
+
+    packages = data["package"] if isinstance(data.get("package"), list) else None
+    found = _sniff_toml(data, packages or [])
+    if found:
+        raise UnsupportedLockfile(_boundary(path, found))
+    if packages and _looks_like_uv(packages):
+        return [p for p in packages if isinstance(p, dict)]
+    if packages is None:
         raise ValueError("no [[package]] entries — is this a lockfile?")
-    return list(data["package"])
+    raise UnsupportedLockfile(
+        _boundary(
+            path,
+            "not a uv.lock: it has [[package]] entries, but none of them carries a\n"
+            "       `source` table, an `sdist` or a `wheels` list",
+        )
+    )
 
 
 def _is_pypi(pkg: dict[str, Any]) -> bool:
@@ -524,15 +678,18 @@ def _is_prerelease(version: str) -> bool:
     return parsed["pre"] is not None or parsed["dev"] is not None
 
 
-def fork_context(entry: dict[str, Any], pins: dict[str, list[str]]) -> tuple[int, bool]:
-    """How often this package is pinned in the lock, and whether this is the highest.
+def fork_context(entry: dict[str, Any], pins: dict[str, list[str]]) -> tuple[list[str], bool]:
+    """Every version this package is pinned at, and whether this entry is the highest.
 
     uv forks a package into several `[[package]]` blocks when different parts of
     the resolution need different versions.
+
+    Returns the versions rather than a count, because the count alone cannot be
+    reported: a frozen install materialises one fork, and naming which requires
+    naming the others.
     """
-    versions = pins.get(_normalize(entry["name"])) or [entry["version"]]
-    highest = max(_version_key(v) for v in versions)
-    return len(versions), _version_key(entry["version"]) >= highest
+    versions = sorted(pins.get(_normalize(entry["name"])) or [entry["version"]], key=_version_key)
+    return versions, _version_key(entry["version"]) >= _version_key(versions[-1])
 
 
 def latest_version(project: dict[str, Any], releases: dict[str, list[dict[str, Any]]]) -> str:
@@ -574,15 +731,18 @@ def check_currency(
     entry: dict[str, Any],
     project: dict[str, Any],
     *,
-    pins: int = 1,
+    pinned: Sequence[str] = (),
     newest: bool = True,
 ) -> dict[str, Any]:
     """Report the registry's true latest version alongside the locked one.
 
-    `pins` and `newest` place the entry among the lockfile's pins of the same
-    package, which is what decides whether `resolution-markers` excuse a gap.
+    `pinned` is every version of this package the lockfile carries and `newest`
+    whether this entry is the highest of them. Together they place the entry
+    among its siblings, which is what decides whether `resolution-markers`
+    excuse a gap — and what lets the report say which fork an install exercised.
     """
     name, locked = entry["name"], entry["version"]
+    siblings = list(pinned) or [locked]
     releases = files_by_version(project)
     latest = latest_version(project, releases)
 
@@ -612,7 +772,11 @@ def check_currency(
         "latest": latest,
         "current": _version_key(locked) == _version_key(latest),
         "constrained": constrained,
-        "pins": pins,
+        "pins": len(siblings),
+        # The sibling versions themselves, not just how many. Phase 5 installs
+        # one fork and Phase 1 verified all of them; a report that cannot name
+        # the others cannot state the difference.
+        "pinned": siblings,
         # uv stamps resolution-markers on *every* block of a forked package, so
         # the markers alone cannot say which pin is expected to trail. A lower
         # fork is held back by design; the highest is the live pin, and its
@@ -747,6 +911,24 @@ def render(report: dict[str, Any]) -> None:
             print(f"      {rel['version']:12s} published {rel['published']}{mark}")
         print("      earliest first; compare it against the PR's createdAt\n")
 
+    # A forked package is checked in full and installed in part, and nothing in
+    # the output said so. Phase 1 verifies every fork's artifacts against the
+    # registry; a frozen install materialises one resolution. A green Phase 5
+    # then reads as though it covered all of them, which is a claim the run
+    # never made. Mechanised here rather than left to the prose, because a
+    # disclosure the report is merely asked to remember is one it can omit.
+    forked = {c["name"]: c["pinned"] for c in report["currency"] if c["pins"] > 1}
+    if forked:
+        print("=== forked packages: every pin verified, one of them installed")
+        for name, versions in forked.items():
+            print(f"      {name:24s} {len(versions)} pins: {', '.join(versions)}")
+        print("      uv splits a package across blocks under different resolution-markers.")
+        print("      The provenance rows above cover all of them; a frozen install")
+        print("      materialises only the resolution matching the interpreter and")
+        print("      platform present — which need not be the highest pin. Name the one")
+        print("      Phase 5 exercised (`uv run python -V` inside the synced environment)")
+        print("      rather than reporting the install as though it covered every fork.\n")
+
     for att in report.get("attestations", []):
         if not att["artifacts"]:
             continue
@@ -822,6 +1004,11 @@ def main() -> int:
 
     try:
         locked = load_lock(args.lock)
+    except UnsupportedLockfile as exc:
+        # Already names the file and what it is. Prefixing "cannot read" here
+        # would say the file is unreadable when it reads fine and is simply not
+        # this plugin's to audit.
+        fail(str(exc))
     except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
         fail(f"cannot read {args.lock}: {exc}")
 
@@ -832,6 +1019,8 @@ def main() -> int:
     if args.changed_vs:
         try:
             selection = derive_changed(packages, args.changed_vs)
+        except UnsupportedLockfile as exc:
+            fail(str(exc))
         except (OSError, tomllib.TOMLDecodeError, ValueError) as exc:
             fail(f"cannot read baseline {args.changed_vs}: {exc}")
         changed = [c["name"] for c in selection]
@@ -917,9 +1106,9 @@ def main() -> int:
                 fail(f"PyPI lookup failed for {entry['name']}: {exc}")
         project = project_cache[key]
         try:
-            n_pins, newest = fork_context(entry, pins)
+            pinned, newest = fork_context(entry, pins)
             report["provenance"].append(check_provenance(entry, project))
-            report["currency"].append(check_currency(entry, project, pins=n_pins, newest=newest))
+            report["currency"].append(check_currency(entry, project, pinned=pinned, newest=newest))
             report["attestations"].append(
                 check_attestations(
                     entry,

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import unittest
 import urllib.error
+from typing import ClassVar
 from unittest import mock
 
 sys.path.insert(
@@ -407,7 +408,7 @@ class TestCurrency(unittest.TestCase):
     def test_held_back_fork_is_not_reported_as_stale(self):
         """The lower fork of a split package trails the registry by design."""
         pkg = entry("rpds-py", "0.30.0", markers=["python_full_version < '3.11'"])
-        result = check_currency(pkg, self._split(), pins=2, newest=False)
+        result = check_currency(pkg, self._split(), pinned=["0.30.0", "2020.1.1"], newest=False)
         self.assertFalse(result["current"])
         self.assertTrue(result["held_back"], "must not read as a staleness finding")
 
@@ -419,7 +420,7 @@ class TestCurrency(unittest.TestCase):
         pin a follow-up bump could ever move.
         """
         pkg = entry("rpds-py", "2020.1.1", markers=["python_full_version >= '3.11'"])
-        result = check_currency(pkg, self._split(), pins=2, newest=True)
+        result = check_currency(pkg, self._split(), pinned=["0.30.0", "2020.1.1"], newest=True)
         self.assertTrue(result["constrained"])
         self.assertFalse(result["held_back"], "markers must not excuse the live pin")
         self.assertEqual([r["version"] for r in result["gap"]], ["2026.6.3"])
@@ -767,19 +768,30 @@ class TestAttestations(unittest.TestCase):
 
 
 FORK_PINS = {"rpds-py": ["0.30.0", "2026.6.3"], "rumdl": ["0.2.53"]}
+SPLIT = FORK_PINS["rpds-py"]
 
 
 class TestForkContext(unittest.TestCase):
-    """Which pin of a forked package is the live one."""
+    """Which pin of a forked package is the live one, and what the others are."""
 
     def test_highest_pin_of_a_fork_is_the_newest(self):
-        self.assertEqual(fork_context(entry("rpds-py", "2026.6.3"), FORK_PINS), (2, True))
+        self.assertEqual(fork_context(entry("rpds-py", "2026.6.3"), FORK_PINS), (SPLIT, True))
 
     def test_lower_pin_of_a_fork_is_not(self):
-        self.assertEqual(fork_context(entry("rpds-py", "0.30.0"), FORK_PINS), (2, False))
+        self.assertEqual(fork_context(entry("rpds-py", "0.30.0"), FORK_PINS), (SPLIT, False))
 
     def test_a_lone_pin_is_its_own_newest(self):
-        self.assertEqual(fork_context(entry("rumdl", "0.2.53"), FORK_PINS), (1, True))
+        self.assertEqual(fork_context(entry("rumdl", "0.2.53"), FORK_PINS), (["0.2.53"], True))
+
+    def test_siblings_come_back_in_version_order_not_lockfile_order(self):
+        """The report prints these, so the order is part of the output.
+
+        A lockfile's blocks are not sorted by version, and reading a fork list
+        that runs backwards invites the reader to take the first entry as the
+        live pin when it is the held-back one.
+        """
+        pins = {"rpds-py": ["2026.6.3", "0.30.0"]}
+        self.assertEqual(fork_context(entry("rpds-py", "0.30.0"), pins)[0], SPLIT)
 
 
 class _MainHarness(unittest.TestCase):
@@ -1008,6 +1020,260 @@ wheels = [
         )
         self.assertEqual(code, 0)
         self.assertIn("CLEAN", out)
+
+
+class TestEcosystemBoundary(_MainHarness):
+    """Handed another ecosystem's lockfile, the script used to blame itself.
+
+    Observed on `BIRSAx2/mdcat`, a Rust repo:
+
+        error: unexpected AttributeError: 'str' object has no attribute 'get'
+               This is a bug, not a finding.
+
+    Everything about that was right except the diagnosis. Exit 2 is correct and
+    no false CLEAN was printed — the failure-versus-finding contract held against
+    an input it was never designed to see. But `Cargo.lock` writes `source` as a
+    string where uv writes a table, so the run reached `_is_pypi` and died, and
+    the message sent the reader hunting for a defect that does not exist.
+
+    Since 0.8.0 the supported surface is `uv.lock` and GitHub Actions, so this
+    message is the *boundary of the tool* and the first thing anyone arriving
+    with a different lockfile sees. Phase 1 leads with the script, so arriving
+    there innocently is the common path, not the careless one.
+
+    `poetry.lock` was worse than the Rust case and is the reason this class
+    covers more than the three formats the issue named. It parses, yields zero
+    PyPI-sourced packages, and exits 2 saying *"either this lockfile did not
+    change, or it is being compared against itself"* — a confident false
+    diagnosis, in this plugin's own vocabulary, on Python's other lockfile.
+    """
+
+    # Fixtures are the smallest excerpt that carries the real signature; each
+    # was checked against a full file from a public repository.
+    FOREIGN: ClassVar[dict[str, tuple[str, str]]] = {
+        "Cargo.lock": (
+            'version = 4\n\n[[package]]\nname = "adler2"\nversion = "2.0.0"\n'
+            'source = "registry+https://github.com/rust-lang/crates.io-index"\n'
+            'checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"\n',
+            "Cargo.lock",
+        ),
+        "poetry.lock": (
+            '[[package]]\nname = "anyio"\nversion = "4.14.2"\noptional = false\n'
+            'python-versions = ">=3.10"\nfiles = [\n    {file = "anyio-4.14.2.tar.gz", '
+            'hash = "sha256:cfa1"},\n]\n\n[metadata]\nlock-version = "2.1"\n',
+            "poetry.lock",
+        ),
+        "package-lock.json": (
+            '{\n  "name": "npm",\n  "lockfileVersion": 3,\n  "packages": {}\n}\n',
+            "package-lock.json",
+        ),
+        "go.sum": (
+            "cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=\n"
+            "cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7b=\n",
+            "go.sum",
+        ),
+        "Pipfile.lock": (
+            '{\n  "_meta": {"pipfile-spec": 6, "hash": {"sha256": "43"}},\n  "default": {}\n}\n',
+            "Pipfile.lock",
+        ),
+        # The header alone is two comment lines, which is *valid TOML* — the
+        # case that proved the sniff has to run before the parse, not after it
+        # fails. The entry below is what a real file carries and is not.
+        "yarn.lock": (
+            "# THIS IS AN AUTOGENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY.\n"
+            "# yarn lockfile v1\n\n"
+            '"@babel/core@^7.0.0":\n  version "7.26.10"\n',
+            "yarn.lock",
+        ),
+        "pnpm-lock.yaml": (
+            "lockfileVersion: '9.0'\n\nsettings:\n  autoInstallPeers: true\n",
+            "pnpm",
+        ),
+        "pyproject.toml": (
+            '[build-system]\nrequires = ["hatchling"]\n\n[project]\nname = "x"\n',
+            "manifest, not a lockfile",
+        ),
+    }
+
+    def _file(self, name: str, body: str) -> str:
+        directory = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, directory, ignore_errors=True)
+        path = pathlib.Path(directory) / name
+        path.write_text(body, encoding="utf-8")
+        return str(path)
+
+    def test_each_foreign_lockfile_is_named_rather_than_blamed_on_the_script(self):
+        for name, (body, expected) in self.FOREIGN.items():
+            with self.subTest(name):
+                code, out, err = self._run([self._file(name, body), "--changed", "p"])
+                self.assertEqual(code, 2, "the exit code was never what needed changing")
+                self.assertIn(expected, err, f"{name} is not named in the message")
+                self.assertNotIn(
+                    "This is a bug",
+                    err,
+                    "reserved for genuinely unexpected exceptions; spending it here is "
+                    "what makes it worthless when it does appear",
+                )
+                self.assertIn("references/ecosystems.md", err, "no route out of the boundary")
+                self.assertNotIn("CLEAN", out)
+
+    def test_a_cargo_lock_no_longer_reaches_the_code_that_crashed_on_it(self):
+        """The specific defect: `source` is a string, `_is_pypi` calls `.get` on it."""
+        body, _ = self.FOREIGN["Cargo.lock"]
+        code, _, err = self._run(
+            [self._file("Cargo.lock", body), "--changed", "p"], entry_point=cli
+        )
+        self.assertEqual(code, 2)
+        self.assertNotIn("AttributeError", err)
+
+    def test_a_poetry_lock_is_not_reported_as_compared_against_itself(self):
+        """It parsed, matched nothing, and diagnosed the *invocation* instead.
+
+        The worst of the set: no crash, no traceback, and a message that reads
+        as a mistake the caller made rather than the boundary they hit.
+        """
+        body, _ = self.FOREIGN["poetry.lock"]
+        path = self._file("poetry.lock", body)
+        code, _, err = self._run([path, "--changed-vs", path])
+        self.assertEqual(code, 2)
+        self.assertIn("poetry.lock", err)
+        self.assertNotIn("compared against itself", err)
+
+    def test_a_foreign_baseline_is_named_too(self):
+        """`--changed-vs` reads a second lockfile, through the same door."""
+        body, _ = self.FOREIGN["Cargo.lock"]
+        code, _, err = self._run(
+            [write_lock(self, self.LOCK), "--changed-vs", self._file("Cargo.lock", body)]
+        )
+        self.assertEqual(code, 2)
+        self.assertIn("Cargo.lock", err)
+        self.assertNotIn("cannot read baseline", err, "it reads fine; it is not ours to audit")
+
+    def test_toml_with_packages_that_are_not_uv_shaped_is_refused_not_crashed(self):
+        """The formats above are the ones worth naming, not the whole world.
+
+        Anything else with `[[package]]` blocks still must not be walked into:
+        proceeding means `pypi_sourced` returns nothing and the run reports on an
+        empty selection. Refusing without a name is honest; guessing one is not.
+        """
+        unknown = 'version = 1\n\n[[package]]\nname = "x"\nversion = "1"\ndeps = ["y"]\n'
+        code, _, err = self._run([self._file("mystery.lock", unknown), "--changed", "x"])
+        self.assertEqual(code, 2)
+        self.assertIn("not a uv.lock", err)
+        self.assertNotIn("This is a bug", err)
+
+    def test_a_real_uv_lock_still_loads(self):
+        """The direction that would be worse than the defect being fixed.
+
+        A sniffer that misfires refuses a lockfile the plugin does support. The
+        first draft ordered the checks the other way — identify uv first, then
+        diagnose — and a real `poetry.lock` passed it, because poetry writes a
+        `[package.source]` table too.
+        """
+        packages = load_lock(write_lock(self, self.LOCK))
+        self.assertEqual([p["name"] for p in packages], ["rumdl", "fpga-simulator"])
+
+    def test_a_uv_lock_of_only_git_and_editable_sources_still_loads(self):
+        """No registry, no wheels — the shape most likely to look foreign."""
+        vcs = """
+[[package]]
+name = "x"
+version = "1.0"
+source = { git = "https://example.invalid/x.git" }
+
+[[package]]
+name = "y"
+version = "0.1"
+source = { editable = "." }
+"""
+        self.assertEqual([p["name"] for p in load_lock(write_lock(self, vcs))], ["x", "y"])
+
+
+class TestForkDisclosure(_MainHarness):
+    """A forked package is verified in full and installed in part.
+
+    `uv sync --locked` asserts the whole lockfile is consistent with the
+    manifest, across every fork. The install then materialises only the
+    resolution for the interpreter that happens to be present. Phase 1 verifies
+    every fork's artifacts against the registry, so a green Phase 5 on 3.14 says
+    nothing about whether the 3.11 fork's artifacts install — and nothing in the
+    output distinguished the two.
+
+    Mechanised here rather than left to `SKILL.md`, per the rule in
+    CONTRIBUTING: prose is the weakest of the three levers, and a disclosure the
+    report is merely asked to remember is one it can omit silently.
+    """
+
+    FORKED = f"""
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = {{ registry = "https://pypi.org/simple" }}
+resolution-markers = ["python_full_version < '3.11'"]
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/p-0.30.0.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = {{ registry = "https://pypi.org/simple" }}
+resolution-markers = ["python_full_version >= '3.11'"]
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/p-2026.6.3.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+"""
+
+    def _forked_meta(self):
+        return pypi_meta(
+            "2026.6.3",
+            [],
+            releases={
+                "0.30.0": [pypi_file("p-0.30.0.whl")],
+                "2026.6.3": [pypi_file("p-2026.6.3.whl")],
+            },
+        )
+
+    def test_the_report_names_every_pin_of_a_forked_package(self):
+        code, out, _ = self._run(
+            [write_lock(self, self.FORKED), "--changed", "rpds-py"], meta=self._forked_meta()
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("forked packages", out)
+        self.assertIn("0.30.0, 2026.6.3", out, "both pins, in version order")
+
+    def test_the_disclosure_says_the_install_covers_one_of_them(self):
+        """Counting the pins is not the point; the asymmetry is.
+
+        "2 pins" alongside a green install still reads as two installs. The row
+        has to say that the provenance checks covered every fork and the install
+        covered one.
+        """
+        _, out, _ = self._run(
+            [write_lock(self, self.FORKED), "--changed", "rpds-py"], meta=self._forked_meta()
+        )
+        self.assertIn("one of them installed", out)
+        self.assertIn("uv run python -V", out, "the interpreter is the thing to record")
+
+    def test_an_unforked_lockfile_says_nothing_about_forks(self):
+        """The row would be noise on most lockfiles, and noise trains the reader
+        to skip the section it appears in."""
+        code, out, _ = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"], meta=self._meta()
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("forked packages", out)
+
+    def test_the_pins_survive_into_json_mode(self):
+        """The machine-readable half has to carry it too, or a caller reading
+        JSON gets the pre-fix output back."""
+        _, out, _ = self._run(
+            [write_lock(self, self.FORKED), "--changed", "rpds-py", "--json"],
+            meta=self._forked_meta(),
+        )
+        currency = json.loads(out)["currency"]
+        self.assertEqual([c["pinned"] for c in currency], [["0.30.0", "2026.6.3"]] * 2)
+        self.assertEqual({c["pins"] for c in currency}, {2})
 
 
 class TestOsvBatching(_MainHarness):

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -313,6 +313,73 @@ class TestEveryPhaseCarriesBothEcosystems(SkillHarness):
         )
 
 
+class TestARedCheckIsAttributedBeforeItCarriesTheVerdict(SkillHarness):
+    """Phase 6 reported conclusions and never asked whether the bump caused them.
+
+    Observed on `BIRSAx2/mdcat` #6: `test (ubuntu-latest)` red beside two green
+    siblings, which reads as a bump breaking one platform. It was a rustdoc
+    intra-doc-link error under `#[deny(warnings)]`, failing identically on the
+    base. A Hold driven by that row would have been correct by accident and
+    unfalsifiable — every cell true, the causal claim never established.
+
+    The same family as the rewritten base and the hand-joined required list: a
+    row that is individually accurate and collectively misleading. It is also the
+    direction that costs least to be wrong in, so it draws the least scrutiny — a
+    false Hold looks conservative.
+    """
+
+    def test_phase_6_consumes_the_base_sha(self):
+        self.assertIn(
+            "$BASE_SHA",
+            self.shell[6],
+            "Phase 6 must establish whether a red check is red at the base; without "
+            "the base commit it can only report the conclusion",
+        )
+
+    def test_the_base_query_reads_check_runs_not_the_workflow_list(self):
+        """`gh run list --json name` answers a different question.
+
+        It returns the *workflow* name — one row reading `CI` — while the rollup
+        contexts Phase 6 reads are job names like `test (ubuntu-latest)`. Matching
+        one against the other yields nothing for every matrix job, and an empty
+        result reads as "no run at the base", which marks it underivable. So the
+        obvious query fails in precisely the direction this section exists to
+        correct. Measured on a repo whose five contexts are `Test (Python 3.11)`
+        through `Lint & type-check`: `gh run list --json name` returns a single
+        `CI`; `commits/<sha>/check-runs` returns all five by context name.
+        """
+        self.assertIn(
+            "check-runs",
+            self.shell[6],
+            "the base conclusions must come from the endpoint keyed by check name",
+        )
+        self.assertNotRegex(
+            self.shell[6],
+            r"gh run list[^\n]*\$BASE_SHA",
+            "gh run list reports workflow names, so a per-check match against it is "
+            "empty for every matrix job",
+        )
+
+    def test_a_base_with_no_run_is_underivable_rather_than_attributable(self):
+        """Phase 0's third state, in the phase most able to lose it.
+
+        The base may predate the workflow, or its run may have aged out. Both are
+        "could not check", and collapsing them into "not pre-existing" hands the
+        red row back to the bump by default.
+
+        Asserted on the phrase rather than on "underivable" alone: that word was
+        already in Phase 6 for `mergeStateStatus: UNKNOWN`, so the looser check
+        passed against the prose that had this defect.
+        """
+        phase6 = dict(self.phases)[6].lower()
+        self.assertIn(
+            "no run at the base",
+            phase6,
+            "Phase 6 must name the case where the base has no run to compare against",
+        )
+        self.assertIn("underivable", phase6, "and give it Phase 0's third state")
+
+
 class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
     """`--locked` checks every fork; the install materialises one of them.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -313,6 +313,60 @@ class TestEveryPhaseCarriesBothEcosystems(SkillHarness):
         )
 
 
+class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
+    """`--locked` checks every fork; the install materialises one of them.
+
+    `uv sync --locked` asserts the whole lockfile is consistent with the
+    manifest, across every `resolution-markers` fork, and Phase 1 verifies every
+    fork's artifacts against the registry. The install then covers only the
+    resolution matching the interpreter present — so a green row on 3.14 says
+    nothing about whether the 3.11 fork's artifacts fetch or install, and nothing
+    in the report distinguished the two.
+
+    Phase 5 already insists the row name *which install* ran. The same rule was
+    not applied to the interpreter, where it matters more.
+    """
+
+    def test_the_interpreter_is_read_from_the_synced_environment(self):
+        """The auditor's own `python3` need not be the one uv chose."""
+        self.assertIn(
+            "uv run python -V",
+            self.shell[5],
+            "Phase 5 must record the interpreter that produced the row, from inside "
+            "the environment rather than from the shell that ran the audit",
+        )
+
+    def test_the_forks_that_were_only_verified_are_named(self):
+        phase5 = dict(self.phases)[5].lower()
+        self.assertIn(
+            "resolution-markers",
+            phase5,
+            "Phase 5 must say that a lockfile can fork, or the single install reads "
+            "as covering every pin",
+        )
+        self.assertIn(
+            "only verified",
+            phase5,
+            "the asymmetry is the finding: every fork verified, one installed. "
+            "Naming the mechanism without it still leaves the row overstating",
+        )
+
+    def test_the_quoted_script_output_is_what_the_script_prints(self):
+        """The prose points the reader at a line `audit.py` emits.
+
+        A cross-artifact check, in the same family as "every path the prose names
+        must exist": reword the script and the quotation goes stale, sending the
+        reader to look for a line that is no longer there.
+        """
+        quoted = "forked packages: every pin verified, one of them installed"
+        self.assertIn(quoted.split(":")[0], dict(self.phases)[5])
+        self.assertIn(
+            quoted,
+            (PLUGIN / "scripts/audit.py").read_text(encoding="utf-8"),
+            "SKILL.md quotes a line audit.py no longer prints",
+        )
+
+
 class TestPhase4MeasuresTheRightTree(SkillHarness):
     """Measuring on the PR's tree hides the finding whenever it is real.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -328,12 +328,25 @@ class TestARedCheckIsAttributedBeforeItCarriesTheVerdict(SkillHarness):
     false Hold looks conservative.
     """
 
-    def test_phase_6_consumes_the_base_sha(self):
-        self.assertIn(
-            "$BASE_SHA",
+    def test_the_comparison_point_is_the_commit_the_bot_branched_from(self):
+        """`$BASE_SHA` is the wrong input, and the live run is what proved it.
+
+        The first version of this asserted Phase 6 read `$BASE_SHA`. Run against
+        the PR the finding came from, that is wrong in the direction the whole
+        section exists to prevent. `mdcat` #6 carries a *human* commit under the
+        bot's, so its four candidate comparison points disagree: the bot's parent
+        is `failure` (pre-existing, the answer), the merge base has no such check
+        at all, and the base branch's tip is `success` — which would have
+        produced the false Hold.
+
+        `pr-<N>^` is `$BASE_SHA` for a genuine one-commit bot PR, so this costs
+        nothing in the ordinary case and is right in the case that is not.
+        """
+        self.assertRegex(
             self.shell[6],
-            "Phase 6 must establish whether a red check is red at the base; without "
-            "the base commit it can only report the conclusion",
+            r"pr-<N>\^",
+            "Phase 6 must attribute a red check against the bot's own parent; the "
+            "merge base attributes to the bump whatever happened beneath it",
         )
 
     def test_the_base_query_reads_check_runs_not_the_workflow_list(self):


### PR DESCRIPTION
Closes #24, #23, #25 — the last three findings from the `BIRSAx2/mdcat` run. All
three are the same shape: a row that is accurate and asserts more than it
established.

## #24 — `audit.py` blamed itself for a bug

Pointed at a `Cargo.lock` it printed `unexpected AttributeError: 'str' object has
no attribute 'get'` / `This is a bug, not a finding`. Everything right except the
diagnosis: exit 2 was correct, no false `CLEAN` was printed, and the
failure-versus-finding contract held. Cargo just writes `source` as a string
where uv writes a table, so the run reached `_is_pypi` and died.

`load_lock` now sniffs before parsing and names what it found. Exit stays 2 —
that was never what needed changing — and `This is a bug` is left for exceptions
that are one.

Two things widened this past the three formats the issue named:

- **`poetry.lock` was worse than the Rust case.** It parses, yields zero
  PyPI-sourced packages, and exits 2 saying *"either this lockfile did not
  change, or it is being compared against itself"* — a confident false diagnosis,
  in this plugin's own vocabulary, on Python's other lockfile.
- Two ordering traps, both found by running real files. Identifying uv *first* is
  the apparently safe order and lets `poetry.lock` through, because poetry writes
  a `[package.source]` table too; the invariant that works is that every foreign
  signature must be one a `uv.lock` **cannot** produce. And sniffing only after a
  `TOMLDecodeError` never sees a yarn v1 lockfile, whose header is valid TOML.

Verified against real files from swsnr/mdcat, cli/cli, python-poetry/poetry,
npm/cli, pypa/pipenv, vercel/next.js, facebook/react and yarnpkg/berry — plus
astral-sh/uv's own 292KB `uv.lock`, which still audits end-to-end against live
PyPI.

## #23 — Phase 5 verified every fork and installed one

`uv sync --locked` checks the whole lockfile; the install materialises one
resolution out of it, which need not be the highest pin. A green row on 3.14 said
nothing about the 3.11 fork.

Mechanised in `audit.py` rather than left to prose, per CONTRIBUTING's lever
rule. On `pydantic/pydantic`'s real lockfile:

```
=== forked packages: every pin verified, one of them installed
      numpy                    2 pins: 2.2.6, 2.3.4
      rpds-py                  2 pins: 0.30.0, 2026.6.3
```

Phase 5 now requires the interpreter (`uv run python -V`, from inside the synced
environment) and names a second `uv sync --python <floor>` as a deliberate
escalation rather than the default — the issue's own lean.

## #25 — a red check attributed to the bump without checking the base

Three states now: **attributable**, **pre-existing**, **underivable**.

**The query the issue proposed does not work.** `gh run list --json name` returns
the *workflow* name (one row, `CI`) while the rollup contexts are job names like
`test (ubuntu-latest)`. It matches nothing for any matrix job, and empty reads as
"no run at the base" — so the fix as specified would have marked every matrix
failure underivable, failing in the direction it exists to correct. Phase 6 uses
`commits/<sha>/check-runs`.

**And the first version of the fix in this PR was also wrong**, caught by
replaying `mdcat` #6 against it. That branch carries a human commit under the
bot's, so the candidate comparison points disagree:

| Commit | `test (ubuntu-latest)` |
|---|---|
| PR head — the bot's commit | `failure` |
| `pr-6^` — the human commit below it | `failure` — pre-existing, and the answer |
| `git merge-base main pr-6` | the check does not exist there at all |
| the base branch's tip | `success` — which would say **attributable** |

Two of four produce the false Hold, and one of them is the merge base. Phase 6
compares against `pr-<N>^`, which *is* `$BASE_SHA` for a genuine one-commit bot
PR — so it costs nothing in the ordinary case and is right where they differ, the
same substitution #19 established for Phase 1's scope diff.

The replay also surfaced a second cause of "underivable": check names drift.
`mdcat`'s `main` now reports `test` and `test-windows` where the PR reports
`test (ubuntu-latest)`.

## Worth noting

**The prose suite passed against the wrong Phase 6 prose.** It was
self-consistent and simply false about the world. `tests/test_skill_prose.py`
catches drift, not wrongness — only the live replay caught this, which is the
fourth time that has been true.

## Verification

- 136 tests, green on 3.11 / 3.12 / 3.13 / 3.14
- ruff 0.16.2 check + format, mypy 2.3.0 strict — the pinned versions
- Every new test was run against the pre-change code and fails there. The Cargo
  case reproduces the exact `AttributeError` text; the poetry case reproduces
  "compared against itself". The two that do not discriminate are guards against
  noise and are marked as such.

The 0.10.0 tag belongs on `HEAD`, not on the `docs: release` commit — the Phase 6
correction landed after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)