### PR TITLE
fix: name the covered ecosystems in every description (0.16.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "dependabot-audit",
-      "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
+      "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
       "author": {
         "name": "Richard Graham"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
-  "description": "Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation. Read-only: it reports, it never merges.",
-  "version": "0.16.0",
+  "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
+  "version": "0.16.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,38 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.16.1] — 2026-08-15
+
+### Fixed
+
+- **Every description now names the covered ecosystems.** `plugin.json`,
+  `marketplace.json`, `SKILL.md`'s frontmatter and the command's all promised to
+  *"audit an automated dependency-bump PR"* and named no ecosystem, while the
+  plugin verifies exactly two. `README.md` has always been scrupulous about this
+  — a table naming both, then a section on why npm, Cargo and Go are out of scope
+  rather than unimplemented — but the descriptions are what a marketplace listing
+  shows, so the first place a user learned otherwise was `audit.py` exiting 2 on
+  their lockfile.
+
+  The added clause is *"verifies uv.lock and GitHub Actions end to end; any other
+  ecosystem gets the ecosystem-independent phases and a stated boundary"*. The
+  second half is deliberate: an out-of-scope PR is meant to load the skill and
+  receive Phase 0's classification, Phase 6's CI state and a named boundary. A
+  refusal with reasons is the product. So the trigger list in `SKILL.md`'s
+  frontmatter is left broad rather than narrowed to the two ecosystems — stating
+  coverage should not suppress the match.
+
+  A patch by this file's own rule: nothing changed about what a phase verifies,
+  only about whether an existing claim was true.
+
+  Considered and rejected: **renaming the repo.** The name is not where the
+  over-promise lives. It under-claims on the bot axis if anything — Renovate is
+  covered too — and encoding coverage in the identifier puts the most volatile
+  fact in the least changeable place, given `CONTRIBUTING.md`'s ecosystem rule is
+  conditional on having a repository to test against rather than a permanent
+  closure. Domain in the name, coverage in the description, evidence in the
+  README.
+
 ## [0.16.0] — 2026-08-15
 
 Phase 0 was the last large block of prose asking a reader to hold a three-state

--- a/commands/dependabot-audit.md
+++ b/commands/dependabot-audit.md
@@ -1,5 +1,5 @@
 ---
-description: Audit a Dependabot or Renovate PR and report an evidence-backed merge recommendation. Reports; never merges.
+description: Audit a Dependabot or Renovate PR and report an evidence-backed merge recommendation. Covers uv.lock and GitHub Actions. Reports; never merges.
 argument-hint: <PR number> [--no-execute] [--comment]
 ---
 

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependabot-audit
-description: Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation — verify lockfile artifact hashes against the registry, cross-check the true latest version, read changelogs for security and behavior changes, reproduce the repo's own checks in an isolated worktree, and report. Use when the user asks to review, audit, check, or decide on a Dependabot or Renovate PR, a dependency bump, a lockfile PR, or asks "is this safe to merge".
+description: Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation — verify lockfile artifact hashes against the registry, cross-check the true latest version, read changelogs for security and behavior changes, reproduce the repo's own checks in an isolated worktree, and report. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary rather than an improvised recipe. Use when the user asks to review, audit, check, or decide on a Dependabot or Renovate PR, a dependency bump, a lockfile PR, or asks "is this safe to merge".
 disallowed-tools: Edit, Write, NotebookEdit
 ---
 


### PR DESCRIPTION
`plugin.json`, `marketplace.json`, `SKILL.md`'s frontmatter and the command's all
promised to *"audit an automated dependency-bump PR"* and named no ecosystem,
while the plugin verifies exactly two.

`README.md` has always been scrupulous about this — a table naming `uv.lock` and
GitHub Actions, then a section on why npm, Cargo and Go are **out of scope rather
than unimplemented**, with the observed Cargo bump that returned matching
checksums, a current latest version and a clean OSV batch on a PR that raised the
project's MSRV past its own declared floor.

But the descriptions are what a marketplace listing shows. A user browsing it
reads *"any dependency-bump PR"*, and the first place they learn otherwise is
`audit.py` exiting 2 on their lockfile. The README cannot fix that, because it is
not the surface where the decision to install gets made.

## The change

One clause, in all four descriptions:

> …verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the
> ecosystem-independent phases and a stated boundary…

plus a compact form in the command's frontmatter, where the slash menu truncates.

**The second half is deliberate, not hedging.** An out-of-scope PR is *meant* to
load the skill and receive Phase 0's classification, Phase 6's CI state and a
named boundary — `SKILL.md` says so, and `audit.py` exits 2 naming the format
precisely so the boundary is reported rather than improvised around. A refusal
with reasons is the product.

So `SKILL.md`'s trigger list is left **broad**, not narrowed to the two
ecosystems. Stating coverage must not suppress the match, or the useful refusal
never happens.

## Considered and rejected: renaming the repo before the flip

The name is not where the over-promise lives.

- It **under**-claims on the bot axis if anything — Renovate is covered too — and
  no short name fixes both axes without becoming a sentence.
- Encoding coverage in the identifier puts the most volatile fact in the least
  changeable place. `CONTRIBUTING.md`'s ecosystem rule is conditional on having a
  repository to test against, not a permanent closure, so a scope-encoding name
  goes wrong again the moment a third ecosystem lands — by which point the repo
  is public and the rename is expensive.
- Renaming the *plugin* is not renaming the *repo*. GitHub redirects the URL, but
  `plugin.json`'s `name` is a separate identifier, and changing it orphans
  installed copies.

Domain in the name, coverage in the description, evidence in the README.

## Versioning

**0.16.1, a patch.** By `CONTRIBUTING.md`'s rule nothing changed about what a
phase verifies or what the report asserts — only about whether an existing claim
was true. `CHANGELOG.md` gets a `## [0.16.1]` section; the `[Unreleased]`
decision record above it stays put, since it is not part of a release.

## The replay

Deleted per the template's own instruction — this changes no phase's method, and
a box ticked to clear a template is worth less than no box.

One thing it is honest to flag as **unverified**: `SKILL.md`'s frontmatter
description is what the natural-language path matches on, and no measurement here
establishes that adding a coverage clause leaves matching behaviour unchanged.
The clause was placed after the method list and before the trigger list, and the
trigger list is untouched, which is the most that can be said without
`claude plugin eval` (#32).

```
python3 -B -m unittest discover -s tests
Ran 201 tests in 0.437s
OK

python3 -c "import json; json.load(open('.claude-plugin/plugin.json')); json.load(open('.claude-plugin/marketplace.json'))"
ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
