### PR TITLE
docs: the release step includes cutting a GitHub Release (0.22.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ patch.
 
 ## [Unreleased]
 
+## [0.22.1] — 2026-08-16
+
+`CONTRIBUTING.md`'s release step stopped at the annotated tag and the CHANGELOG
+entry, so a contributor following it exactly would not cut a GitHub Release. The
+practice changed at 0.22.0; the instruction had not caught up, and an instruction
+that omits a required step is the kind of claim this repo treats as false rather
+than merely incomplete.
+
+The step is now written out, along with the two things about it that are not
+obvious:
+
+- **It is presentation, not distribution.** `.claude-plugin/marketplace.json`
+  declares `"source": "./"`, so `/plugin marketplace add` installs from the
+  default branch and never resolves a Release. Publishing one is for readers who
+  take a Release as more authoritative than a bare tag — and against the failure
+  0.21.1 shipped into, where `releases/latest` advertised `v0.17.0` while the
+  plugin was four versions ahead.
+- **Releases start at `v0.22.0`.** The 35 tags before it are deliberately
+  release-less. Recorded so the gap reads as a decision rather than an omission
+  somebody later tidies up.
+
 ## [0.22.0] — 2026-08-16
 
 ### Fixed
@@ -2154,7 +2175,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.1...HEAD
+[0.22.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.20.0...v0.21.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,7 +299,21 @@ change to what a phase verifies, or to what the report asserts, is a minor bump
 even when no code moved. A fix that only makes an existing claim true is a patch.
 
 Every release gets an annotated tag matching the version in
-`.claude-plugin/plugin.json`, and an entry in `CHANGELOG.md`.
+`.claude-plugin/plugin.json`, an entry in `CHANGELOG.md`, and a published
+[GitHub Release](https://github.com/Machai-Kydoimos/dependabot-audit/releases)
+cut from that tag — `gh release create <tag> --verify-tag`, with notes drawn from
+the CHANGELOG entry.
+
+The Release is presentation, not distribution: `.claude-plugin/marketplace.json`
+declares `"source": "./"`, so `/plugin marketplace add` installs from the default
+branch and never resolves a Release. It is published anyway because a Release
+reads as more authoritative than a bare tag, and because the alternative is what
+0.21.1 shipped into — a repo whose sidebar advertised `v0.17.0` as *Latest* while
+the plugin was four versions ahead. Let `--latest` default so `releases/latest`
+tracks the newest version rather than drifting.
+
+Releases start at `v0.22.0`. The tags before it are deliberately release-less and
+are not to be backfilled.
 
 ## Security
 


### PR DESCRIPTION
`CONTRIBUTING.md`'s "Commits and releases" section said a release gets an annotated tag and a `CHANGELOG.md` entry, and stopped there. The practice changed at 0.22.0 — every version now gets a published GitHub Release — but the instruction did not.

A contributor following it exactly would have done everything it asked and still not cut a Release, landing in the state that put `v0.17.0` in the sidebar as *Latest* while the plugin shipped `0.21.1`. An instruction that omits a required step is not merely incomplete; read literally it is false.

## What the section now says

The tag, the CHANGELOG entry, and `gh release create <tag> --verify-tag` with notes drawn from the CHANGELOG — plus the two things about the step that are not self-evident:

- **It is presentation, not distribution.** `.claude-plugin/marketplace.json` declares `"source": "./"`, so `/plugin marketplace add` installs from the default branch and never resolves a Release. Publishing one is for readers who take a Release as more authoritative than a bare tag. If that is ever to become load-bearing, the lever is `marketplace.json`, not this paragraph.
- **Releases start at `v0.22.0`.** The 35 tags before it are deliberately release-less, recorded so the gap reads as a decision rather than an omission somebody later tidies up by backfilling.

## Versioning

Patch, per this file's own rule: nothing changes about what a phase verifies or what the report asserts. This only makes an existing claim true.

## Verification

`pre-commit run --all-files` — ruff check, ruff format, mypy, and the 225-test suite all pass. No code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)