### PR TITLE
docs: give the replay gate an actual checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+The body is the record. Say what the old behaviour was when it ran, not only
+what the new behaviour is — length is fine, and every PR here carries its
+reasoning. CONTRIBUTING.md has the rules this repo actually enforces.
+-->
+
+
+## The replay
+
+<!--
+CONTRIBUTING → "The gate with no script". A change to a phase's method is
+replayed against the PR that motivated it, before it is committed.
+
+Delete this whole section if the change does not touch a phase's method. A box
+ticked to clear a template is worth less than no box.
+-->
+
+- [ ] Replayed against `owner/repo #N`
+
+What it showed — pasted, not summarised. A tick is an assertion; the output is
+evidence, and this repo's whole position is the difference between the two.
+
+```
+
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,12 +62,19 @@ recency, and prefer one whose consequences the repository's history already
 records: #334 was decisive because the right answer was known before the phase
 ran.
 
-**This is a checklist item, and checklists are visibly skippable.** By this file's
-own ordering that is the middle lever, and no stronger one is available here: for
-*is this claim true about the world* there is no script, only contact with the
-world. A tool that claimed to be one, and could not itself be verified, would be
-the unverified verifier this repo exists to argue against — so do not build one,
-however productive it would look.
+**This is a checklist item, and checklists are visibly skippable.** The box lives
+in `.github/PULL_REQUEST_TEMPLATE.md`, and it asks for what the replay showed
+rather than for a tick — a tick is an assertion, the pasted output is evidence,
+and that distinction is the whole product. Know how little it reaches: the web UI
+applies the template automatically, `gh pr create` takes it only via `-T`, and a
+supplied `--body` or `--body-file` bypasses it entirely, which is how every PR
+here has been opened so far.
+
+By this file's own ordering that is the middle lever, and no stronger one is
+available here: for *is this claim true about the world* there is no script, only
+contact with the world. A tool that claimed to be one, and could not itself be
+verified, would be the unverified verifier this repo exists to argue against — so
+do not build one, however productive it would look.
 
 ## Tests
 


### PR DESCRIPTION
Follow-up to #30. The replay gate as merged in `4020aef` described itself as *"a
checklist item, which is the middle lever"* — but it was a paragraph in
`CONTRIBUTING.md`, which by that file's own ordering is the **weakest** lever, the
one that gets silently skipped. The rule described a checklist that lived nowhere.

`.github/PULL_REQUEST_TEMPLATE.md` now holds it.

## It asks for the output, not for a tick

A ticked box is an assertion, and this repo's whole position is that an assertion
is not evidence. The section asks for what the replay *showed* — pasted, not
summarised — in a fenced block under the box. Same demand the audit makes of its
own report rows, applied to the process that produces them.

It also says to **delete the section** when the change does not touch a phase's
method, rather than offering an N/A box:

> A box ticked to clear a template is worth less than no box.

## Only unmechanisable rules earn a place in it

`CONTRIBUTING`'s rule is that a trap only earns prose when it cannot be enforced.
The same test decides what earns a checkbox, so the template carries the replay
and nothing else:

| Rule | Why it is not a box |
|---|---|
| ruff, mypy, the suite | hooks and CI already refuse |
| the mypy override for a new test module | already loud, per that section |
| a CHANGELOG entry for shipped surface (the `a528514` case) | scriptable — should become a hook if it recurs |

Two candidates were left out **deliberately**, and both would qualify: *write the
test first and watch it fail*, and *write the check from the evidence, not from
the change*. Both are unmechanisable, both have shipped defects. They are out
because a four-box template is one nobody reads, and because the replay is the
only one of the three with a perfect record. Worth adding if the replay box turns
out to be read.

## What it does not reach — said in the file, not left to discovery

The web UI applies the template automatically. `gh pr create` takes it only via
`-T`, and a supplied `--body`/`--body-file` bypasses it entirely — which is how
#28, #29, #30 and **this PR** were all opened. So the box is a prompt in one of
the two paths actually used here, and `CONTRIBUTING` now says so.

Same principle as the rest of that section: a gate whose reach is overstated is
worse than one whose limits are on the label.

## Not in scope

Docs only. No version bump and no `CHANGELOG` entry — this changes how the repo is
contributed to, not what a phase verifies or what the report asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
