### PR TITLE
docs: decline the evidence split, and measure why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,78 @@ patch.
 
 ## [Unreleased]
 
+### Decided
+
+- **The evidence split is dropped**, closing 0.15.0's *Not done, deliberately*.
+  It was held pending something that could detect a narrative turning out to be
+  discriminating rather than motivating. Measuring it first is what settled it
+  instead.
+
+  Every narrative block left in `SKILL.md` totals **2,260 tokens** — that is the
+  figure for moving *all* of them, including the ones designated to stay. The
+  defensible set is ~1,470. The ~4k projection was taken against the 970-line
+  file, and 0.15.0 had already harvested most of it: `setup-nvc`, the seven green
+  release runs and `cli/cli` #14124 left for `actions.md` with the ecosystem
+  split. Of the four narratives listed to move, only the 3,682-deletion
+  `Cargo.lock` story survives, at 78 tokens.
+
+  **The classification had expired in both directions**, and that is the part
+  worth keeping. *Does removing this example make the rule ambiguous?* is a
+  question answered by someone who already knows the rule. The mechanical test is
+  **who enforces this rule now**: `discover.py` decides `BRANCH_POINT`, so
+  `cli/cli` #14049 no longer discriminates a choice the model makes, and
+  `ci_state.py` picks the comparison point, so `mdcat` #6's four-point table does
+  not either — both were listed as staying inline. Phase 4's ruff narrative *is*
+  discriminating and was never a candidate, because `gate_diff.py` takes `--tree`
+  from the caller.
+
+  The destination was also wrong: `evidence.md` is `traps.md` renamed, and
+  `SKILL.md` points at `traps.md` four times, so the move was into a file the
+  per-run cost tables exclude and nothing had measured.
+
+  Against that, ~1,470 tokens buys the property `CONTRIBUTING.md` argues for
+  everywhere else — a rule sitting next to the measurement that produced it
+  resists being reasoned away, which is the failure mode every entry in the
+  replay table shares. Priced honestly that is ~$0.09 of a ~$1.6 run — about 5%,
+  since documentation is re-read from cache on every turn, not once.
+
+### Measured
+
+Two cold runs against the **installed** 0.16.0 plugin, `--no-execute`, each in a
+fresh session so nothing was already in context:
+
+| | `cli/cli` #14091 | `cli/cli` #14049 |
+|---|---|---|
+| turns / cost | 30 / $1.61 | 27 / $1.63 |
+| `actions.md` | fetched | fetched |
+| `report-template.md` | fetched | fetched |
+| **`traps.md`** | **never** | **never** |
+
+Three `traps.md` pointers fire in each run — the preamble, Phase 0's
+branch-protection line, and Phase 6's tail — and none was followed. Both runs
+reached Phase 6 (`discover.py` twice, `ci_state.py` once each), so the phases
+carrying those pointers did execute.
+
+**Soft pointers are not followed; structural handoffs are.** *"`references/traps.md`
+has the reasoning"* does not load a file. *"Method: `references/actions.md` §
+Phase 1"*, in a table the phase must consult to proceed, does. That is why
+0.15.0's split worked, and it is the load-bearing reason this one was dropped:
+`evidence.md` would have been a document no run reaches.
+
+Both audits were sound without it. #14049 — the two-parent maintainer merge —
+came back `BRANCH_POINT=ok` with the base **not** substituted and a correct
+2-file, 4-`uses:`-line scope, which is the narrative that stayed inline doing
+exactly what keeping it inline was for.
+
+### Known, not yet addressed
+
+`traps.md` is ~4,891 tokens that no run reaches. `ci_state.py` mechanised most of
+its CI-state traps in 0.14.0, so what is actually unreachable is narrow: stale
+`CLEAN` right after a push, taking the *latest* run for a SHA, and a bot's own
+rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
+file changes what a phase verifies, so it belongs in its own release behind the
+replay gate rather than in this entry.
+
 ## [0.16.0] — 2026-08-15
 
 Phase 0 was the last large block of prose asking a reader to hold a three-state


### PR DESCRIPTION
The evidence split — moving motivating case narratives out of `SKILL.md` into
`references/evidence.md` — was held at 0.15.0 pending something that could
detect a narrative turning out to be *discriminating* rather than merely
*motivating*. Measuring it first is what settled it instead. This PR records the
decision and the measurement; no procedure changes, no version bump.

## Why the projection no longer held

Every narrative block left in `SKILL.md` totals **2,260 tokens**, on the same
chars/4 basis the `Measured` tables use — and that is the figure for moving *all*
of them, including the ones designated to stay. The defensible set is ~1,470.

The ~4k projection was taken against the 970-line file, and 0.15.0 had already
harvested most of it: `setup-nvc`, the seven green release runs and `cli/cli`
#14124 left for `actions.md` with the ecosystem split. Of the four narratives
listed to move, only the 3,682-deletion `Cargo.lock` story survives, at 78
tokens.

## The classification had expired in both directions

*"Does removing this example make the rule ambiguous?"* is a question answered by
someone who already knows the rule. The mechanical test is **who enforces this
rule now**:

- `discover.py` decides `BRANCH_POINT`, so `cli/cli` #14049 no longer
  discriminates a choice the model makes.
- `ci_state.py` picks the comparison point, so `mdcat` #6's four-point table does
  not either.

Both were listed as *staying inline*. Meanwhile Phase 4's ruff narrative **is**
discriminating and was never a candidate, because `gate_diff.py` takes `--tree`
from the caller.

## And the destination was measured

Two cold runs against the **installed** 0.16.0 plugin, `--no-execute`, each in a
fresh session so nothing was already in context. Three `traps.md` pointers fire
per run — the preamble, Phase 0's branch-protection line, Phase 6's tail — and
none was followed. Both runs reached Phase 6, so the phases carrying those
pointers did execute.

**Soft pointers are not followed; structural handoffs are.**
*"`references/traps.md` has the reasoning"* does not load a file;
*"Method: `references/actions.md` § Phase 1"*, in a table the phase must consult
to proceed, does. That is why 0.15.0's split worked, and it is the load-bearing
reason this one is dropped: `evidence.md` would have been a document no run
reaches, so the move was deletion with extra steps.

Priced honestly, the saving was ~$0.09 of a ~$1.6 run — about 5%, since
documentation is re-read from cache every turn rather than once. Against it
stands the property `CONTRIBUTING.md` argues for everywhere else: a rule sitting
next to the measurement that produced it resists being reasoned away.

## Left for its own release

`traps.md` is ~4,891 tokens that no run reaches. `ci_state.py` mechanised most of
its CI-state traps in 0.14.0, so what is actually unreachable is narrow — stale
`CLEAN` right after a push, taking the *latest* run for a SHA, and a bot's own
rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
file changes what a phase verifies, so it belongs behind the replay gate in a
minor bump, not in this entry.

## The replay

This PR changes no phase's method, so the gate does not strictly apply — but the
decision rests on live evidence, so it is pasted here rather than summarised.

- [x] Replayed against `cli/cli #14091` and `cli/cli #14049`

```
$ claude -p "/dependabot-audit 14091 --no-execute"   # cold session, installed 0.16.0
  30 turns  $1.61   discover.py x2  ci_state.py x1
  actions.md          FETCHED (full)
  report-template.md  FETCHED
  traps.md            NOT FETCHED
  verdict: Merge as-is, confidence high

$ claude -p "/dependabot-audit 14049 --no-execute"   # two-parent maintainer merge head
  27 turns  $1.63   discover.py x2  ci_state.py x1
  actions.md          FETCHED (full)
  report-template.md  FETCHED
  traps.md            NOT FETCHED
  verdict: Merge as-is, confidence medium
          (medium because --no-execute skipped Phase 5's run-history substitute)

#14049 evidence row, verbatim:
  | Branch point | `ok`. Head is a two-parent maintainer merge
  | (`Merge branch 'trunk' into dependabot/...`), not a moved base — zero
  | force-push events. Merge base `5ccd971d` correct and **not** substituted.
  | Scope | 2 files, 4 lines, all `uses:` lines. Gate did not fire.

#14091 caught the version-qualified GHSA trap and queried by name; read v4.37.7
as sitting inside the repo's 3-day cooldown; established the CodeQL
DEFAULT_CONFIG_FILE_NAME change was inert here two independent ways.
```

Both audits were sound with `traps.md` unread, and #14049 is the case the plan
called discriminating-stays-inline — the narrative that stayed inline doing
exactly what keeping it inline was for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
