### PR TITLE
docs: CI becomes the enforcing gate, PVR becomes the channel (0.16.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,72 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.16.2] — 2026-08-15
+
+The repository went public. Four statements that were accurate about a private
+free-org repo stopped being accurate the moment it flipped, and one question the
+plugin has argued about for six releases became measurable for the first time.
+
+### Changed
+
+- **CI is the enforcing gate; the hooks are the fast local pre-check.** A ruleset
+  on `main` requires `Lint & type-check` and all four `Test (Python 3.x)` legs.
+  The README said the reverse, correctly — rulesets and branch protection are
+  unavailable on a private free-org repo (`403 Upgrade to GitHub Pro or make this
+  repository public`), so nothing could be marked required and the hooks carried
+  the whole load.
+
+- **`SECURITY.md` points at GitHub private vulnerability reporting**, now enabled.
+  It previously said an issue *was* a private report, which was true while only
+  org members could see the repo and became false on the flip.
+
+- **The install paragraph no longer asks for credentials**, verified rather than
+  assumed with a credential-free anonymous clone — `GIT_TERMINAL_PROMPT=0`, no
+  credential helper, global and system git config discarded. Exit 0.
+
+### Measured
+
+**A required check that never reports blocks the merge and is invisible to the
+auditor — both, at the same time.** Measured on PR #37 by requiring a context
+(`Test (Python 3.99)`) that can never report:
+
+| | Baseline | With the unsatisfiable requirement |
+|---|---|---|
+| contexts in the rollup | 5 | **5** — the missing one produces no row |
+| every listed `isRequired` | true | true |
+| `statusCheckRollup.state` | SUCCESS | **SUCCESS** |
+| `mergeable` | MERGEABLE | MERGEABLE |
+| `mergeStateStatus` | CLEAN | **BLOCKED** |
+
+The repository's view is loud; the auditor's view is silent. A procedure reading
+`isRequired` and the rollup sees five of five required checks green and reports
+all-clear on a PR GitHub will refuse. That is exactly why Phase 6 reads
+`mergeStateStatus` alongside the rollup, and it is the first time the claim has
+been tested on a repository where the right answer was known in advance rather
+than inferred from someone else's PR.
+
+The genuinely silent variant is the inverse and nothing here catches it: rename a
+job *and* update the ruleset but miss a leg, and that leg still runs, still
+reports, is no longer required, and nothing says so. Recorded in
+`CONTRIBUTING.md` as a hand-check.
+
+- **`references/traps.md` gains the mirror of its own endpoint case.** It already
+  recorded classic protection making `rules/branches/<b>` return `[]` on `mdcat`.
+  Measured here at `admin`, ruleset active, no classic protection:
+  `rules/branches/main` reports the three rules, and `branches/main/protection`
+  returns `404 Branch not protected` about a branch requiring five checks. That
+  404 is the *distinguishable* one, not the bare `404 Not Found` that means you
+  lack `admin`, so permissions do not explain it. Neither endpoint answers "what
+  gates this branch"; each answers for its own mechanism and returns a confident
+  nothing about the other.
+
+### Note on the version
+
+A **patch**, by this file's own rule. Nothing changed about what a phase verifies
+or what the report asserts — the procedure is untouched. Going public is not a
+procedural event, which is the same reasoning recorded on #17 for why the flip
+itself earns no bump.
+
 ## [0.16.1] — 2026-08-15
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,59 @@ reasons that are not this repo's fault. Keep them that way. The value of the
 hermetic suite is that it is cheap and trustworthy on every commit, and anything
 that needs a registry does not belong in it.
 
+## The required checks, and the one that is silent
+
+`main` carries a ruleset requiring `Lint & type-check` and all four
+`Test (Python 3.x)` legs. **CI gates the merge; the hooks are the fast local
+pre-check.** That inverted when the repository went public — rulesets are
+unavailable on a private free-org repo, so until then nothing could be required.
+
+**Renaming a matrix leg without updating the ruleset is loud, not silent** —
+measured here rather than predicted, on PR #37, by adding a required context
+(`Test (Python 3.99)`) that can never report:
+
+| | Baseline | With the unsatisfiable requirement |
+|---|---|---|
+| contexts in the rollup | 5 | **5** — the missing one produces no row |
+| every listed `isRequired` | true | true |
+| `statusCheckRollup.state` | SUCCESS | **SUCCESS** |
+| `mergeable` | MERGEABLE | MERGEABLE |
+| `mergeStateStatus` | CLEAN | **BLOCKED** |
+
+Both halves are true at once and they point opposite ways. **The repository's
+view is loud:** the PR stops being mergeable. **The auditor's view is silent:**
+the unsatisfied requirement is absent from the rollup entirely, so a procedure
+reading `isRequired` and the rollup state sees five of five required checks green
+and reports all-clear.
+
+That is Phase 6's design rationale, and this is the first time it has been
+measured on a repository where the right answer was known in advance rather than
+inferred from someone else's PR. `SKILL.md` already says `mergeStateStatus` is
+what closes the gap; this is the controlled case behind that sentence.
+
+**The genuinely silent failure is the inverse**, and nothing above catches it:
+rename the job *and* update the ruleset, but miss a leg. That leg still runs and
+still reports, is no longer required, and nothing anywhere says so. Check the
+ruleset against `ci.yml`'s matrix by hand whenever either changes.
+
+**The ruleset is also the positive control this repo never had** for the two
+endpoints that look like they answer *what is required here*. Measured at
+`admin`, ruleset active, no classic protection:
+
+```
+GET repos/:o/:r/rules/branches/main       -> deletion, non_fast_forward,
+                                             required_status_checks
+GET repos/:o/:r/branches/main/protection  -> 404 "Branch not protected"
+```
+
+That 404 is the *distinguishable* one from `references/traps.md`'s four-state
+table, not the bare `404 Not Found` that means you lack `admin` — and it is still
+wrong about enforcement, on a branch requiring five checks. It mirrors the case
+`traps.md` records from `mdcat`, where classic protection makes `rules/branches`
+return `[]`. Each endpoint answers about its own mechanism and returns a
+confident "nothing here" about the other. Neither substitutes for asking per-PR,
+which is what Phase 6 does.
+
 ## The gate with no script
 
 **A change to a phase's method is replayed against the PR that motivated it

--- a/README.md
+++ b/README.md
@@ -37,9 +37,18 @@ and compares the publisher against the release being replaced.
 /plugin install dependabot-audit
 ```
 
-The repo is **private to the Machai-Kydoimos organization**, so installing it
-requires git credentials with access — org members should have `gh auth login`
-done, or an SSH key on their account, before running the first command.
+No credentials are needed. Verified rather than assumed, with a credential-free
+anonymous clone — `GIT_TERMINAL_PROMPT=0`, no credential helper, and global and
+system git config both discarded:
+
+```
+$ GIT_TERMINAL_PROMPT=0 GIT_CONFIG_GLOBAL=/dev/null GIT_ASKPASS=/bin/false \
+    git -c credential.helper= clone --depth 1 \
+    https://github.com/Machai-Kydoimos/dependabot-audit.git
+Cloning into 'dependabot-audit'...
+$ echo $?
+0
+```
 
 ## Use
 
@@ -253,10 +262,20 @@ pre-commit install          # ruff, mypy and the suite, on every commit
 pre-commit run --all-files  # exactly what CI runs
 ```
 
-**The hooks are the enforcing gate; CI is advisory.** This repo is private on a
-free org, where branch protection and repository rulesets are both unavailable
-(`403 Upgrade to GitHub Pro or make this repository public`), so no check can be
-marked required. CI earns its place on the one thing the hooks cannot do: run the
+**CI is the enforcing gate; the hooks are the fast local pre-check.** A ruleset on
+`main` requires `Lint & type-check` and all four `Test (Python 3.x)` legs, so a
+red check blocks the merge rather than merely reporting it.
+
+That inverted the moment this repository went public, and the old arrangement is
+worth stating because it explains the shape of everything above: rulesets and
+branch protection are free on public repositories and unavailable on a private
+free-org one (`403 Upgrade to GitHub Pro or make this repository public`), so
+until the flip no check could be marked required and the hooks carried the whole
+load alone.
+
+Install them anyway. They are the same tools at the same pins, and a failure
+found locally costs a second where the same failure found in a PR costs a round
+trip. CI still earns its place on the one thing the hooks cannot do: run the
 suite on Python 3.11 through 3.14, because `audit.py` runs under whatever bare
 `python3` the repo under audit happens to have, and `tomllib` puts the floor at
 3.11. The maintainer's machine is the newest of those, so the older legs are the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,19 @@
 
 ## Reporting
 
-**This repository is private.** Only members of the Machai-Kydoimos organization
-can see it or open issues on it, so for now an issue *is* a private report: open
-one with `SECURITY` in the title.
+Use GitHub's **private vulnerability reporting** — the *Report a vulnerability*
+button on this repository's [Security
+tab](https://github.com/Machai-Kydoimos/dependabot-audit/security/advisories/new).
+It is enabled, and it is the channel.
 
-That changes when the repository goes public. GitHub's private vulnerability
-reporting is a public-repository feature, so it cannot be the channel today;
-switching to it is tracked in
-[#17](https://github.com/Machai-Kydoimos/dependabot-audit/issues/17). Until then,
-do not assume a channel exists that has not been set up.
+Do not open a public issue for anything with a security dimension. There is no
+email alias to fall back to, deliberately: a single advertised channel that is
+known to work beats two where one is unmonitored.
+
+This replaced the pre-public arrangement, where the repository was visible only to
+the Machai-Kydoimos organization and an issue therefore *was* a private report.
+Private vulnerability reporting is a public-repository feature and could not be
+switched on before the flip.
 
 ## The risk most worth understanding is not a bug
 

--- a/skills/dependabot-audit/references/traps.md
+++ b/skills/dependabot-audit/references/traps.md
@@ -288,6 +288,22 @@ repo using classic branch protection returns `[]` and manufactures a false
 "nothing enforced" finding. Ask per-PR instead — `isRequired` is evaluated against
 whatever actually enforces it, and needs only `pull`.
 
+**Both directions are now measured, and each endpoint lies about the other
+mechanism.** On `mdcat`, classic protection enforcing three checks:
+`rules/branches/<b>` returns `[]`. On this plugin's own repo at `admin`, a
+ruleset requiring five checks and no classic protection:
+
+| Call | Answer | True? |
+|---|---|---|
+| `rules/branches/main` | `deletion`, `non_fast_forward`, `required_status_checks` | yes |
+| `branches/main/protection` | `404 Branch not protected` | **about classic protection, yes; about enforcement, no** |
+
+That second 404 is the *distinguishable* one in the table above, not the bare
+`404 Not Found` that means you lack `admin` — so permissions do not explain it,
+and the branch it calls unprotected requires five checks. Neither endpoint
+answers "what gates this branch"; each answers "what does *my* mechanism say",
+and returns a confident nothing for the other.
+
 **Neutral / "skipping" security-scan results are normal** on diffs that do not
 touch the scanned surface. Not a failure, and usually not a required check.
 


### PR DESCRIPTION
Post-flip work from #17. The repository went public, four statements that were
accurate about a private free-org repo stopped being accurate, and one question
this plugin has argued about for six releases became measurable for the first
time.

## Changed

- **CI is the enforcing gate; the hooks are the fast local pre-check.** A ruleset
  on `main` requires `Lint & type-check` and all four `Test (Python 3.x)` legs.
  The README said the reverse, and was right to: rulesets and branch protection
  are unavailable on a private free-org repo.
- **`SECURITY.md` points at private vulnerability reporting**, now enabled. It
  previously said an issue *was* a private report — true while only org members
  could see the repo, false the moment they could not.
- **The install paragraph no longer asks for credentials**, verified with a
  credential-free anonymous clone rather than assumed.

## The measurement #17 reserved for this moment

#17 said the old claim — that a renamed matrix leg *silently drops* its required
check — was "probably backwards at the repository level", and that it could not
be settled before the flip. Settled now, by requiring a context
(`Test (Python 3.99)`) that can never report:

| | Baseline | With the unsatisfiable requirement |
|---|---|---|
| contexts in the rollup | 5 | **5** — the missing one produces no row |
| every listed `isRequired` | true | true |
| `statusCheckRollup.state` | SUCCESS | **SUCCESS** |
| `mergeable` | MERGEABLE | MERGEABLE |
| `mergeStateStatus` | CLEAN | **BLOCKED** |

**Both halves are true at once, and they point opposite ways.** The repository's
view is loud — the PR stops being mergeable. The auditor's view is silent — the
unsatisfied requirement is absent from the rollup entirely, so a procedure
reading `isRequired` and the rollup state sees five of five required green and
reports all-clear on a PR GitHub will refuse.

That is Phase 6's design rationale, and it is the first test of it on a
repository where the right answer was known in advance rather than inferred from
someone else's PR. The genuinely silent variant is the inverse and nothing here
catches it — rename a job *and* update the ruleset but miss a leg — so
`CONTRIBUTING.md` records it as a hand-check.

## The positive control this repo never had

`traps.md` already recorded classic protection making `rules/branches/<b>` return
`[]` on `mdcat`. The mirror, measured here at `admin` with a ruleset active and
no classic protection:

```
GET repos/:o/:r/rules/branches/main       -> deletion, non_fast_forward,
                                             required_status_checks
GET repos/:o/:r/branches/main/protection  -> 404 "Branch not protected"
```

…on a branch requiring five checks. That 404 is the *distinguishable* one, not
the bare `404 Not Found` meaning you lack `admin`, so permissions do not explain
it. Neither endpoint answers "what gates this branch"; each answers for its own
mechanism and returns a confident nothing about the other.

## Versioning

**0.16.2, a patch.** Nothing changed about what a phase verifies or what the
report asserts — the procedure is untouched. Going public is not a procedural
event, which is the reasoning already recorded on #17 for why the flip earns no
bump by itself.

## The replay

Deleted per the template — no phase's method changed. The measurements above are
live rather than replayed, and both are pasted rather than summarised.

```
python3 -B -m unittest discover -s tests
Ran 201 tests in 0.417s
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
