### PR TITLE
docs: write the check from the evidence, and say what the prose suite misses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,18 @@ against the buggy implementation it was written for, and the commit message says
 what the old code did when it ran. If you cannot make your new test fail against
 the current code, the fix is not doing what you think.
 
+**Write the check from the evidence, not from the change.** A test or a caveat
+derived from the fix it guards can only ever confirm it, errors included — it is
+the same failure as a test that has only ever passed, one level up, and rereading
+it will not reveal anything because it agrees with itself by construction. Two
+instances in one session shipping 0.10.0: a Phase 6 prose guard written from the
+fix asserted the very property that *was* the defect, and went green; a
+`traps.md` paragraph written from its own diagnosis restated what the file
+already said two other places. The control is the guard written from a
+**measurement** — `gh run list --json name` returns `CI`, not the check name —
+which caught a real error. The discriminator is not the artifact and not the
+reviewer; it is which direction the writing flows from.
+
 **Assert on what gets *reported*, not only on what gets returned.** The theme is
 silent failure: an audit that claims success while verifying less than it said is
 worse than one that crashes. Several cases drive `main()` and read stdout for
@@ -64,9 +76,20 @@ the frontmatter key that withholds tools must be the one that works. If you add 
 variable or an artifact that crosses phases, add it to the **Phase 0 outputs**
 table — the test reads it.
 
-It does **not** check whether the model follows the phases. That is behavioral,
-belongs in `claude plugin eval`, and is unavailable on this account. The README
-says so and should keep saying so.
+It closes that half and no other. **Two gaps stay open, and they are different
+gaps** — treating the suite's green as coverage of either is the mistake:
+
+- **Whether the model follows the phases.** Behavioral, belongs in
+  `claude plugin eval`, unavailable on this account. The README says so and
+  should keep saying so.
+- **Whether the prose is *true*.** Consistency is not correctness. Every guard
+  can pass on a phase that names a real endpoint, consumes a properly-derived
+  Phase 0 output, and asks it the wrong question. That shipped in 0.10.0: six
+  passing guards on a Phase 6 that produced a false Hold on the only PR it had
+  ever been run against. Nothing here could have caught it, and no plausible tool
+  could — a checker for whether the prose is true, that could not itself be
+  verified, is the unverified verifier this repo exists to argue against. It is
+  closed by replaying the PR a finding came from, and by nothing else. See #27.
 
 **A new inline trap is a signal that something wants mechanising.** Prose is the
 weakest of the three levers — a trap a script refuses cannot be skipped, one on a

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -7,10 +7,21 @@ one specific repo's required check names. Two of them are the same
 forward-reference shape. Each was found by a human reading in order, and each was
 answered by editing the prose — which is the same lever that produced them.
 
+What is checkable here is narrow and still worth having: whether the document is
+consistent **with itself**. Two gaps stay open around it, and they are different
+gaps — a green run here is evidence of neither.
+
 Whether the model *follows* the phases is behavioral and belongs in
-`claude plugin eval`, which is unavailable on this account. That gap stays open
-and stays stated. What is checkable here is narrower and still worth having:
-whether the document is consistent **with itself**.
+`claude plugin eval`, which is unavailable on this account.
+
+Whether the prose is **true** is not checkable at all. Consistency is not
+correctness: every case below can pass on a phase that names a real endpoint,
+consumes a properly-derived Phase 0 output, and asks it the wrong question. That
+shipped in 0.10.0 — six passing guards on a Phase 6 whose attribution query, run
+against the one PR the finding came from, produced a false Hold. One of those
+guards asserted the property that *was* the defect, because it was written from
+the fix rather than from a measurement. Replaying the PR is what caught it, and
+nothing in this file could have.
 
     a phase may not consume what a later phase creates
     the required-context list must be read from a Phase 0 artifact, never typed


### PR DESCRIPTION
The second ask of
[#27](https://github.com/Machai-Kydoimos/dependabot-audit/issues/27), plus the
one-sentence rule that came out of its
[postmortem comment](https://github.com/Machai-Kydoimos/dependabot-audit/issues/27#issuecomment-5299177133).

## The rule — `CONTRIBUTING.md`, Tests

> **Write the check from the evidence, not from the change.**

A test or a caveat derived from the fix it guards can only ever confirm it,
errors included. It is the same failure as a test that has only ever passed, one
level up — and rereading it will not help, because it agrees with itself by
construction.

Two instances in one session shipping 0.10.0:

| | Written from | Could only ever |
|---|---|---|
| the #25 prose guard | the fix just authored | confirm the fix, error included |
| the `traps.md` paragraph | the diagnosis just written | restate it, overshoot included |
| the `gh run list` guard | a **measurement** | catch a real error — which it did |

The third row is the control. The discriminator is not the artifact and not the
reviewer; it is which direction the writing flows from.

Placed directly after *"Write the test first and watch it fail"* — the same
principle for code, already load-bearing here.

## The disclosure — `CONTRIBUTING.md` + `test_skill_prose.py` docstring

Both texts named exactly **one** open gap — whether the model *follows* the
phases — so both read as though consistency checking covered everything else. It
does not. The second gap is different in kind: whether the prose is **true**.

Consistency is not correctness. Every guard can pass on a phase that names a real
endpoint, consumes a properly-derived Phase 0 output, and asks it the wrong
question. That shipped in 0.10.0: six passing guards on a Phase 6 that produced a
false Hold on the only PR it had ever been run against.

Both now name both gaps as distinct, say what closes the second one — replaying
the PR a finding came from — and say what does not. The exclusion is written down
rather than left to judgment, because a checker for whether the prose is true,
which could not itself be verified, is the unverified verifier this repo exists
to argue against.

## Scope

Docs and one docstring. No behaviour change, 136 tests unaffected.

Closes the second ask of #27. **The first — making the replay a gate rather than
a habit — is untouched and still open.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)