### PR TITLE
fix: four findings from auditing fpga-board-sim, plus an exit-code correction (0.18.0–0.21.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,63 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.18.0] — 2026-08-16
+
+Phase 0 read the repo's own gate list out of the **working tree** (#44). Every
+other Phase 0 output is pinned to the PR, and the lockfile reads in
+`uv-lock.md` do it properly — `git show "pr-<N>:uv.lock"`. The gate read was the
+one that did not.
+
+### The replay
+
+`fpga-board-sim` #359, merged. `ci.yml` read three ways:
+
+| Read from | Gates |
+|---|---|
+| the checkout — `main` at `bddcc47` | 6, including `uv run actionlint` |
+| `git show "pr-359:.github/workflows/ci.yml"` | **5** — no `actionlint` |
+| the PR's merge base, `fff3eaf12` | 5 |
+
+`actionlint` arrived in that repo's #362, three PRs *after* the one under audit.
+Run in the PR's worktree it exits **2** — `Failed to spawn: actionlint` — which
+reads downstream as a Phase 5 gate failure on a gate the PR never had. Exit 2 is
+the status this procedure is most careful about everywhere else: "could not run",
+never "ran and found something". Here the procedure manufactured one.
+
+**Not only a replay problem.** Auditing merged PRs is supported and makes the
+divergence certain — the checkout is ahead of every merged PR by construction,
+and every replay CONTRIBUTING's gate asks for is one. The same gap opens on an
+**open** PR whenever another branch is checked out, or the default branch has
+moved since the bot branched.
+
+### Changed
+
+- **Phase 0 reads the gates, and the bot config, at a ref.** The bot config went
+  with them for the same reason: whether a currency gap is lag or a deliberate
+  hold is decided by the config in force on the PR, not by the copy in whatever
+  is checked out.
+
+- **Each phase's gate list comes from the tree that phase runs it in.** Phase 5
+  reproduces in `$SCRATCH/pr-<N>`, Phase 4 measures in `$SCRATCH/base-<N>`, and
+  one list served both. On #359 the two lists agree, which is the honest thing to
+  report and not a reason to read only one.
+
+- **A gate on only one side of the bump is now a finding.** Quiet in both
+  directions: a gate since *removed* runs against a tree that never had it, and a
+  gate the PR *adds* never runs at all. The second is the one that matters — an
+  actions or tooling bump can legitimately add its own.
+
+- **An actions bump creates no worktrees.** `actions.md` reads the diff with
+  `git show` throughout, Phase 4 reads release notes, and Phase 5's substitute is
+  `gh run list`, so Phase 0 was adding and Phase 7 removing two worktrees that no
+  phase consumed. The fetch stays: `git show` needs the ref.
+
+### Tests
+
+`TestTheRepoConfigIsReadAtARef`, three guards. Mutation-checked against the
+0.17.0 prose: the positive guard found no `git show` of a gate list in Phase 0 at
+all, and the per-line negative guard fired on `cat .github/dependabot.yml`.
+
 ## [0.17.0] — 2026-08-15
 
 `references/traps.md` is retired (#35). It was never fetched — measured, not
@@ -1825,7 +1882,11 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.17.0...v0.18.0
+[0.17.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.2...v0.17.0
+[0.16.2]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.1...v0.16.2
+[0.16.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.13.0...v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,71 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.19.0] — 2026-08-16
+
+Phase 1's scope gate fired on a bump that never left the manifest and the
+lockfile (#43). Same family as #19 and the same shape — the gate stopping the
+audit for a reason that is not true, in language that reads exactly like a bump
+reaching into source. #19 was a rewritten base; this is a **human commit on the
+bot's own branch**.
+
+### The replay
+
+`fpga-board-sim` #334, `ruff` 0.15.22 → 0.16.0. Three commits above the base, and
+Phase 0 already printed `HUMAN` against two of them:
+
+| | Files gated on |
+|---|---|
+| 0.18.0 — `git diff $BASE_SHA..pr-334` | **8**: 6 docs, `pyproject.toml`, `uv.lock` → gate fires → Hold |
+| 0.19.0 — the bot's own commits | **2**: `pyproject.toml`, `uv.lock` → gate does not fire |
+| reported separately — the human commits | the 6 docs, as their own finding |
+
+The six files are `8a5f2e130`, *"style: reformat docs for ruff 0.16's markdown
+code-fence formatting"* — a maintainer landing the reformat the bump requires, on
+the bot's branch, so a required check passes again. Merging it is correct.
+
+**The signal was already derived and then thrown away.** Phase 0 reads the
+authorship of every commit above the base; Phase 1 consumed none of it and gated
+on the union. That is this file's forward-reference defect inverted — an output
+derived early and dropped.
+
+**It cost more than the verdict.** The gate stops the audit *before Phase 4*, and
+Phase 4 was the phase that would have measured this bump: ruff 0.16.0 "can now
+format Python code blocks in Markdown files and will do this by default" is this
+plugin's founding Phase 4 observation occurring for real. Phase 4 measures on the
+merge base precisely because a PR carrying the fixup reports no difference on its
+own tree. The base worktree was built, the measurement was available, and the
+gate stopped one phase short of it. Of the five PRs in that batch it is the only
+one where Phase 4 had something to find, and the only one where it did not run.
+
+**A no-op wherever the old form worked.** Replayed against #359, #355 and #332 —
+ordinary one-commit bot PRs — the bot's-commits gate returns exactly the files
+the merge-base diff returned, and `$HUMAN_COMMITS` is correctly unset.
+
+### Added
+
+- **`$BOT_COMMITS` and `$HUMAN_COMMITS`**, Phase 0 outputs. Full 40-character
+  SHAs; the report still abbreviates to nine for reading.
+
+- **A merge commit is in the human half**, not dropped. The branch-point scan
+  drops two-parent commits deliberately — `cli/cli` #14049 — and reusing that
+  filter here would be the obvious move and wrong: `git show` on a clean merge
+  prints nothing, and on an **evil** merge prints what the merge itself changed.
+
+### Changed
+
+- **An empty gate list is never emitted.** `for c in $BOT_COMMITS` over an empty
+  string iterates zero times, so the gate would pass *trivially* — clean rather
+  than erroring, on the one phase whose whole job is to refuse. Underivable is
+  emitted commented-out, and Phase 1 falls back to the whole-diff gate saying so.
+
+### Tests
+
+`TestTheScopeDiffIsSplitByAuthorship` (5) and
+`TestTheScopeGateIsAboutTheBumpNotTheBranch` (3). Mutation-checked: emitting
+unconditionally, reusing `parents == 1` for the split, keeping the `[:9]`
+truncation, and the 0.18.0 Phase 1 prose — each caught by 2–3 cases.
+
 ## [0.18.0] — 2026-08-16
 
 Phase 0 read the repo's own gate list out of the **working tree** (#44). Every
@@ -1882,7 +1947,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.1...v0.16.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,74 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.20.0] — 2026-08-16
+
+Phase 2's prose and Phase 7's table disagreed about the case Phase 2 was written
+for (#42). Phase 2: *"What outranks the hold is what this phase reads for next: a
+`Security` entry or a destructive-fix bug in the gap."* Phase 7's security row
+was gated on `and the gap is outside the cooldown`, so on a gap **inside** the
+window it could not match, and the fall-through landed on *"Merge as-is. Do not
+offer a follow-up"* — the opposite instruction.
+
+### The replay
+
+`fpga-board-sim` #355 and #359, both `rumdl`, three days apart. Publish times
+from PyPI, PR open times from the API:
+
+| | #355 | #359 |
+|---|---|---|
+| proposed | 0.2.43 → **0.2.47** | 0.2.49 → **0.2.52** |
+| opened | 2026-08-03T13:11:49Z | 2026-08-10T13:11:23Z |
+| the evidence in the gap | 0.2.49's `Security` section, published 16h54m before the PR opened | 0.2.53's `md084` / `md038` destructive fixes, 7h13m before |
+| cooldown | **inside** | **inside** |
+| OSV / GHSA / CVE | none — `audit.py` clean across 37 packages | none |
+| does this repo exercise it | **no** — `[tool.rumdl]` inline, `extends` count 0 | **yes** — `entry: uv run rumdl check --fix` |
+| 0.19.0's verdict | merge, do **not** follow up | merge, do **not** follow up |
+| 0.20.0's verdict | merge, then follow up on the merits | merge, then follow up **at once** |
+| what the maintainer did | — | merged, followed up four minutes later |
+
+Three defects in those rows, not one. **Destructive-fix bugs had no row at all**,
+though Phase 2 ranks them equal to `Security` entries — the only evidence class
+this procedure finds that no security feed carries. And **the recommendation
+turned on when you ran the audit**: replayed today, 0.2.49 is outside the window,
+the old row 3 matches, and identical evidence produces the opposite advice.
+Phase 7's stated reason for having a table at all is that leaving the function
+implicit is how two audits with the same evidence reach different
+recommendations.
+
+### Changed
+
+- **Three rows replace one, and none of them reads the clock.** The cooldown
+  decides Hold-versus-follow-up; it never decides whether to look. The wait
+  exempts Dependabot's *security updates* — the advisory-driven kind — not a
+  version update whose changelog happens to carry a privately disclosed fix.
+
+- **"Exercises the affected path" moved from the prose into the row**, where a
+  verdict rule reads it. It was doing real work in both measured cases and no
+  verdict consumed it.
+
+- **Exposure sets the urgency of the follow-up, not the verdict.** The issue
+  proposed `Hold if the repo exercises the affected path`; replaying #359 — the
+  only exposed case measured — says otherwise. The gap is *newer* than what the
+  PR proposes, so the bump moves toward the fix and never away: holding #359
+  leaves the repo on 0.2.49, carrying **both** destructive bugs, rather than
+  0.2.52 carrying neither more of them. Its maintainer merged and followed up
+  four minutes later. Hold is kept for the one configuration where merging is
+  what increases exposure — the bump moving *into* the bug, adopted version
+  affected where the current pin is not.
+
+- **Phase 2 asks the exposure question for `Security` entries too**, not only for
+  destructive fixes. Same `grep`, and Phase 7 now takes a verdict from it.
+
+- **The report template's Security row** carries the exposure answer and the
+  config line that settles it.
+
+### Tests
+
+`TestSecurityEvidenceOutranksTheCooldown`, three guards, asserted on the parsed
+verdict table rather than on the phase text. Mutation-checked against the 0.19.0
+table: all three fire.
+
 ## [0.19.0] — 2026-08-16
 
 Phase 1's scope gate fired on a bump that never left the manifest and the
@@ -1947,7 +2015,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.19.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.16.2...v0.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,82 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.21.0] — 2026-08-16
+
+`ATTRIBUTABLE` is the only one of Phase 6's three labels that produces a **Hold**,
+and it said the least about its own evidence (#41). `PRE-EXISTING` ships with a
+caveat and `underivable` gets a paragraph in `SKILL.md`; attribution was a bare
+assertion.
+
+### The replay
+
+`fpga-board-sim` #332, `actions/checkout` 7.0.0 → 7.0.1. What 0.20.0 printed:
+
+```
+RED  Board-data drift  FAILURE  [CheckRun]
+     ATTRIBUTABLE — green at 3a5b0b4ed (pr-<N>^)
+```
+
+Every cell true. The causal reading it invites is false. That job re-syncs
+generated board sources from **other people's repositories** through the API and
+requires a zero diff; the cause was an upstream ref moving, fixed in that repo's
+own #335 and #336. `actions/checkout` 7.0.1 is "skip running unsafe pr check if
+input is default", "trim only ascii whitespace for branch" and "escape values
+passed to `--unset`" — none of which changes what `litex-boards` serves.
+
+**The comparison could not have settled it.** `pr-332^` is from
+2026-07-23T20:07:40Z, the head from 2026-07-27T13:09:25Z: **3d 17h**, on a check
+whose inputs live upstream. That is the asymmetry, and it is the whole finding:
+
+| Label | Survives a wide interval? |
+|---|---|
+| `pre-existing` | **yes.** If the check was already red the bump is exonerated, whatever else moved |
+| `attributable` | **no.** Green-then-red across 3d 17h is equally consistent with the bump, an upstream change, a runner image roll, or a flake |
+
+The two are not equally strong evidence and were presented as though they were.
+
+**No Hold fired only because `Board-data drift` is not required.** Phase 7's row
+reads "a red **required** check labelled attributable → Hold", so had the repo
+marked it so, this would have Held a security backport released across six majors
+inside 34 minutes, on an upstream board-data change. The guard was the audited
+repo's branch-protection configuration, not anything in the procedure.
+
+### Added
+
+- **The interval travels with the row.** `ATTRIBUTABLE — green at 3a5b0b4ed
+  (pr-<N>^), 3d 17h earlier`, live on #332. Minutes apart on a one-commit bot PR
+  is a strong claim; most of a week is not, and the reader cannot discount what
+  they are not shown.
+
+- **A hedge on the attributable row**, as the other two labels carry: *green-then-
+  red across that interval is CONSISTENT WITH the bump, not proof of it. Read the
+  failing step's log at both commits before this row carries a Hold — especially
+  where the check has inputs outside this repo.* The rule was already in
+  `SKILL.md`, sitting under the *pre-existing* discussion where the reader has
+  been told what to conclude; nothing on the attributable path prompted it.
+
+- **`interval underivable`** rather than silence when a timestamp cannot be read.
+  A missing interval must not be indistinguishable from a tight one — that is the
+  original complaint reproduced inside the fix.
+
+### Changed
+
+- **Phase 7's Hold row keeps the verdict and drops the causal claim.** A red
+  required check blocks the merge either way; what needed qualifying was the
+  report saying the bump *caused* it.
+
+- **`_gh_soft`**, for reads that qualify a row rather than establish one. The
+  interval is a hedge on a claim, so a failed read weakens the row and must never
+  turn Phase 6 into an exit 2. Two calls, and only when a red row exists to
+  qualify.
+
+### Tests
+
+`TestAnAttributableRowSaysWhatItRestsOn` (5) and
+`TestTheAttributableLabelIsHedgedLikeTheOthers` (3). Mutation-checked: hedging
+the pre-existing row identically, making a failed date read fatal, printing
+nothing for an underivable interval, and the 0.20.0 prose.
+
 ## [0.20.0] — 2026-08-16
 
 Phase 2's prose and Phase 7's table disagreed about the case Phase 2 was written
@@ -2015,7 +2091,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.17.0...v0.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,43 @@ rebase not re-triggering CI. Promoting those into Phase 6 versus retiring the
 file changes what a phase verifies, so it belongs in its own release behind the
 replay gate rather than in this entry.
 
+## [0.21.1] — 2026-08-16
+
+`claude plugin eval` does not refuse at exit 0. Re-checked while answering "how
+will I know when it opens up", and the answer needed the refusal's shape to be
+right (#32).
+
+Measured directly on `claude` 2.1.233, no pipe, on both the run path and `init`:
+
+```
+$ claude plugin eval dependabot-audit >out 2>err
+$ echo $?
+1
+$ cat out          # empty
+$ cat err
+`plugin eval` is currently in early access
+```
+
+Two corrections, and the second inverts the argument built on the first:
+
+- **It exits 1**, not 0.
+- **The refusal is on stderr and stdout is empty.** So *"a CI step written from
+  the help text goes green while running nothing"* is backwards — at exit 1 that
+  step goes red, the safe direction. The real hazard is the undocumented one: a
+  check that greps the subcommand's **output** sees a clean empty result.
+
+**How the wrong reading arose**, reproduced: `claude plugin eval … | head` returns
+`head`'s status, which is 0. That is `SKILL.md` Phase 5's own trap — *"`cmd | tail
+&& next` gates on `tail`, so a failing suite sails through"* — landing on the
+measurement that argues for measuring. Whether the code was 0 then and is 1 now,
+or was always 1 with the pipe hiding it, is not separable after the fact; the
+claim is false today either way.
+
+Corrected in `README.md`, `CONTRIBUTING.md` and `tests/test_skill_prose.py`'s
+module docstring. Nothing else in #32 changes — the ten cases, the `live.yml`
+placement and the "not an oracle for a new rule" boundary all stand, and the
+suite is still blocked.
+
 ## [0.21.0] — 2026-08-16
 
 `ATTRIBUTABLE` is the only one of Phase 6's three labels that produces a **Hold**,
@@ -2091,7 +2128,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.1...HEAD
+[0.21.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.18.0...v0.19.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,10 +228,13 @@ gaps** — treating the suite's green as coverage of either is the mistake:
   `claude plugin eval`, still unavailable on this account. The README says so and
   should keep saying so — and note *how* it is unavailable, because the shape is
   this repo's own theme: the subcommand exists, prints a full `--help`, and then
-  refuses with ``plugin eval` is currently in early access` **at exit 0**. A CI
-  step written from the help text passes while running nothing. Verify by
-  invoking it, not by reading `--help`; that distinction cost a wrong claim in
-  0.12.0's first draft.
+  refuses with ``plugin eval` is currently in early access` **on stderr, with an
+  empty stdout**, at exit 1. A check written from the help text has nothing to
+  grep and reports a clean empty result; the exit code is the only signal.
+  Verify by invoking it, not by reading `--help` — and **not through a pipe**:
+  this claim read *"at exit 0"* until 2026-08-16, measured as
+  `claude plugin eval … | head`, which returns `head`'s status. Phase 5's own
+  trap, landing on the measurement that argues for measuring.
 
   When it does open up, know in advance what it will and will not discharge. It
   can replay PRs whose right answer a human already established and grade whether

--- a/README.md
+++ b/README.md
@@ -304,15 +304,20 @@ graders, ablation arms, cost ceilings, thresholds — which reads exactly like a
 feature you can use. Invoking it does not:
 
 ```
-$ claude plugin eval dependabot-audit
-`plugin eval` is currently in early access
+$ claude plugin eval dependabot-audit >out 2>err
 $ echo $?
-0
+1
+$ cat out          # empty — the refusal is on stderr
+$ cat err
+`plugin eval` is currently in early access
 ```
 
-**It exits 0.** So a CI step added on the strength of the help text would go
-green while running nothing at all — the same shape as every other failure this
-repo collects, arriving in the tool that was supposed to close the gap. Checked
+**The refusal goes to stderr, and stdout is empty.** So a CI step added on the
+strength of the help text has nothing to grep: a check written against the
+subcommand's output sees a clean, empty result and reports on it. The exit code
+is the only signal, which is the same lesson `SKILL.md` Phase 5 carries about
+`cmd | tail && next` — and this claim used to read *"it exits 0"* here, taken
+through a `| head` that returned `head`'s status rather than `claude`'s. Checked
 0.12.0; worth re-checking rather than assuming, in either direction.
 
 That gap is real, and it is where the defects keep turning up. Seven have now

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -710,9 +710,37 @@ row in three states, never two:
 
 | At `pr-<N>^` | Label | What it means for the verdict |
 |---|---|---|
-| the same check is green | **attributable** | the bump is implicated; this row can carry a Hold |
+| the same check is green | **attributable** | the bump is *implicated*, not convicted. Read the interval the comparison spans, and the failing step's log at **both commits**, before this row carries a Hold |
 | the same check is red | **pre-existing** | the tree the bump landed on was already red. A real finding, a *different* one, and it must not produce a Hold on this bump |
 | **no run at the base**, or no check by that name | **underivable**, per Phase 0 | say so rather than defaulting to attributable |
+
+**The three labels are not equally strong evidence, and the interval is why.**
+`pre-existing` survives any gap between the two commits: if the check was already
+red, the bump is exonerated regardless of what else moved in between.
+`attributable` does not. Green-then-red across days is consistent with the bump,
+with an upstream change, with a runner image roll, or with a flake — and this
+comparison distinguishes none of them. The script prints the span for that
+reason, and prints `interval underivable` rather than nothing when it cannot, so
+a missing interval never reads as a tight one:
+
+```
+RED  Board-data drift  FAILURE  [CheckRun]
+     ATTRIBUTABLE — green at 3a5b0b4ed (pr-<N>^), 3d 17h earlier
+```
+
+Measured on `actions/checkout` 7.0.0 → 7.0.1. Every cell true; the causal reading
+false. The failing job re-syncs generated sources from **other people's
+repositories** and requires a zero diff, so its inputs are outside this repo
+entirely — an upstream ref had moved, and 7.0.1 is three argument-handling fixes.
+No Hold fired only because that check is not required; had it been, this table
+would have Held a security backport released across six majors inside 34 minutes.
+The guard was the audited repo's configuration, not this procedure.
+
+That is the pre-existing argument pointed the other way. A Hold on an unread
+attributable row is unfalsifiable in exactly the same manner — an evidence table
+saying a check is red, which is true, while implying a cause it never
+established — and it is the direction that costs least to be wrong in, so nobody
+goes back and checks.
 
 **`pr-<N>^` and `$BASE_SHA` are the same commit for a genuine one-commit bot PR**,
 which is the ordinary case — so preferring the parent costs nothing there and is
@@ -851,7 +879,7 @@ recommendations. Read the table top-down and take the **first** row that matches
 | Actions: the tag rolled **behind** the proposed SHA | **Hold.** Close the bot's PR and replace it by hand; a bot cannot express a downgrade |
 | Phase 4: base differs, PR differs — the change is real and unabsorbed | **Hold** |
 | Phase 5: the frozen install failed, or a repo gate failed | **Hold** |
-| A red required check labelled **attributable** | **Hold** |
+| A red **required** check labelled **attributable** | **Hold** — the PR cannot merge either way. But read the failing step's log at **both commits** before the report says the bump *caused* it: green-then-red is consistent with the bump, not proof, and the wider the interval the weaker the claim |
 | A red required check labelled **pre-existing** | **Not a Hold on this bump.** Report it as its own finding, take the verdict from the remaining evidence, and say the PR is unmergeable until someone fixes it |
 | Phase 4: base differs, PR agrees — real and already absorbed | **Merge as-is**, naming what the PR absorbed and how |
 | `mergeStateStatus: BLOCKED` with every check green | **Merge as-is** on the bump's merits; name what blocks it, usually `reviewDecision` |

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -129,16 +129,45 @@ git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
 ```
 
+**An actions bump consumes neither worktree — do not create them for one.**
+`references/actions.md` reads the diff with `git show "pr-<N>:…"` throughout,
+Phase 4 reads release notes, and Phase 5's substitute is `gh run list`. Two
+worktrees added and removed for nothing, on every actions bump. The **fetch**
+stays either way: `git show` needs the ref, and Phase 7 still has a branch to
+remove. Where the ecosystem is not yet known, the scope diff settles it and costs
+one command.
+
 And the part no script can read for you — the bot's configuration, which decides
-whether a currency gap in Phase 2 is lag or a deliberate hold:
+whether a currency gap in Phase 2 is lag or a deliberate hold, and the repo's
+**own** verification commands. That stays here for the same reason the mutations
+do: `pytest` may be `uv run pytest`, `tox`, `nox`, or a `make` target, and only
+the workflow says so.
+
+**Read every one of them at a ref.** The rest of Phase 0 is pinned to the PR and
+these were not — they ran in the user's checkout, so the answers came from
+whatever branch happened to be there:
 
 ```bash
-cat .github/dependabot.yml 2>/dev/null || cat renovate.json 2>/dev/null
+git show "pr-<N>:.github/dependabot.yml" 2>/dev/null || git show "pr-<N>:renovate.json"
+git show "pr-<N>:.github/workflows/<ci>.yml"       # the gates Phase 5 reproduces
+git show "pr-<N>:.pre-commit-config.yaml"
+git show "$BASE_SHA:.github/workflows/<ci>.yml"    # the gates Phase 4 measures with
 ```
 
-Then read the CI workflow and the pre-commit config to learn the repo's **own**
-verification commands. That stays here for the same reason: `pytest` may be
-`uv run pytest`, `tox`, `nox`, or a `make` target, and only the workflow says so.
+**Each phase's gates come from the tree it runs them in**, and the two trees are
+not the same one: Phase 5 reproduces in `$SCRATCH/pr-<N>`, Phase 4 measures in
+`$SCRATCH/base-<N>` — or `$SCRATCH/tip-<N>`. One list run in both manufactures
+this phase's own worst outcome, an **exit 2** that reads downstream as a gate
+*failure*. Observed auditing a merged bump: the checkout's `ci.yml` listed
+`uv run actionlint`, which arrived three PRs later, so in the PR's worktree it
+could not spawn — "could not run" reported as "ran and found something", by the
+procedure that is most careful about that distinction everywhere else.
+
+**A gate on only one side of the bump is itself a finding**, and it is quiet in
+both directions. A gate since *removed* runs against a tree that never had it; a
+gate the PR *adds* never runs at all — and the second is the one that matters,
+because an actions or tooling bump can legitimately add its own. Diff the two
+lists and report the difference rather than picking a side.
 
 If `git worktree add` refuses because the path already exists, a previous run
 left it there. **Prove it still points at this PR's head before reusing it** — a
@@ -161,8 +190,9 @@ If either check fails, `git worktree remove` it and re-add.
 | `$HEAD_SHA` | the full 40-character commit under audit |
 | `$BASE_SHA` | the merge base, from GitHub's own `compare` endpoint — never a local `git merge-base` against `$DEFAULT`, which collapses onto the head once the PR lands. **And whether it is the bot's branch point**, which is a separate answer |
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
-| `$SCRATCH/pr-<N>` | worktree at the PR's head — Phase 5 reproduces in it |
-| `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below |
+| `$SCRATCH/pr-<N>` | worktree at the PR's head — Phase 5 reproduces in it. Not created for an actions bump, which consumes no worktree |
+| `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below. Same exception |
+| the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
 | `$PERMS` | this account's permissions on the repo — `admin`, `maintain`, `push`, `triage`, `pull` |
 
@@ -228,7 +258,10 @@ construction, and Phase 7 re-checks the SHA before you write.
 
 **Never audit the working tree.** Whatever branch the user happens to have checked
 out is not the PR, and a lockfile read from it is indistinguishable from one read
-from the PR — it just quietly reports no changes.
+from the PR — it just quietly reports no changes. That holds for the repo's
+**config** as much as its content: the gate list and the bot config are read
+above at a ref for exactly this reason, and they were the last two reads here that
+were not.
 
 Use a harness-provided scratch directory for `SCRATCH` if you have one; otherwise
 `mktemp -d`. **Never place it inside the repo under audit** — it pollutes
@@ -820,7 +853,9 @@ git worktree remove "$SCRATCH/base-<N>"
 git branch -D "pr-<N>"
 ```
 
-Add `$SCRATCH/tip-<N>` if Phase 0 found the base rewritten and created it.
+Remove exactly what Phase 0 created, and nothing else. Add `$SCRATCH/tip-<N>` if
+Phase 0 found the base rewritten; drop both worktree lines on an actions bump,
+where Phase 0 creates neither and only the branch is left to remove.
 
 Keeping them is reasonable when a follow-up run is likely — say so in the report,
 with the commands above, so the user knows what is there. Silently keeping them

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -493,7 +493,17 @@ adopted. Look for two things, in this order:
 - **Destructive-fix bugs.** Entries like "stop deleting…" or "no longer removes…"
   in a tool the repo runs in **write mode** (`--fix`, `--write`, `-i`) are
   data-loss bugs in a mode that runs automatically. They never appear in a
-  security feed. Check whether the repo actually invokes that write mode.
+  security feed.
+
+**Then ask whether this repo is in the change's scope**, for either kind. Phase 7
+takes the verdict from that answer, so it is a finding and not a footnote: read
+the advisory or the bug for the setting, flag or mode it lives in, and grep this
+repo's config for it. A `Security` entry whose leak path the repo never
+configures is a follow-up on the merits; a destructive fix in a write mode the
+repo runs on every commit is not. Same shape of evidence, two urgencies, and the
+distinction is one `grep` — it is the same question Phase 4 asks of an actions
+bump, where `references/actions.md` calls the answer "inert here", a result and
+not silence.
 
 ## Phase 3 — Known vulnerabilities
 
@@ -835,7 +845,9 @@ recommendations. Read the table top-down and take the **first** row that matches
 |---|---|
 | Phase 1's gate fired — scope, a provenance discrepancy, or `PUBLISHER CHANGED` | **Hold** |
 | OSV or GHSA reports a vulnerability in a version being **adopted** | **Hold** |
-| A `Security` entry in the gap, and the gap is outside the cooldown | **Hold** — or merge-then-follow-up when the fix is already in the adopted version |
+| A `Security` entry or a destructive-fix bug in the gap, and the bump moves **into** it — the version being adopted is affected where the **current pin** is not | **Hold.** Merging is what increases exposure here; take the fixed version instead |
+| A `Security` entry or a destructive-fix bug in the gap, **and this repo exercises the affected path** — cooldown notwithstanding | **Merge as-is, then follow up at once.** The bump is still an improvement; the urgency is the follow-up's |
+| A `Security` entry or a destructive-fix bug in the gap, **inert here** — cooldown notwithstanding | **Merge as-is, then follow up** on the merits. The evidence is real and the exposure is not |
 | Actions: the tag rolled **behind** the proposed SHA | **Hold.** Close the bot's PR and replace it by hand; a bot cannot express a downgrade |
 | Phase 4: base differs, PR differs — the change is real and unabsorbed | **Hold** |
 | Phase 5: the frozen install failed, or a repo gate failed | **Hold** |
@@ -845,8 +857,42 @@ recommendations. Read the table top-down and take the **first** row that matches
 | `mergeStateStatus: BLOCKED` with every check green | **Merge as-is** on the bump's merits; name what blocks it, usually `reviewDecision` |
 | Actions: the workflow file is generated (`DO NOT EDIT`) | **Merge as-is, then follow up** on the generator — this bump is transient without it |
 | A gap exists, outside the cooldown, nothing security-shaped in it | **Merge as-is, then follow up** |
-| A gap exists **inside** the cooldown window | **Merge as-is.** Do *not* offer a follow-up: it hand-lands the release the control exists to delay |
+| A gap exists **inside** the cooldown window, nothing security-shaped in it | **Merge as-is.** Do *not* offer a follow-up: it hand-lands the release the control exists to delay |
 | Everything derived, nothing above matched | **Merge as-is** |
+
+**The cooldown decides Hold-versus-follow-up. It never decides whether to look.**
+The wait exempts Dependabot's *security updates* — the advisory-driven kind — and
+not a version update whose changelog happens to carry a privately disclosed fix,
+which is exactly the evidence Phase 2 reads for. Gating those rows on the gap
+being outside the window makes them unreachable on the case they were written
+for, and the fall-through then says *merge, do not follow up*.
+
+It also makes the recommendation a function of **when you ran the audit**: the
+same PR, replayed once the release ages past three days, matches a different row
+and gets the opposite advice on identical evidence. That is the failure this
+table exists to prevent, reproduced inside the table.
+
+**"Exercises the affected path" is a grep, and it decides which row.** Both halves
+are measured, on the same dependency, three days apart:
+
+| Observed | Exposure | Verdict |
+|---|---|---|
+| a `Security` entry — config `extends` values expanded from the environment, so naming the resolved path printed environment variable values into the build log — in a repo that configures the tool inline with no `extends` anywhere | inert | merge, then follow up on the merits |
+| two destructive-fix bugs, "stop deleting line endings as invisible characters" and "stop deleting a line when trimming a multi-line code span", in a repo whose pre-commit config runs that tool's `--fix` write mode on every commit touching Markdown | live | merge, then follow up **at once** |
+
+Neither had a CVE, a GHSA, or an OSV hit — `audit.py` reported no known
+vulnerabilities across 37 packages, correctly, and the changelog was the only
+place either existed. Both were inside the cooldown.
+
+**Exposure sets the urgency of the follow-up, not the verdict**, and the reason
+is worth being exact about, because "Hold" reads as the cautious choice here and
+is not. The gap is *newer* than what the PR proposes, so the bump moves toward
+the fix and never away from it: holding the second case above leaves the repo on
+a version carrying **both** destructive bugs rather than one carrying neither
+more of them. Its maintainer merged and followed up four minutes later, which is
+what the row now says. The one configuration where Hold is right is the first
+row's — the bug lives in the version being *adopted*, so merging is the thing
+that increases exposure.
 
 **When phases disagree, this is the precedence** — and they are *expected* to
 disagree, which is why more than one of them exists:

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -106,6 +106,8 @@ defines:
 #   NAME=<name>
 #   BRANCH_POINT=<ok|rewritten|suspect|underivable>
 #   MAY_EXECUTE=<yes|no>   whether Phases 4 and 5 are authorised
+#   BOT_COMMITS=<shas>     the bot's own commits above the base — Phase 1's gate
+#   HUMAN_COMMITS=<shas>   non-bot commits on the branch — a finding, not a gate
 ```
 
 **An underivable output is emitted commented-out, so it stays unset.** That is
@@ -195,6 +197,8 @@ If either check fails, `git worktree remove` it and re-add.
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
 | `$PERMS` | this account's permissions on the repo — `admin`, `maintain`, `push`, `triage`, `pull` |
+| `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
+| `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
 
 If a later phase needs something not on this list, it belongs here rather than
 there. A phase that consumes what a later phase creates cannot be run in order,
@@ -353,6 +357,46 @@ fire on files the bump never touched — so take the diff from `pr-<N>^..pr-<N>`
 and report the rewritten base as its own finding. Firing the gate on a stale
 base is not a safe default: it stops the audit for a reason that is not true, and
 it reads in the report exactly like a bump that reaches into source.
+
+**Split the diff by authorship before you gate on it.** A bot PR's branch is not
+always all bot. A maintainer can land the fixup the bump *requires* on the bot's
+own branch, so a required check goes green again — and merging that is correct.
+Gated on the union of the branch's commits it produces a Hold, in language that
+reads exactly like a bump reaching into source.
+
+Phase 0 derived both halves, so take the gate's diff from the bot's commits and
+report the human's separately:
+
+```bash
+# what the bump itself changed — this is what the gate is about
+for c in $BOT_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
+# a maintainer's commit on the bot's branch: read it, report it, do not Hold on it
+for c in $HUMAN_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+```
+
+A merge commit is in the second list and normally prints nothing — its content
+arrived from the branch it merged. What it *does* print is what the merge itself
+changed, which is the one thing worth seeing there.
+
+**Where `$BOT_COMMITS` is unset, gate on the whole `$BASE_SHA..pr-<N>` diff and
+say the split was underivable.** That is Phase 0's third state and the old
+behaviour: the right fallback, not the right default. Never gate on an *empty*
+list — it iterates zero times and the gate passes silently, which is the one
+outcome worse than a false Hold.
+
+**Two reasons a scope diff overshoots, and they present identically.** A moved
+base (`BRANCH_POINT=rewritten`, above) and a human fixup on the bot's branch.
+Both produce a diff far past the manifest, both read in the report as a bump
+reaching into source, and they take different fixes. Observed together on one
+PR: Phase 0 printed `HUMAN` against two of three commits above the base, and
+Phase 1 gated on all three.
+
+Getting this wrong costs more than the verdict. The gate stops the audit **before
+Phase 4** — and on that PR Phase 4 was the phase that would have measured the
+bump, `ruff` 0.15.22 → 0.16.0, this phase's own founding observation occurring
+for real. Phase 4 measures on the merge base precisely because a PR carrying the
+fixup reports no difference on its own tree; the base worktree was built, the
+measurement was available, and the gate stopped one phase short of it.
 
 **This phase is a gate, not just a step.** The diff should touch **only** the
 manifest and the lockfile — or, for an actions bump, **only `uses:` lines**, in

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -29,7 +29,7 @@ named is unfalsifiable, which is the thing this whole report shape exists agains
 | **Scope** | Which files the diff touches. | this run |
 | **Provenance** | N package(s), M artifact(s): hash, size, URL, yanked status — quote the script's own counts, plus anything it reported as unreachable. | this run |
 | **Currency** | Registry latest vs. proposed, with publish time vs. PR open time. Yank and ignore-rule status. | this run |
-| **Security** | Changelog `Security` sections across the gap — including their absence. | this run *or* reused — release notes immutable |
+| **Security** | Changelog `Security` sections and destructive-fix bugs across the gap — including their absence. For each, **whether this repo exercises the affected path**, with the config line that settles it: Phase 7's verdict turns on that, not on the cooldown. | this run *or* reused — release notes immutable |
 | **Vulnerabilities** | OSV result and the ecosystem auditor's, over N packages. | this run |
 | **Behavior change** | Added rules / changed defaults, whether config is opt-in or opt-out, and what running the tool actually showed. | this run *or* reused — head `<sha>` unchanged |
 | **Local reproduction** | Frozen install *in the form that ran*, the interpreter it ran under, any fork verified but not installed, each repo gate with its exit code, test count. | this run *or* reused — head `<sha>` unchanged, worktree verified |

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -90,9 +90,9 @@ verdict is robust and why.
 
 For a follow-up: a separate branch, never a push onto the bot's branch.
 
-**Say what was left behind, on every path.** Phase 0 registers two worktrees and
-a `pr-<N>` branch in the user's repo, and it does so before the audit knows
-whether it will reach Phase 5 — so an audit that stopped at Phase 1's gate has
-exactly the same litter as one that ran to the end. Phase 7 removes them. If they
-were kept deliberately, name them here with their cleanup commands; never leave
-one registered in the user's repo unannounced.
+**Say what was left behind, on every path.** Phase 0 registers a `pr-<N>` branch
+in the user's repo, plus two worktrees on any bump that consumes them — and it
+does so before the audit knows whether it will reach Phase 5, so an audit that
+stopped at Phase 1's gate has exactly the same litter as one that ran to the end.
+Phase 7 removes them. If they were kept deliberately, name them here with their
+cleanup commands; never leave one registered in the user's repo unannounced.

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -66,6 +66,14 @@ a different finding with a different verdict. A Hold that rests on an
 unattributed red row is correct only by accident, and the report gives the reader
 no way to tell which.
 
+**An `attributable` row needs the interval too, and whether the log was read.**
+It is the label that carries a Hold, and it is the weakest of the three: a
+`pre-existing` row survives any gap between the two commits, while green-then-red
+across days is equally consistent with an upstream change, a runner image roll or
+a flake. "FAILURE — **attributable**, green at `3a5b0b4ed` 3d 17h earlier; log
+not read at either commit" is a row a reader can weigh. "FAILURE —
+**attributable**" invites a causal reading nothing established.
+
 **A pre-existing red gets a row and does not get the verdict.** Phase 7's table
 is explicit that it is not a Hold *on this bump*, so the report has two things to
 carry at once and must not collapse them: the bump's own verdict, taken from the

--- a/skills/dependabot-audit/scripts/ci_state.py
+++ b/skills/dependabot-audit/scripts/ci_state.py
@@ -39,6 +39,7 @@ import json
 import os
 import subprocess
 import sys
+from datetime import datetime
 from typing import Any, NoReturn
 
 TIMEOUT = 120
@@ -65,7 +66,7 @@ query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
   repository(owner:$owner, name:$name) {
     pullRequest(number:$number) {
       mergeable mergeStateStatus reviewDecision
-      commits(last:1) { nodes { commit { oid statusCheckRollup { state
+      commits(last:1) { nodes { commit { oid committedDate statusCheckRollup { state
         contexts(first:100, after:$cursor) {
           totalCount
           pageInfo { hasNextPage endCursor }
@@ -130,6 +131,69 @@ def _gh_lines(args: list[str]) -> list[Any]:
         fail(f"`gh {' '.join(args[:2])}` returned unparseable JSON lines: {exc}")
 
 
+def _gh_soft(args: list[str]) -> str:
+    """stdout, or "" when the call failed. For reads that qualify a row.
+
+    `_gh` exits 2 on any failure, which is right for the calls the phase cannot
+    proceed without. The attribution interval is not one of them: it is a hedge
+    on a claim rather than the claim, so a read that cannot be made must weaken
+    the row and never turn Phase 6 into a "could not run".
+    """
+    try:
+        return _gh(args)
+    except SystemExit:
+        return ""
+
+
+def committed_at(owner: str, name: str, sha: str) -> str:
+    """A commit's own timestamp, or "" — the second half of an attribution row.
+
+    The head's comes free with the rollup query; a comparison point needs this.
+    """
+    if not sha:
+        return ""
+    return _gh_soft([
+        "api", f"repos/{owner}/{name}/commits/{sha}", "--jq", ".commit.committer.date",
+    ]).strip()  # fmt: skip
+
+
+def interval(later: str, earlier: str) -> str:
+    """ "3d 17h" between two ISO-8601 timestamps, or "" if that is not derivable.
+
+    Empty covers three cases deliberately, and the caller says so rather than
+    printing a number it does not have: either timestamp missing, either
+    unparseable, and `earlier` not actually earlier — which a rebase produces,
+    since it rewrites committer dates, and where the span means nothing.
+    """
+    if not later or not earlier:
+        return ""
+    try:
+        delta = datetime.fromisoformat(later) - datetime.fromisoformat(earlier)
+    except ValueError:
+        return ""
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        return ""
+    if seconds < 60:
+        return "under a minute"
+    minutes, hours = seconds // 60 % 60, seconds // 3600
+    if hours < 1:
+        return f"{minutes}m"
+    if hours < 24:
+        return f"{hours}h {minutes}m"
+    return f"{hours // 24}d {hours % 24}h"
+
+
+def _span(span: str | None) -> str:
+    """How the interval reads in a basis line, including when it is not one.
+
+    "interval underivable" rather than silence: a missing span must not be
+    indistinguishable from a tight one, which is the same complaint that put the
+    interval on this row in the first place.
+    """
+    return f"{span} earlier" if span else "interval underivable"
+
+
 def _context(node: dict[str, Any]) -> dict[str, Any] | None:
     """Normalise the two context shapes into one, or None for an empty node.
 
@@ -162,6 +226,7 @@ def rollup(owner: str, name: str, number: int) -> dict[str, Any]:
     contexts: list[dict[str, Any]] = []
     cursor: str | None = None
     head_oid = ""
+    head_committed = ""
     total = 0
     state = ""
     pull: dict[str, Any] = {}
@@ -181,6 +246,7 @@ def rollup(owner: str, name: str, number: int) -> dict[str, Any]:
             fail(f"{owner}/{name}#{number} has no commits")
         commit = nodes[0].get("commit") or {}
         head_oid = commit.get("oid") or ""
+        head_committed = commit.get("committedDate") or ""
         rollup_obj = commit.get("statusCheckRollup")
         if not rollup_obj:
             # No checks have reported at all. A real answer, not a failure.
@@ -202,6 +268,7 @@ def rollup(owner: str, name: str, number: int) -> dict[str, Any]:
             break
     return {
         "head_oid": head_oid,
+        "head_committed": head_committed,
         "rollup_state": state,
         "merge_state": pull.get("mergeStateStatus") or "",
         "mergeable": pull.get("mergeable") or "",
@@ -249,6 +316,7 @@ def attribute(
     base: dict[str, str],
     parent_sha: str,
     base_sha: str,
+    spans: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Label one red context: attributable, pre-existing, or underivable.
 
@@ -261,15 +329,26 @@ def attribute(
     parent costs nothing in the ordinary case and is right in the case that is
     not: a branch carrying a human commit under the bot's, where the merge base
     attributes to the bump everything that happened beneath it.
+
+    **The two labels are not equally strong evidence, and the interval is why.**
+    `pre-existing` survives any gap: if the check was already red, the bump is
+    exonerated regardless of what else moved in between. `attributable` does not
+    — green-then-red across days is consistent with the bump, with an upstream
+    change, with a runner image roll, or with a flake, and this comparison
+    distinguishes none of them. So the interval travels with the row. Measured on
+    `fpga-board-sim` #332, where it was **3d 17h** on a check that re-syncs
+    generated sources from other people's repositories.
     """
+    spans = spans or {}
     name = context["name"]
     if name in parent:
         pre = parent[name] in FAILING
         return {
             "label": "pre-existing" if pre else "attributable",
             "basis": f"red at {parent_sha[:9]} (pr-<N>^) too" if pre
-            else f"green at {parent_sha[:9]} (pr-<N>^)",
+            else f"green at {parent_sha[:9]} (pr-<N>^), {_span(spans.get('parent'))}",
             "compared": "parent",
+            "span": spans.get("parent") or "",
             "weakened": False,
         }  # fmt: skip
     # The parent having no runs at all is common for an intermediate commit of a
@@ -281,12 +360,13 @@ def attribute(
         pre = base[name] in FAILING
         weakened = (
             "red before this *branch*, not this commit" if pre
-            else "a weaker claim than the parent would have given"
+            else f"a weaker claim than the parent would have given, {_span(spans.get('base'))}"
         )  # fmt: skip
         return {
             "label": "pre-existing" if pre else "attributable",
             "basis": f"no runs at pr-<N>^; compared against $BASE_SHA {base_sha[:9]} — {weakened}",
             "compared": "base",
+            "span": spans.get("base") or "",
             "weakened": True,
         }
     return {
@@ -295,6 +375,7 @@ def attribute(
         "predate the workflow, its run may have aged out, or the check may simply "
         "be named something else there",
         "compared": "none",
+        "span": "",
         "weakened": False,
     }
 
@@ -370,6 +451,15 @@ def render(report: dict[str, Any]) -> None:
         if attr["label"] == "pre-existing":
             print("       A real finding, and a DIFFERENT one: it must not produce a")
             print("       Hold on this bump. The PR still cannot merge until it is fixed.")
+        if attr["label"] == "attributable":
+            # The only label that can carry a Hold, and it used to say the least.
+            # A pre-existing row survives a wide interval; this one does not, and
+            # presenting the two as equally strong evidence is what produced a
+            # Hold on `actions/checkout` 7.0.1 for an upstream board-data change.
+            print("       Green-then-red across that interval is CONSISTENT WITH the bump,")
+            print("       not proof of it. Read the failing step's log at both commits")
+            print("       before this row carries a Hold — especially where the check has")
+            print("       inputs outside this repo.")
         if attr["weakened"]:
             print("       Say the weakened basis out loud; passing it off as the")
             print("       parent's answer is the failure this comparison exists to avoid.")
@@ -414,8 +504,16 @@ def main() -> int:
     report["parent_names"] = sorted(parent) or sorted(base)
 
     analyse(report)
+    # Only worth two calls when there is a red row for them to qualify.
+    spans = {}
+    if report["red"]:
+        head_at = report["head_committed"]
+        spans = {
+            "parent": interval(head_at, committed_at(args.owner, args.name, args.parent)),
+            "base": interval(head_at, committed_at(args.owner, args.name, args.base_sha)),
+        }
     for ctx in report["red"]:
-        ctx["attribution"] = attribute(ctx, parent, base, args.parent, args.base_sha)
+        ctx["attribution"] = attribute(ctx, parent, base, args.parent, args.base_sha, spans)
 
     if args.json:
         print(json.dumps(report, indent=2))

--- a/skills/dependabot-audit/scripts/discover.py
+++ b/skills/dependabot-audit/scripts/discover.py
@@ -197,7 +197,10 @@ def branch_point(
             if index == len(commits) - 1:
                 head_is_merge = parents > 1
             above.append({
-                "sha": commit.get("sha", "")[:9],
+                # Full length. The report abbreviates for reading; Phase 1 hands
+                # these to `git show`, and Phase 0's rule against transcribing a
+                # 40-character SHA by hand is the same rule one artifact along.
+                "sha": commit.get("sha", ""),
                 "author": author or "(unknown)",
                 "parents": parents,
                 "bot": (author or "") in BOTS,
@@ -251,6 +254,11 @@ def branch_point(
         "base_sha": base_sha,
         "head_is_merge_commit": head_is_merge,
         "commits_above_base": above,
+        # Three states here too: `above` is empty both when the branch genuinely
+        # carries nothing above the base and when the call failed. Phase 1 gates
+        # on this split, and an empty gate list passes trivially — so which of
+        # the two it is has to survive to the shell output.
+        "commits_underivable": commits is None,
         "force_pushes": None if forced is None else len(forced),
     }
 
@@ -342,7 +350,12 @@ def render(report: dict[str, Any]) -> None:
         print("    commits above the base:")
         for c in bp["commits_above_base"]:
             kind = "bot" if c["bot"] else "HUMAN"
-            print(f"      {c['sha']}  parents={c['parents']}  {kind:5}  {c['subject'][:46]}")
+            print(f"      {c['sha'][:9]}  parents={c['parents']}  {kind:5}  {c['subject'][:46]}")
+        if any(not c["bot"] for c in bp["commits_above_base"]):
+            print("\n    A HUMAN commit sits on this branch. Phase 1 gates on $BOT_COMMITS,")
+            print("    not on the merge-base diff: a maintainer landing the fixup the bump")
+            print("    requires is a finding to report, and never a Hold. $HUMAN_COMMITS")
+            print("    carries the other half — read it before merging.")
 
     if bp["verdict"] == "rewritten":
         print("\n    SUBSTITUTE, and report the rewritten base as its own finding:")
@@ -429,6 +442,28 @@ def shell(report: dict[str, Any]) -> None:
     bp, cls = report["branch_point"], report["classification"]
     print(f"BRANCH_POINT={bp['verdict']}")
     print(f"MAY_EXECUTE={'yes' if cls['execute'] else 'no'}")
+
+    # Phase 1's scope gate is about what the *bump* changed, and a bot PR's
+    # branch is not always all bot: a maintainer can land the fixup the bump
+    # requires on the bot's own branch, so a required check goes green. Gating on
+    # the union calls that a Hold. Both halves are already derived above.
+    #
+    # Emitted through `state()` like every other output, and here that matters
+    # more than anywhere else: an *empty* BOT_COMMITS makes `for c in
+    # $BOT_COMMITS` iterate zero times, so the gate passes trivially — clean
+    # rather than erroring, on the one phase whose whole job is to refuse.
+    split = {
+        "BOT_COMMITS": " ".join(c["sha"] for c in bp["commits_above_base"] if c["bot"]),
+        "HUMAN_COMMITS": " ".join(c["sha"] for c in bp["commits_above_base"] if not c["bot"]),
+    }
+    for key, value in split.items():
+        if not bp["commits_underivable"] and state(value) == DERIVED:
+            print(f'{key}="{value}"')
+        else:
+            print(f"# {key} is {'underivable' if bp['commits_underivable'] else ABSENT}")
+    if bp["commits_underivable"] or state(split["BOT_COMMITS"]) != DERIVED:
+        print("#   Phase 1 gates on the whole $BASE_SHA..pr-<N> diff and reports")
+        print("#   the split as underivable. An empty gate list would pass silently")
 
 
 def main() -> int:

--- a/tests/test_ci_state.py
+++ b/tests/test_ci_state.py
@@ -52,6 +52,7 @@ def page(
     review: str = "APPROVED",
     rollup_state: str = "SUCCESS",
     oid: str = HEAD,
+    committed: str = "2026-08-01T00:00:00Z",
 ) -> dict[str, Any]:
     """One GraphQL response. `total` defaults to the node count (nothing truncated)."""
     return {
@@ -66,6 +67,7 @@ def page(
                             {
                                 "commit": {
                                     "oid": oid,
+                                    "committedDate": committed,
                                     "statusCheckRollup": {
                                         "state": rollup_state,
                                         "contexts": {
@@ -95,14 +97,24 @@ class CiStateHarness(unittest.TestCase):
         pages: list[dict[str, Any]],
         runs: dict[str, list[tuple[str, str]]] | None = None,
         statuses: dict[str, list[tuple[str, str]]] | None = None,
+        dates: dict[str, str] | None = None,
+        date_fails: bool = False,
     ) -> tuple[Any, list[str]]:
-        """A `_gh` that dispatches on the call shape, plus the call log."""
+        """A `_gh` that dispatches on the call shape, plus the call log.
+
+        `dates` serves the commit-timestamp read behind the attribution
+        interval; `date_fails` makes that one call exit 2 the way a real `gh`
+        failure does, which must weaken the row rather than end the phase.
+        """
         runs = runs or {}
         statuses = statuses or {}
+        dates = dates or {}
         calls: list[str] = []
         remaining: list[dict[str, Any]] = []
 
         def fake(args: list[str]) -> str:
+            from ci_state import fail
+
             joined = " ".join(args)
             calls.append(joined)
             if "graphql" in joined:
@@ -117,6 +129,10 @@ class CiStateHarness(unittest.TestCase):
             for sha, rows in statuses.items():
                 if f"/commits/{sha}/status" in joined:
                     return "\n".join(json.dumps({"name": n, "result": s}) for n, s in rows)
+            if "committer.date" in joined:
+                if date_fails:
+                    fail("`gh api` failed: HTTP 404")
+                return next((d for sha, d in dates.items() if f"/commits/{sha}" in joined), "")
             return ""
 
         def reset() -> None:
@@ -330,6 +346,99 @@ class TestARedCheckIsAttributedBeforeItCarriesAVerdict(CiStateHarness):
         report = self._json(fake)
         self.assertEqual(report["red"][0]["kind"], "StatusContext")
         self.assertEqual(report["red"][0]["attribution"]["label"], "pre-existing")
+
+
+class TestAnAttributableRowSaysWhatItRestsOn(CiStateHarness):
+    """`ATTRIBUTABLE` is the only label that produces a Hold, and said least.
+
+    `PRE-EXISTING` ships with a caveat and `underivable` gets a paragraph;
+    attribution was a bare assertion. Observed on `fpga-board-sim` #332,
+    `actions/checkout` 7.0.0 -> 7.0.1:
+
+        RED  Board-data drift  FAILURE  [CheckRun]
+             ATTRIBUTABLE — green at 3a5b0b4ed (pr-<N>^)
+
+    Every cell true. The causal reading it invites is false. That job re-syncs
+    generated board sources from *other people's repositories* through the API
+    and requires a zero diff; the cause was an upstream ref moving, fixed in that
+    repo's own #335 and #336. `actions/checkout` 7.0.1 is "skip running unsafe pr
+    check if input is default", "trim only ascii whitespace for branch" and
+    "escape values passed to `--unset`" — none of which changes what
+    `litex-boards` serves.
+
+    **The comparison could not have settled it.** `pr-332^` is from
+    2026-07-23T20:07:40Z and the head from 2026-07-27T13:09:25Z — **3d 17h**, on
+    a check whose inputs live upstream. `PRE-EXISTING` survives that gap: if the
+    check was already red the bump is exonerated regardless of what else moved.
+    `ATTRIBUTABLE` does not — green-then-red across 3d 17h is consistent with the
+    bump, with an upstream change, with a runner image roll, or with a flake, and
+    the comparison distinguishes none of them. That asymmetry is the defect: the
+    two labels are not equally strong evidence and were presented as though they
+    were.
+
+    No Hold fired only because `Board-data drift` is not required. Had the repo
+    marked it so, this would have Held a security backport released across six
+    majors inside 34 minutes, on an upstream board-data change. The guard was the
+    audited repo's branch-protection configuration, not anything in the procedure.
+    """
+
+    RED: ClassVar[list[dict[str, Any]]] = [check_run("Board-data drift", "FAILURE", required=True)]
+
+    def _attributable(
+        self, *, head: str = "2026-07-27T13:09:25Z", parent: str | None = None
+    ) -> Any:
+        return self._fake_gh(
+            [page(self.RED, rollup_state="FAILURE", committed=head)],
+            runs={PARENT: [("Board-data drift", "success")]},
+            dates={PARENT: parent} if parent is not None else {PARENT: "2026-07-23T20:07:40Z"},
+        )[0]
+
+    def test_the_interval_the_comparison_spans_is_printed(self):
+        """Minutes apart on a one-commit bot PR is a strong claim; most of a week
+        is not. The reader cannot discount what they are not shown."""
+        _, out, _ = self._run(self._attributable())
+        self.assertIn("ATTRIBUTABLE", out)
+        self.assertIn("3d 17h", out, "the row must say how far apart the two commits are")
+
+    def test_the_attributable_row_carries_a_hedge(self):
+        """As the other two labels do. This is the one that can carry a Hold."""
+        _, out, _ = self._run(self._attributable())
+        self.assertIn("CONSISTENT WITH", out)
+        self.assertIn("log at both commits", out)
+
+    def test_a_pre_existing_row_is_not_hedged_the_same_way(self):
+        """It survives a wide interval by construction: if the check was already
+        red, the bump is exonerated whatever else moved in between. Hedging both
+        identically would train the reader to discount the row that matters."""
+        fake, _ = self._fake_gh(
+            [page(self.RED, rollup_state="FAILURE")],
+            runs={PARENT: [("Board-data drift", "failure")]},
+            dates={PARENT: "2026-07-23T20:07:40Z"},
+        )
+        _, out, _ = self._run(fake)
+        self.assertIn("PRE-EXISTING", out)
+        self.assertNotIn("CONSISTENT WITH", out)
+
+    def test_an_underivable_interval_says_so_rather_than_reading_as_minutes(self):
+        """Phase 0's third state, one artifact along. A missing interval must not
+        be indistinguishable from a tight one — that is the whole complaint about
+        the unhedged row, reproduced in the hedge."""
+        _, out, _ = self._run(self._attributable(parent=""))
+        self.assertIn("ATTRIBUTABLE", out)
+        self.assertIn("interval underivable", out.lower())
+        self.assertIn("CONSISTENT WITH", out, "the hedge does not depend on the interval")
+
+    def test_a_failed_date_read_does_not_end_the_phase(self):
+        """The interval is a hedge on a claim, not the claim. A read that cannot
+        be made weakens the row; it must not turn Phase 6 into an exit 2."""
+        fake, _ = self._fake_gh(
+            [page(self.RED, rollup_state="FAILURE")],
+            runs={PARENT: [("Board-data drift", "success")]},
+            date_fails=True,
+        )
+        code, out, _ = self._run(fake)
+        self.assertEqual(code, 1, "a red required check is a finding, not a failure to run")
+        self.assertIn("ATTRIBUTABLE", out)
 
 
 class TestMergeStateIsReadAsThreeStates(CiStateHarness):

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -304,6 +304,121 @@ class TestTheMergeBaseSurvivesThePrHavingLanded(DiscoverHarness):
         self.assertTrue(any("$BASE_SHA is underivable" in f for f in report["findings"]))
 
 
+class TestTheScopeDiffIsSplitByAuthorship(DiscoverHarness):
+    """A bot PR's branch is not always all bot, and Phase 1 gated on the union.
+
+    `fpga-board-sim` #334: the bot's bump, then a maintainer's `style: reformat
+    docs for ruff 0.16's markdown code-fence formatting` **on the bot's own
+    branch** so a required CI check goes green again, then a merge of `main`.
+    Phase 0 read the authorship of all three and printed `HUMAN` against two.
+    Phase 1 then took its diff from the merge base, saw eight files, and fired
+    the scope gate — reported as "this bump reaches beyond the manifest and
+    lockfile", which is not what happened. Merging it was correct.
+
+    The cost is more than the wrong verdict: the gate stops the audit **before
+    Phase 4**, and Phase 4 is the phase that would have measured this very bump.
+    ruff 0.15.22 -> 0.16.0 is this plugin's founding Phase 4 observation occurring
+    for real, and Phase 4 measures on the merge base precisely because a PR
+    carrying the fixup reports no difference on its own tree. Of the five PRs in
+    that batch it is the only one where Phase 4 had something to find, and the
+    only one where it did not run.
+
+    Same family as #19 and the same shape — the gate stopping the audit for a
+    reason that is not true, in language that reads exactly like a bump reaching
+    into source. #19 was a rewritten base; this is a human commit on the bot's
+    own branch. They present identically and take different fixes.
+    """
+
+    BOT_SHA = "1" * 40
+    HUMAN_SHA = "2" * 40
+    MERGE_SHA = "3" * 40
+
+    def _mixed(self) -> Any:
+        """#334's branch shape: bot, human, then a merge of the base branch."""
+        fake, _ = self._fake(
+            commits=[
+                commit(self.BOT_SHA, BOT, subject="chore(deps-dev): Bump the python-deps group"),
+                commit(self.HUMAN_SHA, "a-human", subject="style: reformat docs for ruff 0.16"),
+                commit(
+                    self.MERGE_SHA, "a-human", parents=2, subject="Merge remote-tracking branch"
+                ),
+            ]
+        )
+        return fake
+
+    def test_the_two_halves_are_emitted_for_phase_1_to_gate_on(self):
+        _, out, _ = self._run(self._mixed(), ["--shell"])
+        self.assertIn(
+            f'BOT_COMMITS="{self.BOT_SHA}"',
+            out,
+            "the gate is about what the *bump* changed, and only the bot's own commits are that",
+        )
+        self.assertIn(
+            f'HUMAN_COMMITS="{self.HUMAN_SHA} {self.MERGE_SHA}"',
+            out,
+            "a maintainer's commit on this branch is a finding to report, not a "
+            "Hold — and it has to reach Phase 1 to be reported at all",
+        )
+
+    def test_a_merge_commit_is_carried_into_the_split_but_not_into_the_verdict(self):
+        """The commit list has two consumers and they filter differently.
+
+        The branch-point scan drops two-parent commits deliberately — someone
+        merging the base *into* the branch leaves the merge base correct, and
+        substituting there halts the audit on `cli/cli` #14049's four workflow
+        lines. Reusing that `parents == 1` filter for the authorship split would
+        be the obvious move and is wrong: `git show` on a clean merge prints
+        nothing, and on an **evil** merge prints what the merge itself changed.
+        Dropping merges makes that invisible; carrying them costs nothing.
+        """
+        _, out, _ = self._run(self._mixed(), ["--shell"])
+        self.assertIn(self.MERGE_SHA, out, "an evil merge would be invisible to Phase 1")
+        report = self._json(self._mixed())
+        self.assertEqual(
+            report["branch_point"]["verdict"],
+            "ok",
+            "and the same merge must still leave the merge base alone",
+        )
+
+    def test_the_emitted_shas_are_full_length(self):
+        """The report truncates to nine characters for reading; a ref handed to
+        `git show` is Phase 0's own rule about transcribing SHAs, one artifact
+        along. Rendered short and emitted short are different requirements."""
+        report = self._json(self._mixed())
+        self.assertEqual(report["branch_point"]["commits_above_base"][0]["sha"], self.BOT_SHA)
+        _, out, _ = self._run(self._mixed())
+        self.assertIn(self.BOT_SHA[:9], out, "the human-readable report still abbreviates")
+
+    def test_an_unreadable_commit_list_leaves_both_unset(self):
+        """Phase 0's third state. The split is underivable, not empty, and Phase
+        1's fallback is the old whole-diff gate."""
+        fake, _ = self._fake(fails=("/commits",))
+        _, out, _ = self._run(fake, ["--shell"])
+        self.assertNotRegex(out, r"(?m)^BOT_COMMITS=")
+        self.assertNotRegex(out, r"(?m)^HUMAN_COMMITS=")
+        self.assertIn("# BOT_COMMITS", out, "an underivable output is emitted commented-out")
+
+    def test_no_bot_commits_leaves_the_gate_list_unset_rather_than_empty(self):
+        """The dangerous shape, and the reason this cannot be a plain join.
+
+        `for c in $BOT_COMMITS` over an empty string iterates zero times, so the
+        file list comes back empty and the gate passes **trivially** — reporting
+        clean rather than erroring, on the one phase whose entire job is to
+        refuse. Unset instead: Phase 1 then falls back to the merge-base diff and
+        says the split was underivable.
+        """
+        fake, _ = self._fake(
+            pull_json=pull(author="someone"),
+            commits=[commit(HEAD, "someone")],
+        )
+        _, out, _ = self._run(fake, ["--shell"])
+        self.assertNotRegex(
+            out,
+            r"(?m)^BOT_COMMITS=",
+            "an empty gate list is worse than no gate list: it passes silently",
+        )
+
+
 class TestExecutionRequiresABotPrOnARepoYouControl(DiscoverHarness):
     def test_an_ordinary_bot_pr_on_your_own_repo_may_execute(self):
         fake, _ = self._fake()

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -752,6 +752,62 @@ class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
         )
 
 
+class TestTheScopeGateIsAboutTheBumpNotTheBranch(SkillHarness):
+    """Phase 1 gated on the union of every commit above the base.
+
+    A bot PR's branch is not always all bot. On `fpga-board-sim` #334 a
+    maintainer landed `style: reformat docs for ruff 0.16's markdown code-fence
+    formatting` on the bot's own branch so a required check would pass again —
+    correct, and necessary. Phase 0 read the authorship of all three commits
+    above the base and printed `HUMAN` against two of them; Phase 1 consumed
+    none of that, took its diff from the merge base, saw eight files, and Held.
+
+    An output derived early and then dropped — the inverse of the
+    forward-reference defect this suite was built for.
+
+    The cost is not only the verdict. The gate stops the audit **before Phase
+    4**, and Phase 4 was the phase that would have measured that bump: ruff
+    0.15.22 -> 0.16.0, this plugin's founding Phase 4 observation, occurring for
+    real. The base worktree was built and the measurement was available.
+    """
+
+    def test_phase_1_gates_on_the_bots_own_commits(self):
+        self.assertIn(
+            "$BOT_COMMITS",
+            self.shell[1],
+            "the gate's invariant is 'did the bump reach past the manifest and "
+            "lockfile', not 'did this branch' — and only the bot's commits are "
+            "the bump",
+        )
+
+    def test_the_human_half_reaches_phase_1_too(self):
+        """Reporting it is the other half of the fix: a maintainer commit on the
+        branch is a real thing a reader needs before merging. Suppressing it
+        would trade a false Hold for a silent omission."""
+        self.assertIn(
+            "$HUMAN_COMMITS",
+            self.shell[1],
+            "the split has two halves and dropping the second one reports less than the union did",
+        )
+
+    def test_an_underivable_split_falls_back_rather_than_passing_empty(self):
+        """`for c in $BOT_COMMITS` over an empty string iterates zero times, so
+        the file list is empty and the gate passes **trivially**. That is worse
+        than the false Hold it replaces: a gate that reports clean rather than
+        erroring, on the one phase whose entire job is to refuse."""
+        phase1 = dict(self.phases)[1].lower()
+        self.assertIn(
+            "underivable",
+            phase1,
+            "Phase 0's third state applies to the split too; an unset list is not an empty one",
+        )
+        self.assertIn(
+            "$base_sha..pr-<n>",
+            phase1,
+            "and the fallback has to name the whole-diff gate it falls back to",
+        )
+
+
 class TestTheRepoConfigIsReadAtARef(SkillHarness):
     """Phase 0 read the repo's gate list out of whatever was checked out.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -698,6 +698,80 @@ class TestARedCheckIsAttributedBeforeItCarriesTheVerdict(SkillHarness):
         self.assertIn("underivable", phase6, "and give it Phase 0's third state")
 
 
+class TestTheAttributableLabelIsHedgedLikeTheOthers(SkillHarness):
+    """The only label that produces a Hold said the least about its evidence.
+
+    #25 gave Phase 6 the base comparison and three labels. `PRE-EXISTING` ships
+    with a caveat, `underivable` gets a paragraph, and `ATTRIBUTABLE` was a bare
+    assertion. Observed on `fpga-board-sim` #332, `actions/checkout` 7.0.0 ->
+    7.0.1: `Board-data drift` red at the head, green at `pr-332^`, every cell
+    true — and the failing job re-syncs generated board sources from **other
+    people's repositories** through the API and requires a zero diff. The cause
+    was an upstream ref moving, fixed in that repo's own #335 and #336.
+
+    `pr-332^` is from 2026-07-23T20:07:40Z and the head from
+    2026-07-27T13:09:25Z: **3d 17h**. `PRE-EXISTING` survives that gap — if the
+    check was already red, the bump is exonerated regardless of what else moved.
+    `ATTRIBUTABLE` does not: green-then-red across 3d 17h is consistent with the
+    bump, with an upstream change, with a runner image roll, or with a flake, and
+    the comparison distinguishes none of them. The two labels are not equally
+    strong evidence and were presented as though they were.
+
+    This is #25's own argument pointed the other way, and no Hold fired only
+    because `Board-data drift` is not a required check. Had the repo marked it
+    required, Phase 7's table would have Held a security backport released across
+    six majors inside 34 minutes, on an upstream board-data change. The guard was
+    the audited repo's branch-protection configuration, not the procedure.
+    """
+
+    def _attribution_row(self) -> str:
+        for table in tables(dict(self.phases)[6]):
+            for row in table:
+                if "**attributable**" in row.lower():
+                    return row
+        self.fail("Phase 6 has no attributable row")
+
+    def test_the_row_does_not_read_as_a_licence_to_hold(self):
+        row = self._attribution_row().lower()
+        self.assertIn(
+            "both commits",
+            row,
+            "the pre-existing row already tells the reader what it must not do; "
+            "the attributable row is the one that can carry a Hold and said "
+            "least — it has to name the read that would settle causation",
+        )
+
+    def test_the_interval_the_comparison_spans_reaches_the_reader(self):
+        """Minutes apart on a one-commit bot PR is a strong claim; most of a week
+        is not. Both print the same sentence without it."""
+        self.assertIn(
+            "interval",
+            dict(self.phases)[6].lower(),
+            "Phase 6 must say that the interval qualifies the claim",
+        )
+        self.assertIn(
+            "CONSISTENT WITH",
+            self.reachable(6),
+            "and the script has to print the hedge, or it lives only where the "
+            "reader of the output never sees it",
+        )
+
+    def test_phase_7s_hold_row_does_not_assert_causation_by_itself(self):
+        for table in tables(dict(self.phases)[7]):
+            for row in table:
+                if "attributable" in row.lower() and "hold" in row.lower():
+                    self.assertIn(
+                        "both commits",
+                        row.lower(),
+                        "an evidence table saying a check is red — true — while "
+                        "implying a cause it never established is the same "
+                        "family as the rewritten base and the hand-joined "
+                        "required list, and this is the row that acts on it",
+                    )
+                    return
+        self.fail("Phase 7 has no verdict row for an attributable red check")
+
+
 class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
     """`--locked` checks every fork; the install materialises one of them.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -752,6 +752,80 @@ class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
         )
 
 
+class TestTheRepoConfigIsReadAtARef(SkillHarness):
+    """Phase 0 read the repo's gate list out of whatever was checked out.
+
+    Every other Phase 0 output is pinned to the PR, and the lockfile reads in
+    `references/uv-lock.md` do it properly — `git show "pr-<N>:uv.lock"`. The gate
+    read was the one that did not, and it ran in the user's working tree, so the
+    gate list came from whatever branch happened to be there.
+
+    Measured on `fpga-board-sim` #359: `ci.yml` at the checkout listed
+    `uv run actionlint`, which arrived in that repo's #362, three PRs later. Run
+    in the PR's worktree it exits 2 — `Failed to spawn: actionlint` — and reads as
+    a Phase 5 gate failure on a gate the PR never had. Exit 2 is the status this
+    procedure is most careful about everywhere else: "could not run", never "ran
+    and found something". Here the procedure manufactured one.
+
+    Auditing a merged PR makes the divergence certain — the checkout is ahead of
+    every merged PR by construction, and every replay CONTRIBUTING's gate asks for
+    is one. It is not only a replay problem: the same gap opens on an open PR
+    whenever another branch is checked out, or the default branch has moved since
+    the bot branched.
+    """
+
+    # Files whose *content the audit interprets*: the gates it reproduces, and
+    # the bot config that decides whether a currency gap is lag or a hold.
+    INTERPRETED = ("workflows/", ".pre-commit-config", "dependabot.yml", "renovate.json")
+    AT_A_REF = re.compile(r'git show "(?:pr-<N>|\$\{?BASE_SHA\}?|\$\{?DEFAULT\}?):')
+
+    def test_phase_0_reads_the_gate_list_at_a_ref(self):
+        self.assertRegex(
+            self.shell[0],
+            re.compile(r'git show "(?:pr-<N>|\$\{?BASE_SHA\}?):[^"]*(?:workflows|pre-commit)'),
+            "Phase 0 must read the repo's own gates from a ref. Read from the "
+            "checkout, the gate list is whatever happens to be there — and a gate "
+            "the PR never had exits 2, which reads as a Phase 5 failure",
+        )
+
+    def test_no_phase_reads_an_interpreted_config_out_of_the_working_tree(self):
+        """The negative half: `cat`, `grep` and friends read the checkout.
+
+        Asserted per line rather than per phase, because the defect was one line
+        sitting beside several that got it right.
+        """
+        for number, code in sorted(self.shell.items()):
+            for line in code.splitlines():
+                if not any(path in line for path in self.INTERPRETED):
+                    continue
+                self.assertRegex(
+                    line,
+                    self.AT_A_REF,
+                    f"Phase {number} reads a file the audit interprets without "
+                    f"pinning it to a ref, so it reports on the checkout rather "
+                    f"than on the PR: {line.strip()}",
+                )
+
+    def test_both_sides_of_the_bump_get_their_own_gate_list(self):
+        """Phase 4 and Phase 5 run gates in *different* trees.
+
+        One list run in both manufactures the exit 2 above in whichever tree did
+        not have that gate. And a gate present on one side of the bump and not
+        the other is itself a finding — quiet in both directions, since a gate
+        the PR *adds* never runs at all, which is the direction that matters
+        because a tooling bump can legitimately add its own.
+        """
+        shell = self.shell[0]
+        for ref, tree in (("pr-<N>", "Phase 5 reproduces"), (r"\$BASE_SHA", "Phase 4 measures")):
+            self.assertRegex(
+                shell,
+                rf'git show "{ref}:[^"]*workflows',
+                f"Phase 0 must read the gates at the ref of the tree {tree} in; "
+                f"one list serves both trees only until they differ, and the "
+                f"difference is itself the finding",
+            )
+
+
 class TestPhase4MeasuresTheRightTree(SkillHarness):
     """Measuring on the PR's tree hides the finding whenever it is real.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -13,8 +13,8 @@ gaps — a green run here is evidence of neither.
 
 Whether the model *follows* the phases is behavioral and belongs in
 `claude plugin eval`, which is unavailable on this account — the subcommand
-prints a full `--help` and then refuses at exit 0, so reading the help is not
-checking availability.
+prints a full `--help` and then refuses on stderr with an empty stdout, so
+reading the help is not checking availability and neither is grepping the output.
 
 Whether the prose is **true** is not checkable at all. Consistency is not
 correctness: every case below can pass on a phase that names a real endpoint,

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1166,6 +1166,114 @@ class TestTheVerdictIsDerivedRatherThanJudged(SkillHarness):
             self.assertIn(level, template)
 
 
+class TestSecurityEvidenceOutranksTheCooldown(SkillHarness):
+    """Phase 2's prose and Phase 7's table disagreed about Phase 2's own case.
+
+    Phase 2: "A gap inside the cooldown window does not earn a follow-up branch.
+    [...] What outranks the hold is what this phase reads for next: a `Security`
+    entry or a destructive-fix bug in the gap."
+
+    Phase 7, read top-down taking the first row that matches: the security row
+    was gated on `and the gap is outside the cooldown`, so it could not match,
+    and the fall-through landed on "a gap exists **inside** the cooldown window →
+    Merge as-is. Do *not* offer a follow-up" — the opposite of the prose.
+
+    Measured on `fpga-board-sim` #355: `rumdl` 0.2.49 carries a `Security`
+    section — config `extends` values expanded from the environment before
+    resolution, so naming the resolved path printed environment variable values
+    into the build log. Privately reported, no CVE, no GHSA; `audit.py` reported
+    "no known vulnerabilities across 37 packages", correctly. The changelog is
+    the only place it exists, which is the whole reason Phase 2 reads changelogs.
+    0.2.49 published 17 hours before the PR opened — inside the three-day
+    cooldown, so the bot was right to hold, and the gap still contained a
+    security fix.
+
+    Two more gaps in the same rows. **Destructive-fix bugs had no row at all**,
+    though Phase 2 ranks them equal: `fpga-board-sim` #359, `rumdl` 0.2.53 fixing
+    `md084: stop deleting line endings as invisible characters` and `md038: stop
+    deleting a line when trimming a multi-line code span`, in a repo whose
+    pre-commit config runs `rumdl check --fix` on every commit touching Markdown.
+    And **the recommendation turned on when you ran the audit**: replayed once
+    0.2.49 is thirteen days old the gap is outside the cooldown, row 3 matches,
+    and the same evidence produces the opposite verdict. Phase 7's own stated
+    reason for having a table is that leaving the function implicit is how two
+    audits with the same evidence reach different recommendations.
+    """
+
+    def _verdict_table(self) -> list[str]:
+        for table in tables(dict(self.phases)[7]):
+            if any("Verdict" in row for row in table):
+                return table
+        self.fail("Phase 7 has no verdict table")
+
+    def _security_rows(self) -> list[tuple[int, str]]:
+        """Rows that positively *read* security-shaped evidence in the gap.
+
+        Matched on the evidence named rather than on the word "security", which
+        also appears in the row for a gap containing **nothing** security-shaped
+        — and that row is legitimately conditioned on the cooldown.
+        """
+        return [
+            (i, row)
+            for i, row in enumerate(self._verdict_table())
+            if "`security` entry" in row.lower() or "destructive-fix" in row.lower()
+        ]
+
+    def _cooldown_row(self) -> int:
+        for i, row in enumerate(self._verdict_table()):
+            low = row.lower()
+            if "inside" in low and "cooldown" in low:
+                return i
+        self.fail("Phase 7 has no row for a gap inside the cooldown")
+
+    def test_the_evidence_is_read_whatever_the_cooldown_says(self):
+        """The cooldown decides Hold-vs-follow-up, never whether to look."""
+        rows = self._security_rows()
+        self.assertTrue(rows, "no row reads a Security entry in the gap")
+        self.assertLess(
+            min(i for i, _ in rows),
+            self._cooldown_row(),
+            "a security-shaped row below the cooldown row is unreachable: the "
+            "table is first-match, and every gap inside the window stops there",
+        )
+        for _, row in rows:
+            self.assertNotIn(
+                "outside the cooldown",
+                row.lower(),
+                "gating the *reading* of a Security entry on the cooldown routes "
+                "Phase 2's founding case to 'do not follow up' — the cooldown "
+                "exempts Dependabot's security updates, not a version update "
+                "whose changelog carries a privately disclosed fix",
+            )
+
+    def test_a_destructive_fix_bug_reaches_the_table_at_all(self):
+        """Phase 2 ranks them equal to `Security` entries. Phase 7 never
+        mentioned them, so the only evidence class this procedure discovers that
+        no security feed carries had no verdict rule."""
+        self.assertIn(
+            "destructive",
+            " ".join(self._verdict_table()).lower(),
+            "a data-loss bug in a write mode the repo runs automatically is "
+            "Phase 2's second reading target and had no row",
+        )
+
+    def test_the_row_decides_on_exposure_rather_than_on_the_clock(self):
+        """ "if the repo exercises the affected path" was doing real work in both
+        measured cases and sat in the prose, where no verdict reads it: #355's
+        leak path is inert (the repo configures rumdl inline, with no `extends`
+        anywhere), #359's `--fix` write mode is live on every Markdown commit.
+        Same shape of finding, two urgencies, and the distinction is a grep the
+        phase already knows how to do."""
+        rows = " ".join(row for _, row in self._security_rows()).lower()
+        self.assertIn(
+            "affected path",
+            rows,
+            "the verdict has to turn on whether this repo is exposed; taking it "
+            "from the calendar makes the same evidence produce opposite "
+            "recommendations on different days",
+        )
+
+
 class TestFrontmatter(SkillHarness):
     """0.1.9 shipped `tools:`, which is not a field and withheld nothing.
 


### PR DESCRIPTION
Four findings from auditing `Machai-Kydoimos/fpga-board-sim` #332, #334, #355 and
#359 with 0.17.0. Each gets its own commit and its own minor bump, because each
changes what a phase verifies or what the report asserts.

| | Issue | What the old behaviour did when it ran |
|---|---|---|
| **0.18.0** | #44 | Phase 0 read the repo's gate list out of the **working tree**, so an audit ran a gate the PR never had and got exit 2 — "could not run" reported as a Phase 5 gate failure |
| **0.19.0** | #43 | Phase 1's scope gate fired on a **human** commit sitting on the bot's branch, Holding a bump that never left the manifest and lockfile — and stopping the audit one phase short of the measurement that mattered |
| **0.20.0** | #42 | Phase 7's `Security` row was gated on the gap being *outside* the cooldown, so it could not match, and the fall-through said "merge, do **not** follow up" — the opposite of Phase 2's prose. Destructive-fix bugs had no row at all |
| **0.21.0** | #41 | `ATTRIBUTABLE` — the only label that produces a **Hold** — shipped as a bare assertion, with no interval and no hedge, on a comparison spanning 3d 17h |

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim` #332, #334, #355, #359
- [x] Replayed against `BIRSAx2/mdcat` #6 (the pre-existing control)

What it showed — pasted, not summarised.

**#44 — the gate list, read three ways.** `actionlint` arrived in that repo's
#362, three PRs *after* the one under audit:

```
=== gates in the CHECKOUT (main @ bddcc47) ===
      - run: uv run ruff check .
      - run: uv run ruff format --check .
      - run: uv run mypy .
      - run: uv run rumdl check .
      - run: uv run actionlint
      - run: uv run python scripts/check_board_drift.py

=== gates at pr-359 ===            === gates at pr-359's merge base ===
      - run: uv run ruff check .         (identical five — no actionlint)
      - run: uv run ruff format --check .
      - run: uv run mypy .
      - run: uv run rumdl check .
      - run: uv run python scripts/check_board_drift.py
```

**#43 — the scope gate, before and after.** #334, three commits above the base,
two of them `HUMAN`:

```
=== OLD gate: git diff $BASE_SHA..pr-334 ===
 8 files changed, 283 insertions(+), 170 deletions(-)

=== NEW gate: the bot's own commits ===
pyproject.toml
uv.lock

=== reported separately: the human commits ===
CONTRIBUTING.md
docs/7seg_display_plan_v2.md
docs/docs_assets_improvement_plan.md
docs/embedded_core_system_guide.md
docs/u34_single_window_plan.md
docs/u9_led_complete_plan.md
```

A no-op wherever the old form worked — #359, #355 and #332 are ordinary
one-commit bot PRs, and the new gate returns exactly the files the merge-base
diff returned with `$HUMAN_COMMITS` unset.

**And the payoff.** The gate used to stop the audit before Phase 4. With it
fixed, Phase 4 runs on #334 and finds what the gate was hiding:

```
  locked       exit 0   touched 0 file(s)
               uv run --no-project --with ruff==0.15.22 ruff format .
  proposed     exit 0   touched 6 file(s)
               uv run --no-project --with ruff==0.16.0 ruff format .

=== proposed vs locked
  +      CONTRIBUTING.md   acted on by proposed only — widened scope or a new rule
  +      docs/7seg_display_plan_v2.md   acted on by proposed only — widened scope or a new rule
  +      docs/docs_assets_improvement_plan.md   acted on by proposed only — widened scope or a new rule
  +      docs/embedded_core_system_guide.md   acted on by proposed only — widened scope or a new rule
  +      docs/u34_single_window_plan.md   acted on by proposed only — widened scope or a new rule
  +      docs/u9_led_complete_plan.md   acted on by proposed only — widened scope or a new rule

RESULT: GATES DIFFER
```

Identical exit 0 on both versions, and the six files are **exactly** the six the
maintainer had hand-reformatted onto the branch. That is this plugin's founding
Phase 4 observation, occurring for real, on the one PR in the batch where the
gate refused to let Phase 4 run.

**#42 — the two rumdl cases.** Publish times from PyPI, open times from the API:

```
#355  0.2.43 -> 0.2.47, opened 2026-08-03T13:11:49Z
      gap carries 0.2.49's `Security` section, published 16h54m earlier — INSIDE cooldown
      no CVE, no GHSA; audit.py clean over 37 packages
      [tool.rumdl] inline, `extends` count 0                        -> INERT here

#359  0.2.49 -> 0.2.52, opened 2026-08-10T13:11:23Z
      gap carries 0.2.53's md084/md038 destructive fixes, 7h13m earlier — INSIDE cooldown
      `entry: uv run rumdl check --fix` in .pre-commit-config.yaml   -> LIVE here
```

0.19.0 said "merge, do not follow up" on both. 0.21.0 traces #355 to *follow up
on the merits* and #359 to *follow up at once*, which is what that repo's
maintainer did — four minutes after merging.

**One deliberate divergence from #42's proposed row.** It asked for
`Merge as-is, then follow up — Hold if the repo exercises the affected path`.
Replaying #359, the only exposed case measured, says otherwise: the gap is
*newer* than what the PR proposes, so the bump moves toward the fix and never
away from it. Holding #359 leaves the repo on 0.2.49 carrying **both**
destructive bugs rather than 0.2.52 carrying neither more of them. So exposure
sets the urgency of the follow-up, and Hold is kept for the one configuration
where merging is what increases exposure — the bump moving *into* the bug,
adopted version affected where the current pin is not.

**#41 — the attributable row, before and after.** #332, `actions/checkout`
7.0.0 → 7.0.1:

```
  RED  Board-data drift  FAILURE  [CheckRun]
       ATTRIBUTABLE — green at 3a5b0b4ed (pr-<N>^), 3d 17h earlier
       Green-then-red across that interval is CONSISTENT WITH the bump,
       not proof of it. Read the failing step's log at both commits
       before this row carries a Hold — especially where the check has
       inputs outside this repo.
```

`pr-332^` is from 2026-07-23T20:07:40Z and the head from 2026-07-27T13:09:25Z.
The failing job re-syncs generated board sources from other people's
repositories and requires a zero diff; the cause was an upstream ref moving,
fixed in that repo's own #335 and #336. No Hold fired only because
`Board-data drift` is not a required check — had it been, this would have Held a
security backport released across six majors inside 34 minutes.

The `mdcat` #6 control confirms the pre-existing row is unchanged and does *not*
pick up the new hedge:

```
  RED  test (ubuntu-latest)  FAILURE  [CheckRun]
       PRE-EXISTING — red at b1b0dd4c1 (pr-<N>^) too
       A real finding, and a DIFFERENT one: it must not produce a
       Hold on this bump. The PR still cannot merge until it is fixed.
```

Hedging both identically would train the reader to discount the row that matters.

## Tests

223 total, up from 204. Four new classes, 19 cases, every one mutation-checked
against the prose or code it guards — listed per release in `CHANGELOG.md`. Two
worth naming, because both were written from the fix and had to be corrected
from a measurement:

- the verdict-table guard first matched any row containing "security", which also
  caught the row for a gap containing *nothing* security-shaped — a row that is
  legitimately conditioned on the cooldown;
- `test_no_bot_commits_leaves_the_gate_list_unset_rather_than_empty` passed
  vacuously until the emission existed, and only discriminates because
  `discover.py` refuses to emit an empty `$BOT_COMMITS`. An empty gate list
  iterates zero times and passes **silently**, which is worse than the false
  Hold it replaces.

## Also, unplanned: 0.21.1

Re-checking `claude plugin eval` for #32 while answering a question about it
turned up a false claim asserted in three places — `README.md`,
`CONTRIBUTING.md`, and `tests/test_skill_prose.py`'s docstring:

```
$ claude plugin eval dependabot-audit >out 2>err
$ echo $?
1
$ cat out          # empty — the refusal is on stderr
$ cat err
`plugin eval` is currently in early access
```

It exits **1**, not 0, and the message is on **stderr** with an empty stdout. So
*"a CI step written from the help text goes green while running nothing"* is
backwards; at exit 1 it goes red. The real hazard is the undocumented one — a
check that greps the subcommand's output sees a clean empty result.

The wrong reading reproduces exactly as `claude plugin eval … | head`, which
returns `head`'s status. Phase 5's own trap, landing on the measurement that
argues for measuring. Detail on #32.

Closes #44, closes #43, closes #42, closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
