### PR TITLE
feat: hand back the audit's deviations from its own procedure (0.24.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,132 @@ patch.
 
 ## [Unreleased]
 
+## [0.24.0] — 2026-08-20
+
+An audit that works around a defect in **this plugin** reports nothing about it,
+and the report's silence reads as compliance. `fpga-board-sim` #363 ran to a
+complete, well-formed report under 0.22.1 while `SKILL.md` had never loaded at
+all: every row in it was true, and the procedure that produced them was not this
+procedure. Phase 8 could not have asked — its scope was a landmine in the
+*audited* repo or a portable trap in an ecosystem, and a defect in the plugin's
+own machinery is neither. Minor rather than patch: it changes what Phase 8 hands
+back and what the report asserts.
+
+### Added
+
+- **Phase 8 hands back the audit's own deviations**, separately from what it
+  found about the PR: every shell command run that `SKILL.md` did not specify,
+  quoted with the gap it filled, and every plugin file read directly rather than
+  invoked as written. Each classified **plugin defect**, **prose gap**, or
+  **correct**; printed, never filed, on the same contract as the landmine
+  hand-back above it.
+
+  The two categories are the two commands from the #363 transcript, and the pair
+  is load-bearing: a clause asking only about surprising commands misses the
+  `cat SKILL.md`, and one asking only about plugin files misses the invented
+  `export CLAUDE_PLUGIN_ROOT=…`.
+
+  `correct` is a real answer and the common one. The goal is not to suppress
+  improvisation — no procedure enumerates every repo it will meet — but to stop
+  it being invisible, because the workaround that *works* is precisely the one
+  nobody reports. That is how the shadowing shipped in 0.2.1 and survived to
+  0.23.0.
+
+- **Phase 7 discloses a deviation in the report itself**, in one line, and
+  `references/report-template.md` carries the matching slot so the instruction
+  has somewhere to land.
+
+  Stated in Phase 7's **own** terms — "a command this procedure did not specify,
+  or a plugin file read by hand" — rather than by deferring to Phase 8's
+  classification. Phase 8 runs *after* Phase 7, and a phase that consumes what a
+  later phase produces is the forward-reference defect `test_skill_prose.py`
+  already guards twice.
+
+### The replay
+
+Two rounds, `fpga-board-sim` #363 — the PR that motivated the change — audited
+end to end against the working tree via `claude -p --plugin-dir`, in a fresh
+context each time, with the deviation list checked afterwards against the
+session transcript's actual `Bash` calls. The transcript is the independent
+record; the model's recollection is not, and the two disagreed.
+
+**Round one, the clause exactly as proposed.** The hand-back appeared
+**unprompted** and was substantive: three `gh api` calls correctly identified as
+outside the procedure, two of them classified a **prose gap** with a portable
+addition proposed for `references/actions.md` — the release notes for
+`setup-uv` v10.0.0 name three events for the `enable-cache: auto` change while
+`action.yml` and `src/utils/inputs.ts` name four, so a scope grep built from the
+notes checks three triggers and misses one.
+
+**And it missed the row it was written for.** From the same transcript, neither
+reported:
+
+```
+ls .../skills/dependabot-audit/scripts/ .../references/
+D="/home/rick/Projects/dependabot-audit/skills/dependabot-audit/scripts/discover.py"
+```
+
+Every `${CLAUDE_PLUGIN_ROOT}/scripts/…` in this file was silently replaced by an
+absolute path — the same question #363 improvised on, *where is this plugin?*,
+answered by hand and handed back by neither run. The clause was general, and the
+general form did not reach its own motivating case.
+
+**Round two, after naming path resolution explicitly**, reported the
+substitution as its **first** row — "exactly the row SKILL.md predicts goes
+unreported" — plus three more, all four verified true against that transcript:
+orientation commands before Phase 0, `git ls-tree` to enumerate workflows at a
+ref (a genuine `actions.md` prose gap), and re-sourcing `phase0.env` per call
+because shell state does not persist between tool calls. Phase 7's line fired
+correctly and narrowly: *"This audit did not have to improvise on procedure —
+every phase ran as written. It did substitute one absolute path."*
+
+Residual, stated rather than smoothed over: round two folded the `ls` that
+*discovered* the path into the substitution row instead of itemising it. The
+substantive half is reported; the reconnaissance half still is not.
+
+### Measured
+
+- **`CLAUDE_PLUGIN_ROOT` is empty even when the skill loads correctly.** 0.23.0
+  recorded that the shadowed #363 run measured `CLAUDE_PLUGIN_ROOT=[]` and noted
+  that *"whether a correctly loaded skill is given it has never been measured"*,
+  deferring it. Measured now, Claude Code 2.1.238, skill loaded and confirmed by
+  reading back its own final heading:
+
+  | Load path | `printf 'ROOT=[%s]' "$CLAUDE_PLUGIN_ROOT"` |
+  |---|---|
+  | marketplace install, 0.23.0 | `ROOT=[]` |
+  | `--plugin-dir` on the working tree | `ROOT=[]` |
+
+  In both the harness supplies the skill's absolute directory *alongside the
+  instructions*, which is where every recorded run has actually got the path
+  from. So every `${CLAUDE_PLUGIN_ROOT}/scripts/…` in `SKILL.md` is written
+  against a variable that expands to nothing, and each audit silently
+  substitutes — correct, unavoidable, and until now unreported. **Not fixed
+  here**, deliberately: 0.23.0 called it a separate change and it still is. This
+  release makes it *visible*, which is the whole point of the clause.
+
+### Tests
+
+- **Seven guards in `tests/test_skill_prose.py`**, one class, all seven
+  mutation-checked against the prose that preceded them.
+
+  The seventh had to be rewritten before it counted. As first written it
+  asserted that the clause **names** `CLAUDE_PLUGIN_ROOT`, and it **passed
+  against prose carrying no path-resolution clause at all** — the narrative
+  above it already quotes the #363 `export`. Rewritten to assert the
+  *measurement*, that the variable is empty, it fails against the earlier text
+  as a guard should. Written from the fix it
+  would have shipped green and meaningless; CONTRIBUTING's rule about the
+  direction the writing flows from, caught by running it.
+
+### Not done, deliberately
+
+- **The `${CLAUDE_PLUGIN_ROOT}` paths are unchanged.** See **Measured**.
+- **Two candidates the replay raised** stay out: enumerating workflows at a ref
+  in `references/actions.md`, and Phase 7's cleanup block leading with the
+  two-worktree case so the actions exception reads as a parenthetical. Both are
+  real, neither is this change.
+
 ## [0.23.0] — 2026-08-19
 
 A skill and a command are not in separate namespaces. Both are addressed as
@@ -2230,7 +2356,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.0...v0.22.1
 [0.22.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.21.1...v0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,88 +54,83 @@ back and what the report asserts.
 
 ### The replay
 
-Two rounds, `fpga-board-sim` #363 — the PR that motivated the change — audited
-end to end against the working tree via `claude -p --plugin-dir`, in a fresh
-context each time, with the deviation list checked afterwards against the
-session transcript's actual `Bash` calls. The transcript is the independent
-record; the model's recollection is not, and the two disagreed.
+`fpga-board-sim` #363 — the PR that motivated the change — audited end to end in
+a fresh context via `claude -p --plugin-dir`, then the hand-back checked against
+that session transcript's actual `Bash` calls. The transcript is the independent
+record; the model's recollection is not.
 
-**Round one, the clause exactly as proposed.** The hand-back appeared
-**unprompted** and was substantive: three `gh api` calls correctly identified as
-outside the procedure, two of them classified a **prose gap** with a portable
-addition proposed for `references/actions.md` — the release notes for
-`setup-uv` v10.0.0 name three events for the `enable-cache: auto` change while
-`action.yml` and `src/utils/inputs.ts` name four, so a scope grep built from the
-notes checks three triggers and misses one.
+**The hand-back appeared unprompted and was substantive.** Three `gh api` calls
+correctly identified as outside the procedure, two of them classified a **prose
+gap** with a portable addition proposed for `references/actions.md`: `setup-uv`
+v10.0.0's release notes name three events for the `enable-cache: auto` change,
+while `action.yml` and `src/utils/inputs.ts` name four, so a scope grep built
+from the notes checks three triggers and misses tag pushes. Filed as its own
+issue. Verdict unaffected — **merge as-is, high confidence** — so the clause did
+not distort the audit it rides on.
 
-**And it missed the row it was written for.** From the same transcript, neither
-reported:
+**Checked against the transcript, the list was materially complete.** One
+unreported item: an `ls` of the plugin's own `scripts/` and `references/`, run to
+get bearings before Phase 0.
+
+### The second round, and why it is not in this release
+
+A second round ran against an amended clause that named *path resolution* as the
+row most likely to go missing, on the reading that the audit had silently
+replaced every `${CLAUDE_PLUGIN_ROOT}/scripts/…` with an absolute path. **That
+reading was wrong, and the amendment is reverted.** It is recorded because the
+error is the exact class this release exists to surface.
+
+`${CLAUDE_PLUGIN_ROOT}` is expanded **textually at skill load**; it is not an
+environment variable. 0.23.0 said so. Settled from the round-two transcript,
+where the 62,674-character skill injection delivered to the model reads:
 
 ```
-ls .../skills/dependabot-audit/scripts/ .../references/
 D="/home/rick/Projects/dependabot-audit/skills/dependabot-audit/scripts/discover.py"
 ```
 
-Every `${CLAUDE_PLUGIN_ROOT}/scripts/…` in this file was silently replaced by an
-absolute path — the same question #363 improvised on, *where is this plugin?*,
-answered by hand and handed back by neither run. The clause was general, and the
-general form did not reach its own motivating case.
+against a `SKILL.md` that holds `D="${CLAUDE_PLUGIN_ROOT}/…"` on disk at line
+104. The model ran exactly what it was handed. **There was no substitution and no
+deviation** — and round two, following the amended prose, dutifully reported one
+as its first row. A clause that manufactures false deviations is worse than one
+that misses an `ls`, so the clause ships as #50 proposed it.
 
-**Round two, after naming path resolution explicitly**, reported the
-substitution as its **first** row — "exactly the row SKILL.md predicts goes
-unreported" — plus three more, all four verified true against that transcript:
-orientation commands before Phase 0, `git ls-tree` to enumerate workflows at a
-ref (a genuine `actions.md` prose gap), and re-sourcing `phase0.env` per call
-because shell state does not persist between tool calls. Phase 7's line fired
-correctly and narrowly: *"This audit did not have to improvise on procedure —
-every phase ran as written. It did substitute one absolute path."*
-
-Residual, stated rather than smoothed over: round two folded the `ls` that
-*discovered* the path into the substitution row instead of itemising it. The
-substantive half is reported; the reconnaissance half still is not.
+What found this was neither round: it was a project memory recording 0.23.0's own
+conclusion, read back afterwards. The replay gate proved the clause works and did
+**not** catch the error in the amendment written from it — the amendment's row
+looked like a success in both the report and the transcript.
 
 ### Measured
 
-- **`CLAUDE_PLUGIN_ROOT` is empty even when the skill loads correctly.** 0.23.0
-  recorded that the shadowed #363 run measured `CLAUDE_PLUGIN_ROOT=[]` and noted
-  that *"whether a correctly loaded skill is given it has never been measured"*,
-  deferring it. Measured now, Claude Code 2.1.238, skill loaded and confirmed by
-  reading back its own final heading:
-
-  | Load path | `printf 'ROOT=[%s]' "$CLAUDE_PLUGIN_ROOT"` |
-  |---|---|
-  | marketplace install, 0.23.0 | `ROOT=[]` |
-  | `--plugin-dir` on the working tree | `ROOT=[]` |
-
-  In both the harness supplies the skill's absolute directory *alongside the
-  instructions*, which is where every recorded run has actually got the path
-  from. So every `${CLAUDE_PLUGIN_ROOT}/scripts/…` in `SKILL.md` is written
-  against a variable that expands to nothing, and each audit silently
-  substitutes — correct, unavoidable, and until now unreported. **Not fixed
-  here**, deliberately: 0.23.0 called it a separate change and it still is. This
-  release makes it *visible*, which is the whole point of the clause.
+- **`$CLAUDE_PLUGIN_ROOT` is empty in the Bash tool's environment, and that is
+  correct.** Claude Code 2.1.238, skill loaded and confirmed loaded, marketplace
+  install and `--plugin-dir` alike: `printf 'ROOT=[%s]' "$CLAUDE_PLUGIN_ROOT"`
+  gives `ROOT=[]` on both. This looks like a defect and is not one — the token is
+  substituted into the skill *text* before the model ever sees it, so nothing at
+  runtime needs the variable. Recorded because the naive probe points the wrong
+  way, and because 0.23.0 left "whether a correctly loaded skill is given it" as
+  an open question. It is not given it, and does not need to be.
 
 ### Tests
 
-- **Seven guards in `tests/test_skill_prose.py`**, one class, all seven
-  mutation-checked against the prose that preceded them.
+- **Six guards in `tests/test_skill_prose.py`**, one class, each mutation-checked
+  against the prose that preceded it — all six fail against 0.23.0's Phase 8 and
+  report-template.
 
-  The seventh had to be rewritten before it counted. As first written it
-  asserted that the clause **names** `CLAUDE_PLUGIN_ROOT`, and it **passed
-  against prose carrying no path-resolution clause at all** — the narrative
-  above it already quotes the #363 `export`. Rewritten to assert the
-  *measurement*, that the variable is empty, it fails against the earlier text
-  as a guard should. Written from the fix it
-  would have shipped green and meaningless; CONTRIBUTING's rule about the
-  direction the writing flows from, caught by running it.
+  A seventh, written for the amended clause, is gone with it. It is worth its own
+  line: as first written it asserted that the clause **names**
+  `CLAUDE_PLUGIN_ROOT`, and it **passed against prose carrying no
+  path-resolution clause at all**, because the narrative above already quotes the
+  #363 `export`. Rewriting it to assert the measurement made it discriminate —
+  and the measurement it then asserted was false. A guard can be made to fail
+  correctly against the old text and still encode a wrong claim; mutation
+  checking sizes the discrimination, never the truth.
 
 ### Not done, deliberately
 
-- **The `${CLAUDE_PLUGIN_ROOT}` paths are unchanged.** See **Measured**.
-- **Two candidates the replay raised** stay out: enumerating workflows at a ref
-  in `references/actions.md`, and Phase 7's cleanup block leading with the
+- **Two candidates the second round raised** stay out: enumerating workflows at a
+  ref in `references/actions.md`, and Phase 7's cleanup block leading with the
   two-worktree case so the actions exception reads as a parenthetical. Both are
-  real, neither is this change.
+  real; neither is this change, and neither has a defect behind it yet.
 
 ## [0.23.0] — 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,53 @@ not distort the audit it rides on.
 unreported item: an `ls` of the plugin's own `scripts/` and `references/`, run to
 get bearings before Phase 0.
 
+### The round that replayed what ships
+
+The clause above, reverted to #50's form, replayed against #363 once more —
+because the second round had tested prose that is not shipping. Third run, fresh
+context, and the first one whose subject is the released text.
+
+**It found a plugin defect.** `references/actions.md` § Phase 1 documents:
+
+```bash
+gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.type, .object.sha'
+```
+
+That recipe has three outcomes, not two, and the middle one is the case Phase 2
+actually asks about — *does a moving major tag exist?* Reproduced by hand,
+independently of the run:
+
+| Tag asked for | Result |
+|---|---|
+| `v10.0.1` — exact | `commit`, `20cfd1bf9…`, exit 0 |
+| **`v10` — a prefix of existing tags** | **`expected an object but got: array ([{…`, exit 1** |
+| `v999` — absent, not a prefix | clean `404 Not Found` |
+
+GitHub's refs endpoint returns an **array** for a namespace prefix, so asking
+whether `v10` exists — against a repo publishing `v10.0.0` and `v10.0.1` — kills
+the documented `--jq` with what reads like an API fault. The array *is* the
+answer: it lists the tags that do exist and thereby says no `v10` ref does. The
+recipe crashes precisely when it has the data. Filed separately; not fixed here.
+
+**And a prose gap.** Phase 0's `SCRATCH=${SCRATCH:-$(mktemp -d)}` assumes one
+persistent shell. Each `Bash` call is a fresh shell, so `mktemp -d` yields a new
+directory per invocation and the next call's `. "$SCRATCH/phase0.env"` reads a
+path that does not exist. Two of the three rounds worked around it by pinning a
+fixed path; nothing in `SKILL.md` says the scratch path must be *stable*, only
+that it must be outside the repo. Filed separately.
+
+Both were handed back classified, with the gap each filled, alongside a third row
+of ordinary judgement marked **correct** — including the `ls` of the plugin's own
+`scripts/` that round one omitted. The run also stated the contrast this whole
+release exists for, unprompted:
+
+> this time the skill loaded, `disallowed-tools` applied, and no
+> `CLAUDE_PLUGIN_ROOT` export or `cat` of the procedure was needed. **The
+> evidence table came out the same, which is exactly what made the original
+> failure invisible.**
+
+Verdict unchanged across all three rounds: **merge as-is, high confidence**.
+
 ### The second round, and why it is not in this release
 
 A second round ran against an amended clause that named *path resolution* as the

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -1060,20 +1060,5 @@ headings returns a clean sheet every time, because the headings are what you
 *meant* to run; the deviation least likely to be recalled is the small one that
 felt too obvious to mention, and that is the shape both #363 commands had.
 
-**Path resolution counts, and it is the row most likely to go missing.** Both
-recorded runs improvised on the same question — *where is this plugin?* — and
-neither volunteered it. #363 invented the `export`. The first audit run under this
-clause, `fpga-board-sim` #363 replayed on 2026-08-20, listed `scripts/` and
-`references/` and then substituted an absolute path for `${CLAUDE_PLUGIN_ROOT}` in
-every invocation; it reported three other deviations accurately and not that one.
-
-Measured the same day on Claude Code 2.1.238, from a marketplace install and
-under `--plugin-dir` alike: `CLAUDE_PLUGIN_ROOT` is **empty** in the Bash tool's
-environment, while the harness supplies this skill's absolute directory alongside
-these instructions. Substituting it is therefore both correct and unavoidable —
-and still a deviation, because every script path below is written against a
-variable that expands to nothing. If you did not invoke the scripts exactly as
-written, that is a row.
-
 Print it; do not file it — the same contract as the hand-back above. This skill
 does not write, and the session that invoked it owns what happens next.

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -859,6 +859,15 @@ evidence table, reasoning, what would change the verdict, and the **un-run** mer
 command. Lead with evidence; the recommendation is a conclusion drawn from it,
 not a headline it decorates.
 
+**If this audit had to improvise, the report says so.** One line, wherever it ran
+a command this procedure did not specify or read a plugin file by hand instead of
+invoking it — the evidence rows were then produced by a procedure working around
+its own tooling, and nothing else in the report can tell the reader that. Do not
+wait on Phase 8's classification: that hand-back is written for this plugin's
+maintainer and comes *after* this phase, while what the reader here needs is one
+sentence and the PR. On `fpga-board-sim` #363 the table read identically either
+way.
+
 **Mark each row's provenance**, and reuse only where it is legitimate. What
 invalidates a row is not how old it is but what it depends on:
 
@@ -1016,3 +1025,55 @@ section.
 A generally portable trap belongs in this plugin rather than in one project's
 memory — in the phase it applies to if it is a rule, or in that ecosystem's
 reference if it is a recipe. Say which you are proposing, and why.
+
+### Hand back the deviations too
+
+Everything above hands back what the audit learned about the **repo**. This hands
+back what it learned about **itself**, and it is a separate question.
+
+The report asserts *"I followed this procedure"* by silence, and on 2026-08-19
+that assertion was false with nothing anywhere to catch it. `fpga-board-sim` #363
+ran to a complete, well-formed report under 0.22.1 while this file had never
+loaded at all: a `commands/` entry shadowed the skill at the same
+`<plugin>:<name>` address, so `SKILL.md` was unloadable and `disallowed-tools`
+never applied. Every evidence row in that report was true. The procedure that
+produced them was not this one — the audit had reached them by running two
+commands that appear nowhere here, an invented `CLAUDE_PLUGIN_ROOT` export and a
+`cat` of the procedure it should have been handed — and the report mentioned
+neither.
+
+So, separately from what the audit found about the PR, hand back:
+
+- **every shell command run that this file did not specify** — quoted, with the
+  gap it filled;
+- **every plugin file read directly rather than invoked as written.**
+
+Classify each as **plugin defect**, **prose gap**, or **correct**. All three are
+real answers and `correct` is the common one: no procedure enumerates every repo
+it will meet, and improvising is usually the right call. The goal is not to
+suppress the improvisation but to stop it being invisible — a workaround that
+*works* is precisely the one nobody reports, which is how the shadowing shipped
+in 0.2.1 and survived to 0.23.0.
+
+Read it off what you actually ran. Reconstructing the list from the phase
+headings returns a clean sheet every time, because the headings are what you
+*meant* to run; the deviation least likely to be recalled is the small one that
+felt too obvious to mention, and that is the shape both #363 commands had.
+
+**Path resolution counts, and it is the row most likely to go missing.** Both
+recorded runs improvised on the same question — *where is this plugin?* — and
+neither volunteered it. #363 invented the `export`. The first audit run under this
+clause, `fpga-board-sim` #363 replayed on 2026-08-20, listed `scripts/` and
+`references/` and then substituted an absolute path for `${CLAUDE_PLUGIN_ROOT}` in
+every invocation; it reported three other deviations accurately and not that one.
+
+Measured the same day on Claude Code 2.1.238, from a marketplace install and
+under `--plugin-dir` alike: `CLAUDE_PLUGIN_ROOT` is **empty** in the Bash tool's
+environment, while the harness supplies this skill's absolute directory alongside
+these instructions. Substituting it is therefore both correct and unavoidable —
+and still a deviation, because every script path below is written against a
+variable that expands to nothing. If you did not invoke the scripts exactly as
+written, that is a row.
+
+Print it; do not file it — the same contract as the hand-back above. This skill
+does not write, and the session that invoked it owns what happens next.

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -104,3 +104,10 @@ does so before the audit knows whether it will reach Phase 5, so an audit that
 stopped at Phase 1's gate has exactly the same litter as one that ran to the end.
 Phase 7 removes them. If they were kept deliberately, name them here with their
 cleanup commands; never leave one registered in the user's repo unannounced.
+
+**Say if the audit had to improvise.** One line where this run worked around the
+plugin itself — a command the procedure does not specify, or a plugin file read
+by hand rather than invoked. The full deviation list belongs to Phase 8 and is
+written for this plugin's maintainer; what belongs *here* is the single fact that
+the evidence above came from a procedure that had to deviate, which no other row
+in this shape discloses.

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1479,33 +1479,6 @@ class TestTheAuditHandsBackItsOwnDeviations(SkillHarness):
             "the deviation list has no home unless the phase says where it goes",
         )
 
-    def test_it_names_path_resolution_as_the_row_that_goes_missing(self):
-        """Two for two, and the replay of this very clause was the second.
-
-        Both recorded runs improvised on *where is this plugin?* and neither
-        reported it. #363 invented `export CLAUDE_PLUGIN_ROOT=...`; the first
-        audit run under this clause listed the plugin's `scripts/` and
-        `references/` directories and then substituted an absolute path for
-        `${CLAUDE_PLUGIN_ROOT}` in every invocation, handing back three other
-        deviations and not that one.
-
-        The clause is general and the general form did not reach it, so the case
-        is named. Written from the measurement rather than from the clause:
-        `CLAUDE_PLUGIN_ROOT` is empty in the Bash tool's environment on Claude
-        Code 2.1.238, under a marketplace install and `--plugin-dir` alike.
-        """
-        self.assertRegex(
-            self._deviation_section(),
-            re.compile(
-                r"CLAUDE_PLUGIN_ROOT.{0,400}?(is \*\*empty\*\*|expands to nothing)",
-                re.IGNORECASE | re.DOTALL,
-            ),
-            "naming the variable is not enough — the narrative above already does, and "
-            "that version of this guard passed against prose with no path-resolution "
-            "clause at all. What the clause has to carry is the measurement: the "
-            "variable is empty, so substituting it is unavoidable *and* a deviation",
-        )
-
     def test_phase_7_puts_a_plugin_defect_in_the_report(self):
         """Phase 8 is the maintainer's; the PR's reader needs one line of it.
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1380,5 +1380,159 @@ class TestFrontmatter(SkillHarness):
         self.assertEqual(self._frontmatter()["name"], PLUGIN.name)
 
 
+class TestTheAuditHandsBackItsOwnDeviations(SkillHarness):
+    """The report asserted "I followed the procedure" by silence, and was wrong.
+
+    On 2026-08-19 `fpga-board-sim` #363 ran to a complete, well-formed report
+    under 0.22.1 while `SKILL.md` had never loaded at all: `commands/` shadowed
+    the skill at the same `<plugin>:<name>` address, so the procedure was
+    unloadable and `disallowed-tools` never applied (#48, 0.23.0). Every evidence
+    row in that report was true. What produced them was not this procedure.
+
+    The shadowing is fixed. The part that is not is that the audit **routed
+    around it silently**. Two commands from that session's transcript, neither of
+    which appears anywhere in this file:
+
+        export CLAUDE_PLUGIN_ROOT=/home/rick/.claude/plugins/cache/.../0.22.1
+        cd .../skills/dependabot-audit && cat SKILL.md
+
+    The first invents a variable the prose assumes is supplied; the second
+    fetches by hand the procedure that should have been handed over. The report
+    mentioned neither, and Phase 8 as written could not have asked for them — its
+    scope was a landmine in the *audited* repo or a portable trap in an ecosystem,
+    and a defect in the plugin's own machinery is neither.
+
+    **These two cases are the assertions below, and that is deliberate.** They
+    come from the transcript, not from the clause written to answer it — a guard
+    derived from its own fix can only ever agree with it, which is how a Phase 6
+    guard in 0.10.0 asserted the property that *was* the defect. A clause that
+    asked only for surprising commands would still miss the `cat`; one that asked
+    only about plugin files would still miss the `export`.
+
+    What this cannot check is whether the model *does* it. That is behavioral,
+    belongs in `claude plugin eval` (#32, still refused on this account), and
+    until then rests on the replay in CONTRIBUTING: run an audit, ask for the
+    deviation list, and check it against the transcript's actual `Bash` calls.
+    """
+
+    def _deviation_section(self) -> str:
+        """The Phase 8 subsection that asks for deviations, not all of Phase 8.
+
+        Anchored to the subsection so "these words appear somewhere in Phase 8"
+        cannot satisfy the guards: the landmine hand-back above it already talks
+        about evidence, handing back, and not creating files.
+        """
+        phase8 = dict(self.phases)[8]
+        parts = re.split(r"^### ", phase8, flags=re.MULTILINE)
+        for part in parts:
+            if re.search(r"deviat", part, re.IGNORECASE):
+                return part
+        self.fail("Phase 8 has no subsection asking for deviations from the procedure")
+
+    def test_it_asks_for_commands_the_procedure_did_not_specify(self):
+        """The `export` half: a command run to fill a gap in the prose."""
+        self.assertRegex(
+            self._deviation_section(),
+            re.compile(
+                r"command.{0,120}(did not specify|this file does not)", re.IGNORECASE | re.DOTALL
+            ),
+            "a deviation list that does not ask for unspecified commands misses the "
+            "invented CLAUDE_PLUGIN_ROOT export, which is half the #363 evidence",
+        )
+
+    def test_it_asks_for_plugin_files_read_instead_of_invoked(self):
+        """The `cat SKILL.md` half: the procedure fetched by hand."""
+        self.assertRegex(
+            self._deviation_section(),
+            re.compile(r"read directly|read by hand|rather than invoked", re.IGNORECASE),
+            "asking only for surprising commands still reads as satisfied by an audit "
+            "that quietly cat'd the procedure it was supposed to be handed",
+        )
+
+    def test_each_deviation_is_classified_rather_than_only_listed(self):
+        """A list without the verdict column is a diary, not a hand-back.
+
+        `plugin defect` is the class that reached the report in #363 and the one
+        Phase 7 pairs with; `correct` has to be available or the clause reads as
+        an instruction not to improvise, which would be the wrong lesson.
+        """
+        section = self._deviation_section().lower()
+        for label in ("plugin defect", "prose gap", "correct"):
+            self.assertIn(
+                label,
+                section,
+                f"a deviation classified as neither {label!r} nor anything else is "
+                f"handed back with its meaning left to the reader",
+            )
+
+    def test_the_deviation_list_is_handed_back_rather_than_filed(self):
+        """Same contract as the landmine above: this skill does not write.
+
+        `disallowed-tools` withholds Edit, Write and NotebookEdit, and the
+        landmine hand-back is careful to say the invoking session owns the
+        decision. A clause that told the audit to open an issue would ask for a
+        capability the frontmatter removes.
+        """
+        self.assertRegex(
+            self._deviation_section(),
+            re.compile(r"print|hand (it|them|the list) back", re.IGNORECASE),
+            "the deviation list has no home unless the phase says where it goes",
+        )
+
+    def test_it_names_path_resolution_as_the_row_that_goes_missing(self):
+        """Two for two, and the replay of this very clause was the second.
+
+        Both recorded runs improvised on *where is this plugin?* and neither
+        reported it. #363 invented `export CLAUDE_PLUGIN_ROOT=...`; the first
+        audit run under this clause listed the plugin's `scripts/` and
+        `references/` directories and then substituted an absolute path for
+        `${CLAUDE_PLUGIN_ROOT}` in every invocation, handing back three other
+        deviations and not that one.
+
+        The clause is general and the general form did not reach it, so the case
+        is named. Written from the measurement rather than from the clause:
+        `CLAUDE_PLUGIN_ROOT` is empty in the Bash tool's environment on Claude
+        Code 2.1.238, under a marketplace install and `--plugin-dir` alike.
+        """
+        self.assertRegex(
+            self._deviation_section(),
+            re.compile(
+                r"CLAUDE_PLUGIN_ROOT.{0,400}?(is \*\*empty\*\*|expands to nothing)",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            "naming the variable is not enough — the narrative above already does, and "
+            "that version of this guard passed against prose with no path-resolution "
+            "clause at all. What the clause has to carry is the measurement: the "
+            "variable is empty, so substituting it is unavoidable *and* a deviation",
+        )
+
+    def test_phase_7_puts_a_plugin_defect_in_the_report(self):
+        """Phase 8 is the maintainer's; the PR's reader needs one line of it.
+
+        Without this the split loses the case that motivated it: an audit that
+        worked around a defect in its own tooling produced every row in that
+        table, and the reader of the report cannot tell that run from an
+        unremarkable one.
+        """
+        phase7 = dict(self.phases)[7]
+        self.assertRegex(
+            phase7,
+            re.compile(r"improvis|deviat|work(ed)? around", re.IGNORECASE),
+            "Phase 7 writes the report and never mentions that the run may not have "
+            "followed the procedure; compliance stays implied, which is the defect",
+        )
+
+    def test_the_report_template_carries_the_same_disclosure(self):
+        """Phase 7 telling the writer something the shape has no room for is how
+        the verdict table and Phase 2's prose drifted apart in 0.10.0."""
+        template = (PLUGIN / "references/report-template.md").read_text(encoding="utf-8").lower()
+        self.assertRegex(
+            template,
+            re.compile(r"improvis|deviat|work(ed)? around", re.IGNORECASE),
+            "the report shape has nowhere to say the audit improvised, so Phase 7's "
+            "instruction lands on a template that does not ask for it",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #50.

Phase 8's scope was a landmine in the *audited* repo, or a portable trap in an
ecosystem. A defect in this plugin's own machinery is neither — so an audit could
run substantially outside the procedure with nothing anywhere to say so.

**What that looked like when it ran.** `fpga-board-sim` #363 produced a complete,
well-formed report under 0.22.1 while `SKILL.md` had never loaded: `commands/`
shadowed the skill at the same `<plugin>:<name>` address. Every evidence row in
that report was true. The procedure that produced them was not this procedure,
the audit had reached them by inventing a `CLAUDE_PLUGIN_ROOT` export and `cat`-ing
the procedure off disk, and the report mentioned neither. *"I followed this
procedure"* was asserted by silence.

## What changes

- **Phase 8 hands back the audit's own deviations**, separately from what it found
  about the PR: every shell command run that `SKILL.md` did not specify, quoted
  with the gap it filled, and every plugin file read directly rather than invoked
  as written. Each classified **plugin defect**, **prose gap**, or **correct**;
  printed, never filed, on the same contract as the landmine hand-back above it.

  Both categories are load-bearing and both come from the #363 transcript: a
  clause asking only about surprising commands misses the `cat SKILL.md`; one
  asking only about plugin files misses the invented `export`.

- **Phase 7 discloses a deviation in the report**, in one line — stated in Phase
  7's own terms rather than deferring to Phase 8's classification. Phase 8 runs
  *after* Phase 7, and consuming what a later phase produces is the
  forward-reference defect `test_skill_prose.py` already guards twice.
  `references/report-template.md` carries the matching slot.

- **Six guards**, each mutation-checked against the prose that preceded it.

Prose rather than a script, per #50's constraint: the deviation list is a claim
about what a run actually did, and a tool asserting that — unable to be checked
itself — is the unverified verifier this repo exists to argue against.

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim #363`

Two rounds, the PR that motivated the change, audited end to end in a fresh
context via `claude -p --plugin-dir`, each hand-back then checked against that
session transcript's actual `Bash` calls. The transcript is the independent
record; the model's recollection is not, and they disagreed.

**Round one — the clause exactly as proposed in #50.** The hand-back appeared
*unprompted*:

```
Commands run that this procedure does not specify:

| Ran | Gap it filled | Classification |
| `gh api repos/astral-sh/setup-uv/contents/action.yml?ref=<SHA>` at both pins,
  then `diff` | `references/actions.md` § Phase 4 says to read *release notes*
  and grep this repo. It offers no way to see the action's **interface**
  change. | **prose gap** — proposed addition below |
| `gh api .../git/trees/<SHA>?recursive=1` then reading `src/utils/inputs.ts` at
  both pins | The release notes and `action.yml` **disagreed** on the scope of
  the breaking change (3 events vs. 4). Neither is authoritative; the source is.
  Without this the scope check would have missed tag pushes. | **prose gap** |
| `gh api repos/astral-sh/setup-uv/tags` filtered to major tags | ... does not
  say how to establish that a major tag line *doesn't* exist. | **correct** |

No plugin file was read by hand instead of being invoked.
```

**Checked against the transcript, that list was materially complete.** One
unreported item: an `ls` of the plugin's own `scripts/` and `references/`, run
for bearings before Phase 0.

Both this round and the second reached the same verdict on #363 — **merge as-is,
high confidence** — so the clause does not distort the audit it rides on.

### The round that replayed what ships

Rounds one and two both tested prose that is not shipping — round one predates
the amendment, round two tested the amendment that got reverted. **Third run,
fresh context, and the first whose subject is the released text.**

**It found a plugin defect**, which is the outcome the clause exists for.
`references/actions.md` § Phase 1 documents:

```bash
gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.type, .object.sha'
```

Three outcomes, not two — reproduced by hand, independently of the run:

| Tag asked for | Result |
|---|---|
| `v10.0.1` — exact | `commit`, `20cfd1bf9…`, exit 0 |
| **`v10` — a prefix of existing tags** | **`expected an object but got: array ([{…`, exit 1** |
| `v999` — absent, not a prefix | clean `404 Not Found` |

GitHub's refs endpoint returns an **array** for a namespace prefix. Asking
whether a moving major tag `v10` exists — exactly what Phase 2 asks, on exactly
that shape of name — kills the documented `--jq` with what reads like an API
fault. The array *is* the answer: it enumerates the tags that do exist and
thereby says no `v10` ref does. The recipe crashes precisely when it has the
data.

**And a prose gap.** Phase 0's `SCRATCH=${SCRATCH:-$(mktemp -d)}` assumes one
persistent shell. Each `Bash` call is a fresh shell, so `mktemp -d` yields a new
directory per invocation and the next call's `. "$SCRATCH/phase0.env"` reads a
path that does not exist. Two of three rounds worked around it by pinning a fixed
path; `SKILL.md` says the scratch directory must be outside the repo and never
says it must be *stable*.

Neither is fixed here — separate changes to separate phases, and this PR is about
Phase 8. Both filed.

The third row was ordinary judgement marked **correct**, and included the `ls` of
the plugin's own `scripts/` that round one omitted. The run also stated the
contrast this PR exists for, unprompted:

> this time the skill loaded, `disallowed-tools` applied, and no
> `CLAUDE_PLUGIN_ROOT` export or `cat` of the procedure was needed. **The
> evidence table came out the same, which is exactly what made the original
> failure invisible.**

Verdict unchanged across all three rounds: **merge as-is, high confidence**.

### The second round, and the error it carried

**A second round ran against an amended clause, and the amendment was wrong.**
It named *path resolution* as the row most likely to go missing, on my reading
that the audit had silently replaced every `${CLAUDE_PLUGIN_ROOT}/scripts/…`
with an absolute path. Reverted in `2269f17`, and recorded here rather than
quietly dropped, because the error is the exact class this PR exists to surface.

`${CLAUDE_PLUGIN_ROOT}` is expanded **textually at skill load** — it is not an
environment variable, and 0.23.0 already said so. Settled from the round-two
transcript, where the 62,674-character skill injection delivered to the model
reads:

```
D="/home/rick/Projects/dependabot-audit/skills/dependabot-audit/scripts/discover.py"
```

against a `SKILL.md` holding `D="${CLAUDE_PLUGIN_ROOT}/…"` on disk at line 104.
The model ran exactly what it was handed: no substitution, no deviation. My
reading compared the command against `SKILL.md` **on disk** rather than against
what was actually handed over.

Round two then dutifully reported the non-deviation as its **first** row — a
false positive manufactured by the prose that asked for it. A clause that
manufactures false deviations is worse than one that misses an `ls`, so the
clause ships as #50 proposed it.

**What did not catch this**, which is the part worth keeping:

- **Not the replay gate.** Round two went green; the false row read as a success
  in both the report and the transcript.
- **Not the guards.** The seventh was mutation-checked, failed against the
  earlier prose exactly as a guard should, and encoded a false claim while doing
  it. Mutation checking sizes discrimination, never truth.
- **Not CI.** Eight checks green.

What caught it was a project memory carrying 0.23.0's own conclusion, read back
after this PR was already open.

### Measured, with the sign corrected

`$CLAUDE_PLUGIN_ROOT` is empty in the Bash environment on both load paths —
marketplace install and `--plugin-dir`, Claude Code 2.1.238 — and **that is
correct**, because nothing at runtime needs it. Recorded because the naive probe
points the wrong way. 0.23.0 left *"whether a correctly loaded skill is given
it"* open: it is not, and does not need to be.

## Tests

Six guards, one class, each failing against 0.23.0's Phase 8 and report-template.
A seventh went with the reverted amendment; see the second-round section above
for why it is worth a line.

234 tests at `15d3c52`, 233 after the revert. ruff and mypy green via the pinned
hooks.
