### PR TITLE
fix: handle the array the tag query returns on a prefix (0.25.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,96 @@ patch.
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-08-21
+
+Phase 2 asks whether a moving major tag exists, and the recipe it used to ask
+with **crashed on the answer**. `git/refs/tags/<tag>` is *get all references in a
+namespace*: given a name that is a prefix rather than a ref it returns the array
+of everything matching, and `.object.type` against an array is a jq type error at
+exit 1. The names Phase 2 asks with — `v1`, `v4`, `v10` — are exactly the
+prefixes of the point releases beneath them, so the recipe failed on the question
+it existed to answer and worked only on the exact tags Phase 1 already had from
+the pin comment. Minor rather than patch: it changes what Phase 2 can establish.
+
+Found by 0.24.0's own deviation clause, on its first replay against the shipped
+text — the audit worked around it in one call, reached the right answer, and
+would never have mentioned it before #50.
+
+### Fixed
+
+- **The tag recipe branches on the array** instead of dying on it, and reports it
+  as what it is: `no such tag — these share the prefix: …`, enumerating the refs
+  that do exist.
+
+  **The array is the answer, not a failed call.** It arrives exactly when the
+  question is answerable, and `expected an object but got: array` reads like an
+  API fault — inviting a retry that returns it again and a report calling
+  currency *underivable* when it was fully derivable. The same shape as
+  CONTRIBUTING's `branches/<b>/protection` table: a confident-looking error about
+  the wrong thing.
+
+  The singular `git/ref/tags/<tag>` was rejected, and the reason is recorded: it
+  does not crash, and it is worse. It answers a bare `404` to both "no such tag,
+  and here is what does exist" and "nothing here at all", discarding the half
+  Phase 2 needs. Not crashing is not the same as answering.
+
+### Added
+
+- **The three outcomes, as a table in `references/actions.md` § Phase 1** — object,
+  array, `404` — measured rather than described. The first row is the one that
+  keeps the fix honest: `actions/checkout@v5` returns the **object** although
+  `v5.0.0`, `v5.0.1` and `v5.1.0` all sit under the same prefix. An exact ref
+  wins. Without that row, "an array means no such tag" generalises to "a moving
+  major tag returns an array", which is false and inverts the answer for every
+  action that publishes one.
+
+- **Phase 2 checks the tag line exists before reasoning about it.** The rule that
+  a newer patch is not a gap holds only where a moving major tag exists — and one
+  that existed can be discontinued.
+
+  Measured on `astral-sh/setup-uv` 2026-08-21: `v1` through `v7` are refs; `v8`,
+  `v9` and `v10` are not. The moving tag stopped at v8 (2026-03-29) and every
+  release since stands alone, so above v7 a newer patch **is** a gap and reads
+  like a registry currency gap; at v7 and below it does not. One repository
+  answers both ways depending on the major under audit, which is why it is asked
+  per bump rather than settled once per action.
+
+### The replay
+
+Both branches, on two merged PRs in a repo this account controls — the fifth-row
+lesson in CONTRIBUTING, which is that a defect on a path no reachable PR
+exercises survives this gate:
+
+| Replayed | Phase 2 asks | Old | New |
+|---|---|---|---|
+| `fpga-board-sim` #363 — `astral-sh/setup-uv` 9.0.0 → 10.0.1 | `v10`, `v9` | `expected an object but got: array`, **exit 1** | `no such tag — these share the prefix: refs/tags/v10.0.0, refs/tags/v10.0.1`, exit 0 |
+| `fpga-board-sim` #332 — `actions/checkout` 7.0.0 → 7.0.1 | `v7` | `commit 3d3c42e5…`, exit 0 | `commit 3d3c42e5…`, exit 0 — byte-identical |
+
+Phase 1's exact tags (`v10.0.1`, `v9.0.0`, `v7.0.1`) agree under both recipes, so
+the change is non-regressive on the case that already worked. The absent case
+still exits 1 with a `404`, keeping the three outcomes distinguishable.
+
+**The exit codes above were re-measured without a pipe.** The first run of this
+replay read them through `| tr`, which reports `tr`'s status and showed the
+crashing case as exit 0 — the trap CONTRIBUTING already records against
+`claude plugin eval | head`, hit again in the harness written to verify the fix.
+
+### Tests
+
+Four guards in `tests/test_skill_prose.py`, anchored to the recipe block and to
+the outcome table rather than to the phase, since Phase 1 hands off to two
+ecosystem files and "the word appears somewhere in Phase 1" would be satisfied by
+any of it. All four mutation-checked: verified failing against the pre-fix prose
+before the fix was written. 237 tests.
+
+### Measured
+
+`astral-sh/setup-uv` moving-major refs, and `actions/checkout` as the control —
+both publish `v1`–`v7`; only checkout still publishes one above that. The claim
+that `setup-uv` publishes no moving major tag was **false and was corrected
+before it reached the prose**: it publishes seven and discontinued the eighth.
+
+
 ## [0.24.0] — 2026-08-20
 
 An audit that works around a defect in **this plugin** reports nothing about it,
@@ -2398,7 +2488,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.1...v0.23.0
 [0.22.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.0...v0.22.1

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -60,15 +60,40 @@ check, and note that a bump leaving the comment unchanged — `# v1` on both sid
 means the bot is tracking a **moving** tag.
 
 ```bash
-gh api repos/<owner>/<repo>/git/refs/tags/<tag> --jq '.object.type, .object.sha'
+gh api "repos/<owner>/<repo>/git/refs/tags/<tag>" \
+  --jq 'if type == "array"
+        then "no such tag — these share the prefix: \([.[].ref] | join(", "))"
+        else "\(.object.type) \(.object.sha)" end'
 # if type == "tag" (annotated), dereference — the ref gives you the *tag object*:
-gh api repos/<owner>/<repo>/git/tags/<sha> --jq '.object.sha'
+gh api "repos/<owner>/<repo>/git/tags/<sha>" --jq '.object.sha'
 ```
 
 The dereference step is mandatory for annotated tags and a no-op for lightweight
 ones. Skipping it compares a tag object against a commit and reports a false
 mismatch. Verified live on `nickg/setup-nvc@v1`: annotated, and the undereferenced
 SHA matches nothing.
+
+**That endpoint is *get all references in a namespace*, so it answers in three
+shapes, and the middle one is the case Phase 2 asks about.** Measured 2026-08-21:
+
+| Asked for | Answer | Meaning |
+|---|---|---|
+| `actions/checkout@v5` — an **exact** ref, with `v5.0.0`, `v5.0.1` and `v5.1.0` under the same prefix | object: `commit fbc6f399` | the tag exists. An exact ref wins, and siblings under the prefix do not change that |
+| `astral-sh/setup-uv@v10` — no such ref | **array**: `refs/tags/v10.0.0`, `refs/tags/v10.0.1` | **no such tag** — and the array names what does exist instead |
+| `astral-sh/setup-uv@v999` — nothing matches | `404 Not Found`, exit 1 | no tag, and nothing beneath it either |
+
+**The array is the answer, not a failed call.** It enumerates the refs that exist
+and thereby settles that the one asked for does not, so it arrives exactly when
+the question is answerable — and `.object.type` against it dies with `expected an
+object but got: array` at exit 1. That message reads like an API fault, which
+invites a retry that returns it again and a report calling currency *underivable*
+when it was fully derivable. The same trap as `branches/<b>/protection` in
+CONTRIBUTING: a confident-looking error about the wrong thing.
+
+The singular `git/ref/tags/<tag>` does not crash, and is worse. It answers a bare
+`404` to both of the last two rows, collapsing "no such tag, and here is what does
+exist" into "nothing here" — so it discards the half Phase 2 needs. Not crashing
+is not the same as answering.
 
 **A workflow file can be generated, and then the bot's edit does not stick.**
 Compilers that emit workflows own the `uses:` pins they write — `gh-aw` generates
@@ -98,6 +123,19 @@ trigger.
 picks up new releases on its own, so a newer patch is not a gap. What matters is
 whether the *major* being adopted is still the newest one, and whether the tag
 still points where the PR proposed.
+
+**Check the tag line exists before reasoning about it.** The paragraph above
+assumes a moving major tag. Not every action publishes one, and one that did can
+stop — so ask Phase 1's recipe for the bare major and read an array as *no*.
+
+Measured on `astral-sh/setup-uv` 2026-08-21: `v1` through `v7` are refs; `v8`,
+`v9` and `v10` are not. The moving tag was discontinued at v8 (2026-03-29) and
+every release since stands alone, so above v7 there is nothing to pick up a new
+release, a newer patch **is** a gap, and it reads exactly like a registry currency
+gap. At v7 and below, it does not. One repository answers both ways depending on
+the major under audit, which is why this is asked per bump rather than settled
+once per action — and a bump that crosses the boundary changes what the pin
+comment promises, which no bot PR mentions.
 
 **When the tag does not point at the proposed SHA, that is a question, not a
 verdict.** Ask which way it moved:

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1507,5 +1507,132 @@ class TestTheAuditHandsBackItsOwnDeviations(SkillHarness):
         )
 
 
+class TestTheTagRecipeSurvivesAPrefixMatch(SkillHarness):
+    """`git/refs/tags/<tag>` is *get all references in a namespace*, and it crashed.
+
+    Found by the #50 deviation clause on its first replay against the shipped
+    text, and reproduced by hand afterwards (#54). Measured 2026-08-21:
+
+        actions/checkout    v5     -> object, commit fbc6f399  (three siblings share the prefix)
+        actions/checkout    v5.1   -> array(1): refs/tags/v5.1.0
+        astral-sh/setup-uv  v10    -> array(2): refs/tags/v10.0.0, refs/tags/v10.0.1
+        astral-sh/setup-uv  v999   -> 404 Not Found, exit 1
+
+    The rule the four measurements give: an exact ref returns an **object even
+    when siblings share the prefix**; with no exact ref the endpoint returns the
+    **array** of everything matching; with nothing matching at all, a **404**.
+    `.object.type` against the array is a jq type error — `expected an object but
+    got: array` — at exit 1.
+
+    Phase 2 asks *does a moving major tag exist* with names like `v1`, `v4`,
+    `v10`, which are prefixes of the point releases beneath them, so the recipe
+    failed on the question it exists to answer and worked only on the exact tags
+    Phase 1 already had from the pin comment.
+
+    **The array is the answer, which is why a crash is the wrong shape.** It
+    enumerates the refs that do exist and thereby settles that no `v10` does. The
+    recipe died exactly when it held the data, and `expected an object but got:
+    array` reads like an API fault rather than "no such tag" — so an auditor may
+    treat it as transient, retry, get the same error, and report as underivable a
+    question that is fully derivable. Same shape as CONTRIBUTING's
+    `branches/<b>/protection` table: a confident-looking error about the wrong
+    thing.
+
+    **The singular `git/ref/tags/<tag>` does not crash and is worse.** Measured
+    the same day, it answers a bare `404` to both `v5.1` and `v999` — collapsing
+    "no such tag, and here is what does exist" into "nothing here", which is the
+    half Phase 2 needs. Not crashing is not the same as answering.
+
+    The assertions below come from those four measurements rather than from the
+    recipe written to satisfy them: the fourth exists because "a moving major tag
+    returns an array" is the natural reading of the fix and is **false**, and
+    believing it inverts the answer for every action that does publish one.
+    """
+
+    def _tag_recipe(self) -> str:
+        """The actions.md § Phase 1 bash that asks where a tag points.
+
+        Anchored to the block, not the phase: Phase 1 hands off to two ecosystem
+        files and carries its own shell, and "the word array appears somewhere in
+        Phase 1" would be satisfied by any of it.
+        """
+        for name, section in self._handoffs(1):
+            if name != "actions.md":
+                continue
+            for block in bash_blocks(section):
+                if "git/refs/tags" in block:
+                    return block
+        self.fail("actions.md § Phase 1 has no bash block asking where a tag points")
+
+    def _outcome_table(self) -> list[str]:
+        """The actions.md § Phase 1 table with a row per outcome of that query.
+
+        Anchored the same way. Phase 1 already carries a two-row table about the
+        pin, and a guard reading "some table in this phase" would score against
+        it.
+        """
+        for name, section in self._handoffs(1):
+            if name != "actions.md":
+                continue
+            for table in tables(section):
+                joined = "\n".join(table).lower()
+                if "array" in joined and "404" in joined:
+                    return table
+        self.fail("actions.md § Phase 1 has no table separating the tag query's outcomes")
+
+    def test_the_recipe_branches_on_the_array(self):
+        """The defect itself: `.object.type` against an array is a type error."""
+        self.assertIn(
+            "array",
+            self._tag_recipe(),
+            "the tag query returns an array whenever the name is a prefix rather than "
+            "a ref, which is the case Phase 2 asks about; a recipe that does not "
+            "branch on the type dies at exit 1 on the ordinary question",
+        )
+
+    def test_the_query_has_three_outcomes_not_two(self):
+        """Object, array and 404 — and the middle one is the common case."""
+        rows = [row for row in self._outcome_table() if set(row) - set("|- :")]
+        self.assertGreaterEqual(
+            len(rows) - 1,
+            3,
+            "the tag query has three outcomes; a table with two lets the reader "
+            "collapse the array into the 404 and read a prefix match as absence",
+        )
+
+    def test_the_array_is_a_negative_answer_rather_than_a_failure(self):
+        """`expected an object but got: array` reads like an API fault. It is not.
+
+        Written from the failure mode rather than from the recipe: an auditor who
+        reads the array as an error retries it, and reports underivable a
+        currency question the array had already answered.
+        """
+        self.assertRegex(
+            self.material(1),
+            re.compile(
+                r"array.{0,600}(no such tag|does not exist|no .{0,20}ref)",
+                re.IGNORECASE | re.DOTALL,
+            ),
+            "the array has to be named as the negative answer to *does this tag "
+            "exist*; left as a crash or an error it reads as a failed call",
+        )
+
+    def test_a_shared_prefix_does_not_mean_the_tag_is_missing(self):
+        """`actions/checkout@v5` has three siblings under it and still returns the object.
+
+        Without this measurement the fix's own reading — array means no such tag —
+        generalises to "a moving major tag returns an array", which is false and
+        inverts the answer on every action that publishes one.
+        """
+        table = "\n".join(self._outcome_table()).lower()
+        self.assertIn(
+            "exact",
+            table,
+            "the outcome table must say the exact ref wins even when other refs "
+            "share the prefix, or the array row reads as covering the moving major "
+            "tag it is the negative answer about",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #54.

`references/actions.md` § Phase 1 documented a tag query that **crashes on the
case Phase 2 asks about**:

```bash
gh api repos/<o>/<r>/git/refs/tags/<tag> --jq '.object.type, .object.sha'
```

`git/refs/tags/<tag>` is *get all references in a namespace*. Given a name that
is a prefix rather than a ref it returns the array of every matching ref, and
`.object.type` against an array is a jq type error — `expected an object but got:
array` — at exit 1. Phase 2 asks *does a moving major tag exist* with `v1`, `v4`,
`v10`, which are exactly the prefixes of the point releases beneath them. So the
recipe failed on the question it existed to answer and worked only on the exact
tags Phase 1 already had from the pin comment.

**The array is the answer, which is why the crash is the wrong shape.** It
enumerates the refs that do exist and thereby settles that the one asked for does
not — so it arrives precisely when the question is answerable, and the message
reads like an API fault. An auditor may retry, get it again, and report currency
*underivable* when it was fully derivable. Same shape as CONTRIBUTING's
`branches/<b>/protection` table.

Found by 0.24.0's own deviation clause on its first replay against the shipped
text. The audit worked around it in one call and reached the right answer, so
nothing was mis-reported — which is the argument #50 was filed on: the workaround
that works is the one nobody reports.

## The replay

Both branches, on two merged PRs in a repo this account controls — CONTRIBUTING's
fifth row, that a defect on a path no reachable PR exercises survives this gate.

| Replayed | Phase 2 asks | Old | New |
|---|---|---|---|
| `fpga-board-sim` #363 — `astral-sh/setup-uv` 9.0.0 → 10.0.1 | `v10`, `v9` | `expected an object but got: array` — **exit 1** | `no such tag — these share the prefix: refs/tags/v10.0.0, refs/tags/v10.0.1` — exit 0 |
| `fpga-board-sim` #332 — `actions/checkout` 7.0.0 → 7.0.1 | `v7` | `commit 3d3c42e5…` — exit 0 | `commit 3d3c42e5…` — exit 0, byte-identical |

Phase 1's exact tags (`v10.0.1`, `v9.0.0`, `v7.0.1`) agree under both recipes, so
the change is non-regressive on the case that already worked. The absent case
still exits 1 with a `404`, keeping the three outcomes distinguishable, and the
annotated-tag dereference is untouched (`nickg/setup-nvc@v1` → `tag bb4b3a91…`).

**The exit codes were re-measured without a pipe.** The first run read them
through `| tr`, which reports `tr`'s status and showed the crashing case as exit
0 — the trap CONTRIBUTING records against `claude plugin eval | head`, hit again
inside the harness written to verify this fix.

## Two things the measurement changed before they shipped

- **`actions/checkout@v5` returns the object** although `v5.0.0`, `v5.0.1` and
  `v5.1.0` sit under the same prefix. An exact ref wins. Without that row,
  "an array means no such tag" generalises to "a moving major tag returns an
  array" — false, and it inverts the answer for every action that publishes one.
  It is the first row of the new table for that reason.
- **The draft said `setup-uv` publishes no moving major tag. It publishes seven.**
  `v1`–`v7` are refs; `v8`, `v9`, `v10` are not — discontinued at v8
  (2026-03-29). That is the better Phase 2 fact: above v7 a newer patch **is** a
  gap; at v7 and below it is not. One repository answers both ways depending on
  the major, so Phase 2 now asks per bump rather than settling it per action.

## Rejected alternative

The singular `git/ref/tags/<tag>` does not crash, and is worse: it answers a bare
`404` to both `v5.1` (no such tag, but `v5.1.0` exists) and `v999` (nothing at
all), discarding the half Phase 2 needs. Recorded in the file so it is not
re-proposed.

## Gates

Four new guards in `tests/test_skill_prose.py`, anchored to the recipe block and
the outcome table rather than to the phase. All four mutation-checked — written
first, verified failing against the pre-fix prose. 237 tests, ruff, mypy green.

Minor rather than patch: it changes what Phase 2 can establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
