### PR TITLE
docs: disclose that the plugin was developed with Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,21 @@ Two caveats worth knowing, since both were wrong here until `0.1.9`:
   a hard error. That is a deliberate trade: enforcement in the channel this plugin
   actually ships through beats portability to one it doesn't.
 
+## How this was built
+
+**This plugin was developed with Claude Code**, and every commit carries a
+`Co-Authored-By: Claude ...` trailer naming the model that worked on it.
+
+Said plainly because the product here is prose and judgment — a procedure a model
+follows — and a reader weighing whether to trust it deserves to know how it was
+made. It is disclosure, not authorship: `plugin.json` names one author, the
+maintainer, who answers the security channel above and owns what this repository
+claims. The gates in this file exist because prose written that way needs
+checking, and the honest limits are stated in **Tests** rather than argued away:
+201 hermetic cases check `SKILL.md` for consistency, nothing checks it for truth
+except replaying a real PR, and whether the model *follows* the procedure is
+still ungated.
+
 ## License
 
 MIT.


### PR DESCRIPTION
Adds a short **How this was built** section above the licence.

The product here is prose and judgment — a procedure a model follows — and a
reader weighing whether to trust it deserves to know how it was made. Every
commit already carries a `Co-Authored-By` trailer; this states it where a reader
looks rather than leaving it in `git log`.

**Deliberately disclosure and not authorship.** `plugin.json` names one author,
the maintainer, who answers the security channel and owns what this repository
claims. Blurring that on a security-adjacent tool whose whole position is *"an
unverified verifier is worse than none"* would cost exactly the accountability
the rest of the README spends its length defending — and a co-author with no
account behind it cannot answer a report.

The paragraph points at **Tests** rather than asserting the prose is sound: 201
hermetic cases check `SKILL.md` for consistency, nothing checks it for truth
except replaying a real PR, and whether the model *follows* the procedure is
still ungated behind #32. Stating how it was built is only worth anything next to
the limits of how it is checked.

No version bump — nothing changed about what a phase verifies or what the report
asserts.

## The replay

Deleted per the template — no phase's method changed.

```
python3 -B -m unittest discover -s tests
Ran 201 tests in 0.352s
OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
