### PR TITLE
docs: add the 0.23.0 compare links (0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2230,7 +2230,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.1...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.0...v0.21.1


### PR DESCRIPTION
#48 added the `## [0.23.0]` entry but not its link definition, and left `[Unreleased]` comparing from `v0.22.1`. Every other version in the file carries both.

```
[Unreleased]: …/compare/v0.23.0...HEAD
[0.23.0]:     …/compare/v0.22.1...v0.23.0
```

Checked rather than eyeballed — headings and link definitions are now in exact correspondence:

```
$ python3 -c '…'   # set(## [x]) vs set([x]:)
headings without a link: none
links without a heading: none
```

No version bump: this corrects the record of 0.23.0 rather than changing anything the plugin does. No replay section — this touches no phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)