### PR TITLE
docs: the Upgrade-to-Pro 403 is returned even at admin: true

### DIFF
--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -226,7 +226,7 @@ Four states, not three, and only the first is your own mistake:
 | `404 Branch not found` | wrong branch name — fix and re-run |
 | `404 Branch not protected` | correct branch, no protection configured |
 | **`404 Not Found`** (bare) | **you lack `admin`** — protection may exist and be invisible to you |
-| `403 Upgrade to GitHub Pro…` | protection unavailable on this plan (a private repo on a free plan) |
+| `403 Upgrade to GitHub Pro…` | protection unavailable on this **plan**, not a permission you lack — returned even at `admin: true` |
 
 `repos/:o/:r/rules/branches/<b>` is not the way around it. It *is* readable
 without admin, which is precisely the trap: it reports **rulesets only**, so a


### PR DESCRIPTION
One clause on an existing row. **One line changed, net zero added.**

```diff
-| `403 Upgrade to GitHub Pro…` | protection unavailable on this plan (a private repo on a free plan) |
+| `403 Upgrade to GitHub Pro…` | protection unavailable on this **plan**, not a permission you lack — returned even at `admin: true` |
```

The 403 was already recorded here and in Phase 0, both saying "a private repo on
a free plan". What neither said is that the plan gate **survives the top
permission tier**. Measured on this repo — private, free org:

```
permissions: {"admin":true,"maintain":true,"pull":true,"push":true,"triage":true}

branches/main/protection      403 Upgrade to GitHub Pro…
rules/branches/main           403 Upgrade to GitHub Pro…
rulesets                      403 Upgrade to GitHub Pro…
```

The row sits directly beneath **"you lack `admin`"**, so the one thing worth
adding is that elevating permissions changes nothing — only the plan or the
repo's visibility does. It saves chasing access that would not help.

## What this PR used to be

Nine lines, including a six-line paragraph. That was wrong twice over and is now
dropped:

- `branches/<b>/protection` is a call this procedure **forbids** —
  `test_no_phase_reads_required_checks_from_branch_protection` enforces it, and
  `SKILL.md` says don't. Expanding on how to read its responses is interpretive
  detail for a request nobody should issue. That is the same shape retracted in
  [#17](https://github.com/Machai-Kydoimos/dependabot-audit/issues/17#issuecomment-5299069534)
  for `rules/branches/<b>`, one endpoint over.
- The paragraph restated what the row and Phase 0 already said. Prose is the half
  of this repo that nothing can verify, and it is the fastest-growing half —
  `SKILL.md` is up 79% across three releases. It does not need six lines to carry
  one clause.

Recorded rather than quietly rewritten, because the overshoot is a second
instance of the pattern in
[#27](https://github.com/Machai-Kydoimos/dependabot-audit/issues/27): a fix
written from its own diagnosis instead of from what the file already said.

🤖 Generated with [Claude Code](https://claude.com/claude-code)