### PR TITLE
feat: read the action's interface, not only its notes (0.27.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,76 @@ patch.
 
 ## [Unreleased]
 
+## [0.27.0] — 2026-08-21
+
+Phase 4 for actions had one source and no way to check it. An action cannot be
+run locally at two versions, so reading the release notes is the method rather
+than the shortcut — which makes it load-bearing that what is read is complete.
+It is not. Minor: it changes what Phase 4 verifies.
+
+Measured on `fpga-board-sim` #363, `astral-sh/setup-uv` 9.0.0 → 10.0.1, where
+v10.0.0 disables the cache under `enable-cache: auto`:
+
+| Source | Conditions it names |
+|---|---|
+| the release notes | **3** — `pull_request_target`, `workflow_run`, `release` |
+| `action.yml` description | **5** — "GitHub-hosted runners except for release, **tag push**, `pull_request_target`, and `workflow_run`" |
+| `src/utils/inputs.ts` | **5** — `isTagPush` checked *first*, its own branch and its own log line, then the three-event `||` chain |
+
+The word *tag* appears nowhere in the notes body. They were written from the
+second `if` and missed the first.
+
+### Added
+
+- **Phase 4 reads the action's interface at both pins.** `action.yml` ships in
+  the action's own repo, so it is fetchable at any SHA, and the diff answers the
+  *a default input flips* row mechanically instead of by inference.
+
+- **A description-only diff is a finding, not a clean bill.** `default: "auto"`
+  is **unchanged** across #363 — what changed is what `auto` means — so a check
+  asking whether a default flipped correctly answers *no* while the behaviour
+  moves underneath it. The only place the fourth condition surfaced was
+  description prose.
+
+- **Where the notes and the interface disagree, the source settles it**, and it
+  ships in the same repo at the same ref.
+
+### Fixed
+
+- **The trigger row could not see a tag push.** It greps for event names, and a
+  tag push is not one: it is `push` with a `refs/tags/` ref. Grepping
+  `pull_request_target:` and `workflow_run:` finds nothing; grepping `push:`
+  matches nearly every workflow ever written. The row now names the shape —
+  `push:` carrying a `tags:` key — and `release:`, which it had also omitted.
+
+### The replay
+
+Two targets, both merged PRs on a repo this account controls, chosen to exercise
+the two branches — CONTRIBUTING's fifth row, since #363 alone reaches only one:
+
+| Replayed | `action.yml` diff | Outcome |
+|---|---|---|
+| #363 — setup-uv 9.0.0 → 10.0.1 | description text only | **discovers** — the fourth condition exists nowhere in the notes |
+| #333 — setup-uv 8.3.2 → 9.0.0 | one line: `prune-cache` `default: "true"` → `"false"` | **confirms** — v9.0.0 announces it under *🚨 Breaking changes* |
+
+The second is the one worth having: interface and notes agree, the read costs one
+call, and it returns a falsifiable *no surprises*. A method that only ever fires
+is one nobody runs. It also exercises the *default input flips* row end to end —
+`fpga-board-sim` sets `prune-cache` nowhere, so it takes the new default rather
+than pinning the old one, and the finding is real rather than inert.
+
+On #363 the original verdict of *inert here* was correct, and correct **by luck**:
+that repo triggers on `push: branches: [main]` and `pull_request:` only. The same
+procedure on a repo with `push: tags:` reports inert about a change that is live.
+
+### Tests
+
+Four guards, all mutation-checked against the pre-fix prose. One asserts the
+phase carries the **query** rather than the advice to compare — a phase that says
+"check the interface" and hands over no command is a wish, and the existing
+handoff guards would have been satisfied by the sentence alone. 246 tests.
+
+
 ## [0.26.1] — 2026-08-21
 
 Phase 6 declared a requirement the handoff has never carried:
@@ -2644,7 +2714,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.1...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.1...v0.27.0
 [0.26.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.24.0...v0.25.0

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -209,7 +209,7 @@ repo's workflows that decides whether it applies:
 
 | Change | What to grep for here |
 |---|---|
-| a trigger is newly restricted | `pull_request_target:`, `workflow_run:` in this repo's workflows |
+| a trigger is newly restricted | `pull_request_target:`, `workflow_run:`, `release:` in this repo's workflows — **and `push:` carrying a `tags:` key**, because a tag push is not an event name. It is `push` with a `refs/tags/` ref, so the event-name grep cannot see it |
 | a default input flips | that input's name — an explicit setting pins the old behaviour |
 | a minimum runner or Node version | `runs-on:` — GitHub-hosted is fine, a self-hosted label is not |
 | credential or token handling | `permissions:`, `persist-credentials`, and what later steps do with the token |
@@ -220,6 +220,59 @@ this phase working; reaching it by not looking is the failure. Observed:
 `workflow_run` — a security change shipped as a plain bullet with no heading and
 no ⚠️ — and it was genuinely inert on a repo that uses neither trigger. The report
 should say so and name the greps that settled it.
+
+**Read the interface, not only the notes.** The notes are prose written by the
+releaser; `action.yml` is what the runner loads, it ships in the action's own
+repo, and it is therefore readable at both pins:
+
+```bash
+for R in <old-sha> <new-sha>; do
+  gh api "repos/<owner>/<action>/contents/action.yml?ref=$R" --jq .content \
+    | base64 -d > "$SCRATCH/action-$R.yml"
+done
+diff -u "$SCRATCH/action-<old-sha>.yml" "$SCRATCH/action-<new-sha>.yml"
+```
+
+An input added, removed, renamed, or with its `default:` changed shows up here or
+does not, which is a falsifiable answer to the *default input flips* row above
+rather than an inference from someone's summary.
+
+**A description-only diff is a finding, not a clean bill.** Measured on
+`astral-sh/setup-uv` 9.0.0 → 10.0.1, whose v10.0.0 disables the cache under
+`enable-cache: auto`:
+
+| Source | Conditions it names |
+|---|---|
+| the release notes | **3** — `pull_request_target`, `workflow_run`, `release` |
+| `action.yml` description | **5** — "GitHub-hosted runners except for release, **tag push**, `pull_request_target`, and `workflow_run`" |
+| `src/utils/inputs.ts` | **5** — `isTagPush` checked *first*, its own branch and its own log line, then the three-event `||` chain |
+
+The word *tag* appears nowhere in the notes body. They were written from the
+second `if` and missed the first. And `default: "auto"` is **unchanged** across
+the bump — what changed is what `auto` means — so a check asking whether a
+default flipped correctly answers *no* while the behaviour moves underneath it.
+The only place the fourth condition surfaced was description prose. Treat that
+prose as the signal it is.
+
+**Where the notes and the interface disagree, the source settles it**, and it
+ships in the same repo at the same ref. That is the read that turned "the
+description says four, the notes say three" into which one is true.
+
+On `fpga-board-sim` #363 the verdict was *inert here* and was correct — that repo
+triggers on `push: branches: [main]` and `pull_request:` only. It was correct by
+luck. The same procedure, on a repo with `push: tags:`, reports inert about a
+change that is live.
+
+**Most of the time the diff confirms rather than discovers, and that is the
+result you want.** Same action one release earlier — `fpga-board-sim` #333,
+setup-uv 8.3.2 → 9.0.0 — and the diff is a single clean line, `prune-cache`
+`default: "true"` → `"false"`, which v9.0.0's notes announce under *🚨 Breaking
+changes*. Interface and notes agree, so the read costs one call and returns a
+falsifiable *no surprises*. A method that only ever fires is one nobody runs.
+
+That bump is also the *default input flips* row working end to end: the repo sets
+`prune-cache` nowhere, so it takes the new default rather than pinning the old
+one, and the finding is real rather than inert.
 
 **Two signals that the notes alone will not give you.** Both were observed:
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1854,5 +1854,97 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
             )
 
 
+class TestPhase4ReadsTheActionsInterfaceNotOnlyItsNotes(SkillHarness):
+    """The release notes understated the change, and the method had no second source.
+
+    `references/actions.md` § Phase 4 said: read the notes for every version in
+    the gap, then grep this repo's workflows for what they name. An action cannot
+    be run locally at two versions, so reading is the method rather than the
+    shortcut — which makes it load-bearing that what is read is complete.
+
+    It is not. Measured on `fpga-board-sim` #363, `astral-sh/setup-uv`
+    9.0.0 → 10.0.1, where v10.0.0 disables the cache under `enable-cache: auto`:
+
+        release notes      3 conditions — pull_request_target, workflow_run, release
+        action.yml         5 — "GitHub-hosted runners except for release, tag push,
+                               pull_request_target, and workflow_run"
+        src/utils/inputs.ts 5 — isTagPush checked FIRST, its own branch, its own
+                               log line, then the three-event `||` chain
+
+    The word *tag* does not appear anywhere in the notes body. The notes were
+    written from the second `if` and missed the first.
+
+    **Two things the diff shows that no reading of the notes does.** `default:
+    "auto"` is **unchanged** across the bump — what changed is what `auto` means,
+    so a check asking "did a default flip?" correctly answers no while the
+    behaviour changed underneath it. And the only place the fourth condition
+    surfaced at all was **description prose**, which is why a description-only
+    diff is a finding rather than a clean bill.
+
+    **The trigger is not an event name, which is why the grep row missed it.**
+    Tag push is `eventName === "push"` *and* `GITHUB_REF` starting `refs/tags/`.
+    Grepping a workflow for `pull_request_target:` and `workflow_run:` finds
+    nothing; grepping for `push:` matches nearly every workflow ever written.
+    Neither answers the question. The check is `push:` carrying a `tags:` key.
+
+    On #363 the verdict was "inert here" and was right — that repo triggers on
+    `push: branches: [main]` and `pull_request:` only. It was right by luck: the
+    same procedure on a repo with `push: tags:` reports inert about a change that
+    is live. Per CONTRIBUTING's fifth row, a defect on a path no reachable PR
+    exercises survives the replay gate, and this one did until the notes were
+    checked against the source.
+    """
+
+    def _phase4(self) -> str:
+        for name, section in self._handoffs(4):
+            if name == "actions.md":
+                return section
+        self.fail("Phase 4 does not hand off to actions.md")
+
+    def test_the_interface_is_read_at_both_pins(self):
+        """`action.yml` ships in the action's own repo, so it is readable at any pin."""
+        self.assertIn(
+            "action.yml",
+            self._phase4(),
+            "Phase 4 for actions reads only the release notes, which are prose written "
+            "by the releaser; action.yml is the interface the runner actually loads and "
+            "it is fetchable at both SHAs",
+        )
+
+    def test_it_is_a_command_rather_than_an_instruction_to_look(self):
+        """A phase that says 'check the interface' and hands over no query is a wish."""
+        blocks = "\n".join(bash_blocks(self._phase4()))
+        self.assertRegex(
+            blocks,
+            re.compile(r"action\.yml"),
+            "Phase 4 for actions must carry the query that fetches the interface at "
+            "both pins, not only the advice to compare them",
+        )
+
+    def test_a_description_only_diff_is_not_a_clean_bill(self):
+        """`default: "auto"` never changed; the meaning of `auto` did.
+
+        From the measurement rather than the fix: the fourth condition existed
+        *only* in description prose, so a reader who treats description churn as
+        cosmetic discards the one place the change was visible.
+        """
+        self.assertRegex(
+            self._phase4(),
+            re.compile(r"description", re.IGNORECASE),
+            "the diff's description-only case has to be called out, or it reads as "
+            "the clean result it looks like — which is how the fourth condition hid",
+        )
+
+    def test_the_tag_push_shape_is_named_rather_than_the_event_list(self):
+        """`push:` + `tags:` — grepping the three event names cannot find it."""
+        self.assertIn(
+            "tags:",
+            self._phase4(),
+            "the trigger row greps for event names, and tag push is not one: it is "
+            "`push` plus a refs/tags ref, so the three-name grep returns nothing and "
+            "reports inert on a repo that publishes tags",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #53.

Phase 4 for actions had one source and no way to check it. An action cannot be
run locally at two versions, so reading the release notes is the *method* rather
than the shortcut — which makes it load-bearing that what is read is complete.

It is not. Measured on `fpga-board-sim` #363, `astral-sh/setup-uv` 9.0.0 →
10.0.1, where v10.0.0 disables the cache under `enable-cache: auto`:

| Source | Conditions it names |
|---|---|
| the release notes | **3** — `pull_request_target`, `workflow_run`, `release` |
| `action.yml` description | **5** — "GitHub-hosted runners except for release, **tag push**, `pull_request_target`, and `workflow_run`" |
| `src/utils/inputs.ts` | **5** — `isTagPush` checked *first*, its own branch and its own log line, then the three-event `||` chain |

The word *tag* appears nowhere in the notes body. They were written from the
second `if` and missed the first.

## Two things the diff shows that no reading of the notes does

**`default: "auto"` is unchanged** across the bump. What changed is what `auto`
*means*, so a check asking "did a default flip?" correctly answers *no* while the
behaviour moves underneath it. And the only place the fourth condition surfaced
was **description prose** — which is why a description-only diff is a finding
rather than a clean bill, and why this is not merely a default-flip detector.

## The trigger row could not see it either

A separate defect in the same paragraph. The row greps for event names, and a tag
push is not one: it is `eventName === "push"` **and** `GITHUB_REF` starting
`refs/tags/`. Grepping `pull_request_target:` and `workflow_run:` finds nothing;
grepping `push:` matches nearly every workflow ever written. Neither answers the
question. The row now names the shape — `push:` carrying a `tags:` key — plus
`release:`, which it had also omitted.

## The replay

Two targets, both merged PRs on a repo this account controls, chosen to exercise
the two branches. CONTRIBUTING's fifth row applies: #363 alone reaches only one,
and the issue noted such a second target had not been found yet.

| Replayed | `action.yml` diff | Outcome |
|---|---|---|
| #363 — setup-uv 9.0.0 → 10.0.1 | description text only | **discovers** — the fourth condition exists nowhere in the notes |
| #333 — setup-uv 8.3.2 → 9.0.0 | one line: `prune-cache` `default: "true"` → `"false"` | **confirms** — v9.0.0 announces it under *🚨 Breaking changes* |

**The second is the one worth having.** Interface and notes agree, the read costs
one call, and it returns a falsifiable *no surprises*. A method that only ever
fires is one nobody runs. It also exercises the *default input flips* row end to
end: `fpga-board-sim` sets `prune-cache` nowhere, so it takes the new default
rather than pinning the old one, and the finding is real rather than inert.

On #363 the original verdict of *inert here* was correct, and correct **by luck** —
that repo triggers on `push: branches: [main]` and `pull_request:` only.

## Gates

Four guards, all mutation-checked against the pre-fix prose. One asserts the phase
carries the **query** rather than the advice to compare: a phase that says "check
the interface" and hands over no command is a wish, and the existing handoff
guards would have been satisfied by the sentence alone.

246 tests, ruff, mypy green. Minor rather than patch: it changes what Phase 4
verifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
