### PR TITLE
fix: match the PyPI registry host, not a URL prefix (0.22.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ patch.
 
 ## [Unreleased]
 
+## [0.22.0] — 2026-08-16
+
+### Fixed
+
+- **A registry host that merely *starts with* `https://pypi.org` is no longer
+  taken for PyPI.** `_is_pypi` tested the URL with
+  `startswith("https://pypi.org")`, so `https://pypi.org.evil.com/simple` passed
+  it. Found by CodeQL (`py/incomplete-url-substring-sanitization`) once code
+  scanning was made a required check.
+
+  **The damage was silence, not a bad hash.** Artifacts are fetched from the
+  `SIMPLE` constant regardless of what the lockfile names, so a look-alike index
+  was still compared against the real pypi.org and a substituted artifact would
+  still have failed. What the prefix match cost was the *other* half of the
+  report: classifying the package as PyPI-sourced kept it out of `non_pypi`, and
+  `non_pypi` exists precisely so that a dependency this script cannot verify is
+  named rather than dropped. Run against a lockfile carrying such an entry, the
+  old code printed `RESULT: CLEAN — 1 package(s) NOT checked … fpga-simulator`
+  and never mentioned the look-alike at all — it even reached OSV as though it
+  were a real PyPI package. An under-audit indistinguishable from a clean one,
+  which is the failure `non_pypi`'s own docstring names.
+
+  Now `urllib.parse.urlsplit` is used and the **host is compared exactly**, with
+  the scheme required to be `https`. A look-alike index falls into `non_pypi`
+  and is reported as not checked, which is the honest answer.
+
 ### Decided
 
 - **The evidence split is dropped**, closing 0.15.0's *Not done, deliberately*.
@@ -2128,7 +2154,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.19.0...v0.20.0

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -574,7 +574,14 @@ def load_lock(path: str) -> list[dict[str, Any]]:
 
 
 def _is_pypi(pkg: dict[str, Any]) -> bool:
-    return str(pkg.get("source", {}).get("registry", "")).startswith("https://pypi.org")
+    # The host is matched, not the prefix. `startswith("https://pypi.org")` also
+    # accepted `https://pypi.org.evil.com/simple`, and the damage was silence
+    # rather than a bad hash: artifacts are fetched from the `SIMPLE` constant
+    # regardless, so a look-alike index still got checked against the real PyPI —
+    # but it dropped out of `non_pypi` on the way, so nothing in the report ever
+    # said the lockfile points somewhere other than PyPI.
+    parts = urllib.parse.urlsplit(str(pkg.get("source", {}).get("registry", "")))
+    return parts.scheme == "https" and parts.hostname == "pypi.org"
 
 
 def pypi_sourced(packages: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -890,6 +890,28 @@ class TestMainContract(_MainHarness):
         self.assertIn("NOT checked", out)
         self.assertIn("fpga-simulator", out)
 
+    def test_a_lookalike_registry_host_is_not_taken_for_pypi(self):
+        """`https://pypi.org.evil.com/simple` is a prefix match, so the old check passed it.
+
+        The damage was silence rather than a bad hash: artifacts are fetched from
+        the `SIMPLE` constant either way, so the package was still compared against
+        the real PyPI — but being classified PyPI-sourced kept it out of
+        `non_pypi`, and nothing in the report said the lockfile names an index
+        that is not PyPI.
+        """
+        lock = (
+            self.LOCK
+            + """
+[[package]]
+name = "impostor"
+version = "1.0"
+source = { registry = "https://pypi.org.evil.com/simple" }
+"""
+        )
+        _, out, _ = self._run([write_lock(self, lock), "--changed", "rumdl"], meta=self._meta())
+        self.assertIn("NOT checked", out)
+        self.assertIn("impostor", out)
+
     def test_an_unrecorded_size_survives_into_the_report(self):
         """A third state beside match/MISMATCH, or the distinction is lost at the
         last step — and `--json` gets null, which is the honest encoding."""


### PR DESCRIPTION
Closes the open CodeQL alert `py/incomplete-url-substring-sanitization` on `main` — the first thing found after code scanning became a required check.

## The defect

`_is_pypi` classified a package by prefix:

```python
str(pkg.get("source", {}).get("registry", "")).startswith("https://pypi.org")
```

`https://pypi.org.evil.com/simple` satisfies that.

## What it actually cost

Not a bad hash. Artifacts are fetched from the `SIMPLE` constant regardless of what the lockfile names, so a look-alike index was still compared against the real pypi.org and a substituted artifact would still have failed.

The cost was the other half of the report. Being classified PyPI-sourced kept the package out of `non_pypi` — which exists so a dependency the script *cannot* verify is named rather than dropped. Reproduced against a lockfile carrying such an entry, the old code printed:

```
RESULT: CLEAN — 1 package(s), 1 artifact(s) checked
        1 package(s) NOT checked (not PyPI-sourced): fpga-simulator
```

The look-alike appears nowhere, and it reached OSV as though it were a real PyPI package. An under-audit indistinguishable from a clean one — the failure `non_pypi`'s own docstring names.

## The fix

`urllib.parse.urlsplit` parses the registry and the host is compared exactly, with the scheme required to be `https`. `.hostname` lowercases and strips port and userinfo, so `https://pypi.org:443/simple` still matches and `https://user@pypi.org.evil.com/` does not.

The `.get` on `source` is unchanged, so a `Cargo.lock` string `source` still raises the AttributeError `_sniff_toml` is tested against.

## Verification

- New regression test, confirmed to fail without the fix (asserts the look-alike reaches the NOT-checked line).
- Full suite: 225 tests, green.
- `pre-commit run --all-files`: ruff check, ruff format, mypy, unittest — all pass.

## Versioning

Minor rather than patch, per `CONTRIBUTING.md`: this changes what the report asserts. A lockfile that previously produced no mention of its index now produces a NOT-checked line.

`CHANGELOG.md` rolls the existing `[Unreleased]` "Decided" entry into 0.22.0, per Keep a Changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)