### PR TITLE
fix: stop Phase 0 promising $PERMS it never hands over (0.26.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,76 @@ patch.
 
 ## [Unreleased]
 
+## [0.26.1] — 2026-08-21
+
+Phase 6 declared a requirement the handoff has never carried:
+
+> *Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*
+
+`discover.py --shell` does not write `$PERMS`. It prints it in the
+human-readable report and writes only the derived `MAY_EXECUTE` to `phase0.env`,
+so a phase that sourced the handoff and read `$PERMS` would get the empty string.
+The Phase 0 outputs table listed it too, under a heading saying *every later phase
+consumes these and nothing else*.
+
+**Patch rather than minor**, unlike the two fixes before it. Nothing was broken in
+execution: no shell block reads `$PERMS`, so the empty value never reached a
+command, and Phase 6 behaves exactly as it did. This only makes an existing claim
+true, which is this file's own definition of a patch.
+
+### Fixed
+
+- **Phase 6's requires-line drops `$PERMS`**, and the direction of the fix is
+  settled by the phase it was attached to rather than by convenience: Phase 0
+  says the required-checks question "moved to Phase 6, which asks it per-PR in a
+  form readable at `pull`". Needing no permission tier is the whole point of that
+  design, so `$PERMS` in its contract contradicted it.
+
+- **The outputs table lists only what crosses.** `$PERMS` comes off the row —
+  it is read from the report *in Phase 0*, where the execution gate and the
+  actionability question both use it, and the handoff carries `MAY_EXECUTE`
+  instead, which is the decision `$PERMS` was consulted to make. The reason it
+  cannot cross is now stated: `$PERMS` is a set of flags, `$PERMS.push` is how
+  the gate addresses it, and there is no shell form of that.
+
+- **`$BRANCH_POINT` goes on**, which the drift ran the other way. It is emitted,
+  and Phase 1 reads it, and it was missing from the table that claims to be
+  complete.
+
+### Tests
+
+Two guards, closing the class rather than the instance, as the issue that filed
+it proposed: every name in a *Requires from Phase 0* line, and every `$VAR` row in
+the outputs table, must be something Phase 0 actually produces — from
+`discover.py`'s emitter or from Phase 0's own shell.
+
+The emitter's names are read from the script's **source**, since the suite is
+offline and `discover.py` needs `gh`. It is located by the header it prints
+rather than by its function name: found by name, a rename would silently empty
+the set and every guard would pass by matching nothing. The second half of
+`_produced()` is not padding either — `$SCRATCH` never passes through the script,
+so an emitter-only guard would call the most-used output of all a broken promise.
+
+Both mutation-checked against the pre-fix prose, and re-checked afterwards by
+restoring `$PERMS` to the requires-line, which fails as it should. 242 tests.
+
+### Measured
+
+Replayed against `fpga-board-sim` #363 as two calls, sourcing a real
+`phase0.env`. Phase 6's four remaining requirements resolve —
+`9cea0a0e9647`, `bddcc474b732`, `Machai-Kydoimos`, `fpga-board-sim` — while
+`$PERMS` is empty exactly as the corrected table now says, `$BRANCH_POINT=ok` is
+carried, and `$MAY_EXECUTE=yes` is what crosses in its place.
+
+The drift was **bidirectional**, which the issue did not catch and the guards now
+do: the table promised `$PERMS` and `$SCRATCH` while the emitter writes ten names
+including `BASE_REF`, `BRANCH_POINT` and `MAY_EXECUTE`. `$SCRATCH` is legitimate —
+Phase 0's shell assigns it directly — and `BASE_REF` is Phase 0's own cross-check
+that no later phase consumes, so the completeness rule runs one way only: the
+table may omit an output nothing downstream reads, but it may not promise one
+that does not exist.
+
+
 ## [0.26.0] — 2026-08-21
 
 Phase 0 wrote its handoff to a directory the next call could not name. The line
@@ -2574,7 +2644,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.23.0...v0.24.0

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -216,9 +216,21 @@ If either check fails, `git worktree remove` it and re-add.
 | `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below. Same exception |
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
-| `$PERMS` | this account's permissions on the repo — `admin`, `maintain`, `push`, `triage`, `pull` |
+| `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **Phase 1 reads it**, and the table below says what each one means |
 | `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
 | `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
+
+**`$PERMS` is not on that list, and the distinction is the point.** It is read off
+`discover.py`'s report *here in Phase 0*, where the execution gate and the
+actionability question both use it. It is **not** written to `phase0.env`: the
+shell handoff carries `MAY_EXECUTE`, which is the decision `$PERMS` was consulted
+to make. So a later phase that sources the handoff and reads `$PERMS` gets the
+empty string, and the table above is the list that crosses — anything else is
+Phase 0's own working state.
+
+The reason is that `$PERMS` is a set of flags rather than a value: `$PERMS.push`
+is how the gate below addresses it, and there is no shell form of that. Reducing
+it to the one bit later phases actually branch on is what `MAY_EXECUTE` is.
 
 If a later phase needs something not on this list, it belongs here rather than
 there. A phase that consumes what a later phase creates cannot be run in order,
@@ -652,7 +664,7 @@ tidy up after itself.
 
 ## Phase 6 — CI verification
 
-*Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*
+*Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`.*
 
 Confirm the green you are trusting belongs to **this** commit, **and that it
 exercised the change**. Those are two questions, and an actions bump routinely

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1746,5 +1746,113 @@ class TestTheScratchDirectorySurvivesTheNextCall(SkillHarness):
         )
 
 
+def _emitted_by_discover() -> set[str]:
+    """The variable names `discover.py --shell` writes, read from its source.
+
+    Static rather than executed: the suite is offline and stdlib-only, and the
+    script needs `gh`. The emitter is located by the **header it prints** rather
+    than by its function name, so renaming the function cannot silently empty
+    this set — which would make every guard below pass by matching nothing.
+    """
+    src = (PLUGIN / "scripts/discover.py").read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        body = ast.unparse(node)
+        if "Phase 0 outputs. Sourced, not transcribed." not in body:
+            continue
+        # `("DEFAULT", ...)` and `{"BOT_COMMITS": ...}` are bare constants;
+        # `f"BRANCH_POINT={...}"` puts the name straight against an `=`.
+        names = {
+            c.value
+            for c in ast.walk(node)
+            if isinstance(c, ast.Constant)
+            and isinstance(c.value, str)
+            and re.fullmatch(r"[A-Z][A-Z0-9_]*", c.value)
+        }
+        return names | set(re.findall(r"\b([A-Z_][A-Z0-9_]*)=", body))
+    raise AssertionError("discover.py has no function printing the Phase 0 shell header")
+
+
+class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
+    """Phase 6 declared a requirement the handoff has never carried.
+
+    Its contract line read:
+
+        *Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*
+
+    and the Phase 0 outputs table listed `$PERMS` under a heading saying *every
+    later phase consumes these and nothing else*. `discover.py --shell` does not
+    write it. Measured against a real `phase0.env` from `fpga-board-sim` #363:
+
+        DEFAULT HEAD_SHA BASE_REF BASE_SHA OWNER NAME BRANCH_POINT
+        MAY_EXECUTE BOT_COMMITS HUMAN_COMMITS
+
+    Ten names, no `PERMS`. The script prints `$PERMS` in its **human-readable
+    report** and writes only the derived `MAY_EXECUTE` to the shell output, so a
+    phase that sourced the handoff and read `$PERMS` would get the empty string.
+
+    Nothing broke, which is why it survived: no shell block reads `$PERMS`, so
+    the empty value never reached a command, and the forward-reference guard —
+    which scans shell, not prose — was right to stay quiet. The contract was
+    still false, and a requires-line is exactly the sentence someone trusts when
+    adding a step that branches on permissions.
+
+    **Phase 6 does not want it anyway**, which is what settles the direction of
+    the fix. Phase 0 says the required-checks question "moved to Phase 6, which
+    asks it per-PR in a form readable at `pull`" — the whole point of that design
+    is that Phase 6 needs no permission tier at all. `$PERMS` in its requires-line
+    contradicted the phase it was attached to.
+
+    Guarded as a class rather than as the instance, per the issue that filed it:
+    a name in a requires-line, or a row in the outputs table, must be something
+    Phase 0 actually produces — from the script's emitter or from its own shell.
+    """
+
+    REQUIRES = re.compile(r"Requires from Phase 0:(.*)", re.IGNORECASE)
+
+    def _produced(self) -> set[str]:
+        """What a later phase can actually receive: the emitter, plus Phase 0's shell.
+
+        The second half is not padding — `$SCRATCH` is assigned by Phase 0
+        directly and never passes through `discover.py`, so a guard reading only
+        the emitter would call the most-used output of all a broken promise.
+        """
+        return _emitted_by_discover() | set(ASSIGNED.findall(self.shell[0]))
+
+    def test_every_requires_line_names_something_phase_0_produces(self):
+        produced = self._produced()
+        seen = 0
+        for number, body in self.phases:
+            for line in body.splitlines():
+                found = self.REQUIRES.search(line)
+                if not found:
+                    continue
+                seen += 1
+                for name in re.findall(r"\$([A-Z_][A-Z0-9_]*)", found.group(1)):
+                    self.assertIn(
+                        name,
+                        produced,
+                        f"Phase {number} requires ${name} from Phase 0, which neither "
+                        f"discover.py --shell writes nor Phase 0's shell assigns; a phase "
+                        f"sourcing the handoff and reading it gets the empty string",
+                    )
+        self.assertGreater(seen, 0, "no phase states what it requires from Phase 0")
+
+    def test_the_outputs_table_lists_only_real_outputs(self):
+        """The table says later phases consume these *and nothing else*."""
+        produced = self._produced()
+        rows = re.findall(r"^\|\s*`\$([A-Z_][A-Z0-9_]*)`", dict(self.phases)[0], re.MULTILINE)
+        self.assertTrue(rows, "Phase 0 has no outputs table")
+        for name in rows:
+            self.assertIn(
+                name,
+                produced,
+                f"the Phase 0 outputs table promises ${name}, which nothing in Phase 0 "
+                f"writes into the handoff; the table is what later phases are told they "
+                f"may consume",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #58.

Phase 6 declared a requirement the handoff has never carried:

> *Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`, `$PERMS`.*

`discover.py --shell` does not write `$PERMS`. It prints it in the human-readable
report (`discover.py:336`, `:343`) and writes only the derived `MAY_EXECUTE` to
`phase0.env` (`:444`). The Phase 0 outputs table listed it too, under a heading
saying *every later phase consumes these and nothing else*.

Nothing broke, which is why it survived to be found by accident while replaying
#55: no shell block reads `$PERMS`, so the empty value never reached a command,
and the forward-reference guard — which scans shell, not prose — was right to stay
quiet.

## The direction of the fix is settled by the phase it was attached to

Not by which edit is cheaper. Phase 0 states that the required-checks question
"moved to Phase 6, which asks it per-PR in a form readable at `pull`". Needing no
permission tier is the *whole point* of that design, so `$PERMS` in Phase 6's
contract contradicted the phase it belonged to. Emitting `PERMS=` to satisfy the
line would have made the contract true and the design incoherent.

`$PERMS` also cannot cross in any useful form: it is a set of flags, `$PERMS.push`
is how Phase 0's gate addresses it, and there is no shell form of that. Reducing
it to the one bit later phases branch on is what `MAY_EXECUTE` already is.

## The drift was bidirectional, which the issue did not catch

| | |
|---|---|
| table promises, emitter does not write | `$PERMS` — **the defect**; `$SCRATCH` — legitimate, Phase 0's shell assigns it directly |
| emitter writes, table omits | `BASE_REF` — Phase 0's own cross-check, no later consumer; `MAY_EXECUTE`; **`BRANCH_POINT` — emitted *and* read by Phase 1 (line 434)** |

`$BRANCH_POINT` is now a row. So the completeness rule runs one way only, and the
guards encode exactly that: the table may omit an output nothing downstream reads,
but it may not promise one that does not exist.

## The replay

Against `fpga-board-sim` #363 as two calls, sourcing a real `phase0.env`:

```
Phase 6's requires-line, AS CORRECTED:
  $HEAD_SHA  = [9cea0a0e9647b9]  OK
  $BASE_SHA  = [bddcc474b7329f]  OK
  $OWNER     = [Machai-Kydoimo]  OK
  $NAME      = [fpga-board-sim]  OK

  $PERMS        = []      empty — as the corrected table now states
  $BRANCH_POINT = [ok]    carried, and Phase 1 reads it
  $MAY_EXECUTE  = [yes]   the decision $PERMS was consulted to make
```

## Gates

Two guards, closing the class rather than the instance, as the issue proposed.
The emitter's names are read from `discover.py`'s **source**, since the suite is
offline and the script needs `gh`. It is located by *the header it prints* rather
than by its function name — found by name, a rename would silently empty the set
and every guard would pass by matching nothing. The second half of `_produced()`
is load-bearing too: `$SCRATCH` never passes through the script, so an
emitter-only guard would call the most-used output of all a broken promise.

Both mutation-checked against the pre-fix prose, and re-checked after the fix by
restoring `$PERMS` to the requires-line, which fails as it should. 242 tests,
ruff, mypy green.

**Patch rather than minor**, unlike the two fixes before it: nothing was broken in
execution and Phase 6 behaves exactly as it did. This only makes an existing claim
true, which is CONTRIBUTING's definition of a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
