### PR TITLE
fix: derive $SCRATCH so the next call can name it (0.26.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,92 @@ patch.
 
 ## [Unreleased]
 
+## [0.26.0] — 2026-08-21
+
+Phase 0 wrote its handoff to a directory the next call could not name. The line
+was `SCRATCH=${SCRATCH:-$(mktemp -d)}`, commented *"any directory OUTSIDE the
+repo"* — which says what the directory must **be** and never that it must be the
+**same one** next time. Everything downstream depends on the second property:
+`$SCRATCH/phase0.env` is written by one call and sourced by another, and both
+worktrees are addressed across calls. Minor rather than patch: it changes what
+Phase 0 can hand to the phases after it.
+
+Found by 0.24.0's deviation clause during the #51 replays and classified by the
+run itself as a prose gap (#55). Two of three rounds hit it and repaired it
+unprompted — one pinned `export SCRATCH=/tmp/tmp.5tGlKz9N3s` after the fact and
+re-sourced at the top of every later call. Both reached correct results, which is
+the point: the workaround that works is the one nobody reports.
+
+### Fixed
+
+- **`$SCRATCH` is derived rather than remembered**, so any call can recompute it:
+
+  ```bash
+  SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"; mkdir -p "$SCRATCH"
+  ```
+
+  `REPO` moves above it, since the name is derived from it. A harness-provided
+  `SCRATCH` still wins, and now for a stated reason: if one is exported into every
+  call's environment it is stable by definition, and the derived default is what
+  applies when it is not.
+
+### Measured
+
+Against this harness, two separate `Bash` calls — the claim the issue flagged as
+worth checking rather than assuming:
+
+| Carried across a call boundary? | |
+|---|---|
+| environment variables | **no** — `export PROBE_VAR=…` in call 1 is unset in call 2 |
+| shell functions | **no** — each call is a new shell process (pid 3634427 → 3634720) |
+| working directory | **yes**, while it stays inside the project — but a call that ends outside has its cwd **reset** back |
+
+So nothing ambient crosses the boundary, and the one thing that appeared to —
+cwd — is unusable here precisely because `$SCRATCH` is required to be *outside*
+the repo. What is left is a path each call can recompute from what it already
+has, which is the repo and `<N>`.
+
+Replayed with the real `discover.py` against `fpga-board-sim` #363, the PR the
+deviation was found on, as two separate calls:
+
+| | Call 2 resolves `$SCRATCH` to | `phase0.env` | Outputs downstream |
+|---|---|---|---|
+| old | `/tmp/tmp.WxRwlYLFeq` — a new directory | absent | `$DEFAULT`, `$HEAD_SHA`, `$BASE_SHA`, `$BOT_COMMITS` all **silently empty** |
+| new | `/tmp/dbaudit-Machai-Kydoimos-fpga-board-sim-363` | sourced | `main`, `9cea0a0e9647`, `bddcc474b732`, `9cea0a0e9647` |
+
+Silently empty rather than erroring is what made it survive: a truncated
+`$HEAD_SHA` matches no CI run and reads exactly like *CI never ran*.
+
+### Added
+
+- **The scratch rule now states both requirements**, not just the one about
+  location, and says why the second exists. The Phase 0 outputs table row says it
+  too, since that table is what later phases are told they may consume.
+- **`TMPDIR` joins `EXTERNAL`** in `tests/test_skill_prose.py` — the allowlist of
+  variables supplied by the environment rather than by a phase. Without it the
+  forward-reference guard reads `${TMPDIR:-/tmp}` as an output one phase owes
+  another. It caught exactly that on the first run of the fix, which is the guard
+  working.
+
+### Tests
+
+Three guards, all mutation-checked against the pre-fix prose. The third needed a
+second attempt and is the more interesting one: scanning all of Phase 0 for
+stability language went **green on the pre-fix file**, matching the *caching*
+paragraph — "persist the answers to these … Deriving costs one call" — which has
+nothing to do with where the handoff is written. Re-anchored to the paragraphs
+that name the scratch directory, it fails as it should. A guard that matches
+anything anywhere stops discriminating. 240 tests.
+
+### Not done, deliberately
+
+`$PERMS` is listed in the Phase 0 outputs table and named in Phase 6's *Requires
+from Phase 0* line, and `discover.py --shell` **does not emit it** — it prints
+`$PERMS` in the human-readable report and writes only `MAY_EXECUTE` to
+`phase0.env`. Same class as this fix, different cause, and the remedy is a choice
+between two designs rather than a correction. Filed separately.
+
+
 ## [0.25.0] — 2026-08-21
 
 Phase 2 asks whether a moving major tag exists, and the recipe it used to ask
@@ -2488,7 +2574,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.22.1...v0.23.0

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -102,8 +102,9 @@ contract is "reports, never merges" should keep them.
 
 ```bash
 D="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/discover.py"
-SCRATCH=${SCRATCH:-$(mktemp -d)}          # any directory OUTSIDE the repo
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+# OUTSIDE the repo, and the SAME directory on every later call — derived, not remembered
+SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"; mkdir -p "$SCRATCH"
 
 python3 "$D" --repo "$REPO" --number <N>                              # the report
 python3 "$D" --repo "$REPO" --number <N> --shell > "$SCRATCH/phase0.env"
@@ -207,7 +208,7 @@ If either check fails, `git worktree remove` it and re-add.
 | | |
 |---|---|
 | `$DEFAULT` | the repo's default branch, derived |
-| `$SCRATCH` | scratch directory, outside the repo |
+| `$SCRATCH` | scratch directory, outside the repo — and **derived, so every later call resolves it to the same place**. Nothing else here survives a call boundary |
 | `$HEAD_SHA` | the full 40-character commit under audit |
 | `$BASE_SHA` | the merge base, from GitHub's own `compare` endpoint — never a local `git merge-base` against `$DEFAULT`, which collapses onto the head once the PR lands. **And whether it is the bot's branch point**, which is a separate answer |
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
@@ -286,10 +287,36 @@ from the PR — it just quietly reports no changes. That holds for the repo's
 above at a ref for exactly this reason, and they were the last two reads here that
 were not.
 
-Use a harness-provided scratch directory for `SCRATCH` if you have one; otherwise
-`mktemp -d`. **Never place it inside the repo under audit** — it pollutes
-`git status`, and a gate that walks the tree (a linter, a formatter, a test
-collector) will descend into a full second copy of the project and report on it.
+**`SCRATCH` has two requirements, and only one of them is about where it is.**
+Never place it inside the repo under audit — it pollutes `git status`, and a gate
+that walks the tree (a linter, a formatter, a test collector) will descend into a
+full second copy of the project and report on it. And it must resolve to the
+**same directory on every later call**, because `$SCRATCH/phase0.env` is written
+by one call and sourced by another, and both worktrees are addressed the same way.
+
+`SCRATCH=${SCRATCH:-$(mktemp -d)}` satisfied the first and failed the second, and
+that is why the line above derives the name instead. Measured against this
+harness, two separate calls: an `export` in the first is **unset** in the second,
+shell functions likewise, and each call is a new shell process. So `${SCRATCH:-…}`
+found `SCRATCH` unset every time, `mktemp -d` returned a new directory, and the
+next call sourced a `phase0.env` that was not there — leaving `$BASE_SHA`,
+`$HEAD_SHA`, `$BOT_COMMITS` and `$DEFAULT` silently empty downstream rather than
+erroring.
+
+**The working directory does survive, and is still not a way out.** It carried
+between calls when it stayed inside the project; a call that ends outside has its
+cwd reset back. `SCRATCH` is required to be outside the repo, so it can never be
+reached that way. Nothing ambient crosses the boundary — only a path each call
+can recompute from what it already has, which is the repo and `<N>`.
+
+A harness-provided `SCRATCH` still wins, and now for a reason: if one is exported
+into every call's environment it is stable by definition. The derived default is
+what applies when it is not.
+
+Re-running the same audit reuses the directory rather than littering a new one,
+so Phase 7's cleanup is addressable from any call — but a stale worktree from an
+interrupted run is then in the way, which is a thing to remove rather than to
+work around.
 
 **Why the base comes from `compare` and not from `git merge-base`.** Once a PR
 has landed its head *is* an ancestor of the default branch, so the merge base of

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -47,7 +47,11 @@ PLUGIN = ROOT / "skills/dependabot-audit"
 SKILL = PLUGIN / "SKILL.md"
 
 # Names the skill is entitled to use without defining: the harness supplies them.
-EXTERNAL = {"CLAUDE_PLUGIN_ROOT", "HOME", "PATH", "IFS"}
+# Supplied by the environment, never by a phase, so the forward-reference guard
+# must not read them as outputs one phase owes another. `TMPDIR` joined them in
+# 0.26.0: Phase 0 derives `$SCRATCH` under `${TMPDIR:-/tmp}` so the path is the
+# same on every call, and macOS sets TMPDIR where Linux leaves it unset.
+EXTERNAL = {"CLAUDE_PLUGIN_ROOT", "HOME", "PATH", "IFS", "TMPDIR"}
 
 PHASE_HEADING = re.compile(r"^## Phase (\d+)\b", re.MULTILINE)
 FENCE = re.compile(r"^```(\w*)\n(.*?)^```", re.MULTILINE | re.DOTALL)
@@ -1631,6 +1635,114 @@ class TestTheTagRecipeSurvivesAPrefixMatch(SkillHarness):
             "the outcome table must say the exact ref wins even when other refs "
             "share the prefix, or the array row reads as covering the moving major "
             "tag it is the negative answer about",
+        )
+
+
+class TestTheScratchDirectorySurvivesTheNextCall(SkillHarness):
+    """Phase 0 wrote its handoff to a directory the next call could not name.
+
+    The line was `SCRATCH=${SCRATCH:-$(mktemp -d)}`, commented "any directory
+    OUTSIDE the repo" — which says what the directory must *be* and never that it
+    must be the *same one* next time. Everything downstream depends on the second
+    property: `$SCRATCH/phase0.env` is written by one call and sourced by another,
+    and both worktrees are addressed across calls.
+
+    Measured against this harness on 2026-08-21, two separate `Bash` calls:
+
+        call 1  export PROBE_VAR=...   pid 3634427   cd .../skills
+        call 2  PROBE_VAR=<UNSET>      pid 3634720   pwd=.../skills
+
+    Environment variables and shell functions do **not** cross the boundary — each
+    call is a new shell process. So `${SCRATCH:-...}` finds `SCRATCH` unset every
+    time and `mktemp -d` hands back a different directory, after which
+    `. "$SCRATCH/phase0.env"` sources a path that does not exist and `$BASE_SHA`,
+    `$HEAD_SHA`, `$BOT_COMMITS` and `$DEFAULT` are all empty downstream. Run as
+    the two calls above:
+
+        new form: SCRATCH=/tmp/dbaudit-<owner>-<name>-<N> in both -> sourced OK
+        old form: /tmp/tmp.wqlEPyTVGA in call 2 -> phase0.env absent, outputs empty
+
+    **The working directory does cross it, and is still not a way out.** `pwd`
+    persisted into call 2 above — but a call that ends outside the project has its
+    cwd *reset* (measured: `cd /tmp` came back to the project root), and `$SCRATCH`
+    is required to be outside the repo. So no ambient state reaches the next call,
+    and the only thing that can is a path every call can **recompute** from inputs
+    it already has.
+
+    Found by 0.24.0's deviation clause during the #51 replays and classified by
+    the run as a prose gap (#55): two of three rounds hit it and repaired it
+    unprompted, one by pinning `export SCRATCH=/tmp/tmp.5tGlKz9N3s` after the
+    fact and re-sourcing at the top of every later call. Both reached correct
+    results, which is the point — the workaround that works is the one nobody
+    reports.
+    """
+
+    def _scratch_assignment(self) -> str:
+        """The line in Phase 0's shell that sets `SCRATCH`.
+
+        Anchored to the assignment, not the phase: `$SCRATCH` is used all over
+        Phase 0, and "the phase mentions mktemp somewhere" would be satisfied by
+        the paragraph that discusses it.
+        """
+        for line in self.shell[0].splitlines():
+            if re.match(r"\s*SCRATCH=", line):
+                return line
+        self.fail("Phase 0 has no line assigning SCRATCH")
+
+    def test_the_scratch_directory_does_not_change_between_calls(self):
+        """`mktemp -d` is a new directory per call, and the handoff is per audit."""
+        self.assertNotIn(
+            "mktemp",
+            self._scratch_assignment(),
+            "Phase 0 assigns SCRATCH from mktemp, which hands back a different "
+            "directory on every Bash call; the next call then sources a phase0.env "
+            "that is not there and every Phase 0 output is empty downstream",
+        )
+
+    def test_the_scratch_path_is_derived_rather_than_remembered(self):
+        """No ambient state survives, so the path has to be recomputable.
+
+        From the measurement rather than from the fix: env vars die, functions
+        die, and cwd is reset the moment a call ends outside the project. What is
+        left is deriving the name from inputs every call already has.
+        """
+        self.assertRegex(
+            self._scratch_assignment(),
+            re.compile(r"\$\{?REPO|\$\{?OWNER|<N>"),
+            "SCRATCH must be derived from the repo and the PR number so any call "
+            "can recompute it; a value that has to be carried is a value that is "
+            "lost at the next call boundary",
+        )
+
+    def _scratch_rule(self) -> str:
+        """Every paragraph of Phase 0 that says what the scratch directory must be.
+
+        Anchored to paragraphs naming it. The first version of this guard scanned
+        all of Phase 0 and went green on the *caching* paragraph — "persist the
+        answers to these ... Deriving costs one call" — which is about not caching
+        a profile and has nothing to do with where the handoff is written. A guard
+        that matches anything anywhere stops discriminating.
+        """
+        chunks = [
+            chunk
+            for chunk in re.split(r"\n\s*\n", self.material(0))
+            if re.search(r"scratch", chunk, re.IGNORECASE)
+        ]
+        if not chunks:
+            self.fail("Phase 0 says nothing about the scratch directory")
+        return "\n\n".join(chunks)
+
+    def test_the_rule_says_stable_and_not_merely_outside_the_repo(self):
+        """The old comment gave one of the two properties, and not the load-bearing one."""
+        self.assertRegex(
+            self._scratch_rule(),
+            re.compile(
+                r"(stable|same directory|same place|survive|recompute)",
+                re.IGNORECASE,
+            ),
+            "the scratch rule states only that the directory sits outside the repo; "
+            "the property phase0.env and both worktrees actually depend on is that "
+            "the next call resolves it to the same place",
         )
 
 


### PR DESCRIPTION
Closes #55.

Phase 0 wrote its handoff to a directory the next call could not name:

```bash
SCRATCH=${SCRATCH:-$(mktemp -d)}          # any directory OUTSIDE the repo
```

The comment says what the directory must **be** and never that it must be the
**same one** next time — the property everything downstream depends on.
`$SCRATCH/phase0.env` is written by one call and sourced by another, and both
worktrees are addressed across calls.

Each `Bash` call is a new shell, so `${SCRATCH:-…}` found `SCRATCH` unset every
time, `mktemp -d` returned a fresh directory, and the next call sourced a
`phase0.env` that was not there. `$BASE_SHA`, `$HEAD_SHA`, `$BOT_COMMITS` and
`$DEFAULT` were then empty downstream — **silently**, which is what let it
survive: a truncated `$HEAD_SHA` matches no CI run and reads exactly like *CI
never ran*.

## Measured, because the issue said to check rather than assume

Two separate `Bash` calls against this harness:

| Carried across a call boundary? | |
|---|---|
| environment variables | **no** — `export PROBE_VAR=…` in call 1 is unset in call 2 |
| shell functions | **no** — each call is a new shell process (pid 3634427 → 3634720) |
| working directory | **yes**, while it stays inside the project — but a call that ends outside has its cwd **reset** back |

The cwd result is the one that mattered and it does not rescue anything: it is
unusable here precisely because `$SCRATCH` is required to be *outside* the repo.
Nothing ambient crosses the boundary. What is left is a path each call can
recompute from what it already has:

```bash
REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"; mkdir -p "$SCRATCH"
```

`REPO` moves above it since the name derives from it. A harness-provided
`SCRATCH` still wins, and now for a stated reason: exported into every call's
environment it is stable by definition, and the derived default applies when it
is not.

## The replay

Real `discover.py` against `fpga-board-sim` #363 — the PR the deviation was found
on — as two separate calls:

| | Call 2 resolves `$SCRATCH` to | `phase0.env` | Outputs downstream |
|---|---|---|---|
| old | `/tmp/tmp.WxRwlYLFeq` — a new directory | absent | all **silently empty** |
| new | `/tmp/dbaudit-Machai-Kydoimos-fpga-board-sim-363` | sourced | `DEFAULT=main`, `HEAD_SHA=9cea0a0e9647`, `BASE_SHA=bddcc474b732`, `BOT_COMMITS=9cea0a0e9647` |

## Gates

Three guards, all mutation-checked. **The third took two attempts and is the
instructive one:** scanning all of Phase 0 for stability language went *green on
the pre-fix file*, matching the caching paragraph — "persist the answers to these
… Deriving costs one call" — which is about not caching a profile and has nothing
to do with where the handoff is written. Re-anchored to the paragraphs that name
the scratch directory, it fails as it should.

`TMPDIR` joins `EXTERNAL`, the allowlist of variables supplied by the environment
rather than by a phase. The forward-reference guard read `${TMPDIR:-/tmp}` as an
output one phase owed another and failed the first run of this fix — the guard
working, not a false positive.

240 tests, ruff, mypy green. Minor rather than patch: it changes what Phase 0 can
hand to the phases after it.

## Found on the way, not fixed here

`$PERMS` is in the Phase 0 outputs table and in Phase 6's *Requires from Phase 0*
line, and `discover.py --shell` **does not emit it** — it prints `$PERMS` in the
human-readable report and writes only `MAY_EXECUTE` to `phase0.env`. Same class
as this defect, different cause, and the remedy is a choice between two designs.
Filed separately rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
