### PR TITLE
fix: reload Phase 0's handoff in every block that consumes it (0.28.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,113 @@ patch.
 
 ## [Unreleased]
 
+## [0.28.0] — 2026-08-21
+
+Phase 0's handoff was written once, sourced once, and read by seven blocks that
+never reloaded it. Minor: Phase 1's scope gate now gates where it previously
+passed silently, which is a change to what a phase verifies.
+
+`SKILL.md` has stated the mechanism since 0.26.0, in its own Phase 0:
+
+> Measured against this harness, two separate calls: an `export` in the first is
+> **unset** in the second, shell functions likewise, and each call is a new shell
+> process.
+
+Re-measured across two Bash calls in one session: a variable exported in the
+first reads `<UNSET>` in the second, a function defined in the first is `not
+found`, and the pids differ. 0.26.0 fixed `$SCRATCH`'s **derivation** so the next
+call could name the directory. **Recomputable is not recomputed** — nothing told
+the next call to go and find it, so `. "$SCRATCH/phase0.env"` appeared exactly
+once in the plugin, inside the phase that writes it, while Phase 1, Phase 4,
+Phase 6, Phase 7 and both ecosystem references read what it carries.
+
+Running each consuming block in a fresh call with nothing sourced:
+
+| Block | Result |
+|---|---|
+| Phase 1, `uv.lock` | `/base.uv.lock: Permission denied` — loud |
+| Phase 4, `gate_diff.py` | `error: /base-1 is not a git worktree`, exit 2 — loud |
+| Phase 6, `ci_state.py` | `Could not resolve to a Repository with the name '/'`, exit 2 — loud |
+| Phase 7, cleanup | `fatal: '/pr-1' is not a working tree`, exit 128 — loud, and both worktrees stay registered in the user's repo |
+| **Phase 1, the authorship gate** | **silent** |
+
+`for c in $BOT_COMMITS` over an unset variable iterates zero times, so the gate's
+file list is empty and it passes. `SKILL.md` names that outcome itself — *"the one
+outcome worse than a false Hold"*. On an actions bump nothing fails loudly ahead
+of it: `references/actions.md` § Phase 1 makes no `$SCRATCH` writes at all.
+
+### Fixed
+
+- **Every block that consumes a Phase 0 output reloads it first.** Three lines,
+  repeated in all seven rather than stated once, because a step that is merely
+  implied is one that gets skipped — the same argument that put the gate list at
+  a ref. The `||` is the load-bearing half: a `.` on a missing file returns 1 and
+  keeps going, so without it the block runs on with every output empty.
+
+- **Phase 1's underivable fallback moved out of the prose and into the shell.**
+  Phase 0 already emits `# BOT_COMMITS is absent` commented out, precisely so the
+  variable stays unset, and Phase 0's third state already said what to do
+  instead — *"Where `$BOT_COMMITS` is unset, gate on the whole
+  `$BASE_SHA..pr-<N>` diff"*. The block did not implement it. Both doors to the
+  silent pass are now shut: the handoff is reloaded, and an unset list is tested
+  rather than iterated.
+
+- **`git` state is the exception and is now said to be.** The `pr-<N>` ref Phase
+  0 fetches lives in the repository, so `git show "pr-<N>:…"` works from any
+  call. Only the shell handoff is lost, and conflating the two is what made the
+  reload look unnecessary.
+
+### The replay
+
+Two calls, deliberately separate, against two PRs chosen to exercise both
+branches of the gate — CONTRIBUTING's fifth row again, since one target reaches
+only one:
+
+| Replayed | `BOT_COMMITS` | Outcome |
+|---|---|---|
+| `fpga-board-sim` #363 — setup-uv 9.0.0 → 10.0.1, a real bot PR | one SHA | call 2 opened with `SCRATCH` and `BASE_SHA` unset, re-derived, re-sourced, and gated correctly on `.github/workflows/ci.yml` |
+| `dependabot-audit` #60 — a human PR, so the split is absent | unset | the fallback fires |
+
+The second is the discriminating one, because the same handoff drives both
+blocks:
+
+```
+### OLD block (0.27.0):
+    ^ that is the entire output: 0 files. The gate passes.
+
+### NEW block:
+BOT_COMMITS underivable — gating on the whole $BASE_SHA..pr-60 diff
+CHANGELOG.md
+.claude-plugin/plugin.json
+skills/dependabot-audit/references/actions.md
+tests/test_skill_prose.py
+```
+
+Four files, one of them inside the plugin's own `references/`, reported as a
+clean scope by the shipped gate. A `uv.lock` bump whose diff reached that far is
+the case Phase 1 exists to stop before Phase 5 runs it.
+
+### Tests
+
+Three guards, each mutation-checked against the pre-fix prose:
+
+- **every bash block that reads a handoff value also sources the handoff**, with
+  the names read from `discover.py`'s emitter rather than typed, and Phase 0
+  exempted as the block that writes it;
+- **the `$SCRATCH` derivation appears in exactly one form**, since seven copies
+  is seven places to drift and 0.26.0 changed the formula once already;
+- **a value the prose promises to handle when unset is tested rather than
+  iterated.** Keyed on the document declaring a fallback rather than on a name,
+  which is what separates `$BOT_COMMITS`, that gates, from `$HUMAN_COMMITS`, that
+  is reported and where zero iterations is the truthful answer.
+
+The second mutation was run twice: the first attempt used a malformed `sed` that
+never landed, and the guard passed. A mutation that does not mutate reads exactly
+like a guard that discriminates — CONTRIBUTING's `__pycache__` warning, one lever
+along. 249 tests.
+
+Closes #61.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -208,7 +208,7 @@ If either check fails, `git worktree remove` it and re-add.
 | | |
 |---|---|
 | `$DEFAULT` | the repo's default branch, derived |
-| `$SCRATCH` | scratch directory, outside the repo — and **derived, so every later call resolves it to the same place**. Nothing else here survives a call boundary |
+| `$SCRATCH` | scratch directory, outside the repo — and **derived, so every later call resolves it to the same place**. Nothing else here survives a call boundary, so every consuming block re-derives this and re-sources `phase0.env` before reading any row below |
 | `$HEAD_SHA` | the full 40-character commit under audit |
 | `$BASE_SHA` | the merge base, from GitHub's own `compare` endpoint — never a local `git merge-base` against `$DEFAULT`, which collapses onto the head once the PR lands. **And whether it is the bot's branch point**, which is a separate answer |
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
@@ -321,6 +321,35 @@ cwd reset back. `SCRATCH` is required to be outside the repo, so it can never be
 reached that way. Nothing ambient crosses the boundary — only a path each call
 can recompute from what it already has, which is the repo and `<N>`.
 
+**Recomputable is not recomputed, and that distinction shipped as a defect.**
+Deriving `$SCRATCH` made the handoff *findable* from a later call; it did not make
+any later call go and find it. So every block below that consumes a Phase 0 output
+opens with the same three lines, and they are not decoration:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+```
+
+Repeated rather than stated once, because a step that is merely implied is one
+that gets skipped — the same argument that put the gate list at a ref. The `||`
+is the load-bearing half: a `.` on a missing file returns 1 and keeps going, so
+without it the block runs on with every output empty, which is the state this
+whole phase exists to make impossible.
+
+**What that empties, measured**, running each consuming block in a fresh call with
+nothing sourced: Phase 1's lockfile read, Phase 4, Phase 6 and Phase 7's cleanup
+all fail loudly — a `Permission denied`, two exit 2s, an exit 128 — and Phase 1's
+**authorship gate passes silently**, because `for c in $BOT_COMMITS` over an unset
+variable iterates zero times and hands the gate an empty file list. That is why
+the block below tests the variable rather than trusting it: the fallback belongs
+in the shell, not only in the paragraph that describes it.
+
+`git` state is the exception and needs no reload. The `pr-<N>` ref Phase 0 fetches
+is in the repository, so `git show "pr-<N>:…"` works from any call. Only the shell
+handoff is lost.
+
 A harness-provided `SCRATCH` still wins, and now for a reason: if one is exported
 into every call's environment it is stable by definition. The derived default is
 what applies when it is not.
@@ -426,10 +455,21 @@ Phase 0 derived both halves, so take the gate's diff from the bot's commits and
 report the human's separately:
 
 ```bash
-# what the bump itself changed — this is what the gate is about
-for c in $BOT_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# what the bump itself changed — this is what the gate is about.
+# Unset is Phase 0's third state, and an unset list iterates zero times: the
+# fallback has to fire here, or the gate passes on an empty diff.
+if [ -z "${BOT_COMMITS+set}" ]; then
+  echo "BOT_COMMITS underivable — gating on the whole \$BASE_SHA..pr-<N> diff" >&2
+  git diff --name-only "$BASE_SHA" "pr-<N>" | sort -u
+else
+  for c in $BOT_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+fi
 # a maintainer's commit on the bot's branch: read it, report it, do not Hold on it
-for c in $HUMAN_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+for c in $HUMAN_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
 ```
 
 A merge commit is in the second list and normally prints nothing — its content
@@ -693,6 +733,10 @@ in this file were here — each of them a real endpoint asked the wrong question
 answering in a well-formed way. A hand-run query cannot be regression-tested.
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 C="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/ci_state.py"
 PARENT=$(git rev-parse "pr-<N>^")
 
@@ -888,6 +932,10 @@ commit that no longer exists while Phase 6 reports on the new one — and the ta
 silently asserts that they agree:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 test "$(gh pr view <N> --json headRefOid --jq .headRefOid)" = "$HEAD_SHA"
 ```
 
@@ -1033,6 +1081,10 @@ stop, and the one that used to litter every time. Phase 7 is the only phase ever
 audit reaches, including the one that ends at the gate.
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git worktree remove "$SCRATCH/pr-<N>"
 git worktree remove "$SCRATCH/base-<N>"
 git branch -D "pr-<N>"

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -226,6 +226,10 @@ releaser; `action.yml` is what the runner loads, it ships in the action's own
 repo, and it is therefore readable at both pins:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 for R in <old-sha> <new-sha>; do
   gh api "repos/<owner>/<action>/contents/action.yml?ref=$R" --jq .content \
     | base64 -d > "$SCRATCH/action-$R.yml"

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -27,6 +27,10 @@ Both lockfiles come out of git at the ref Phase 0 pinned, never off the working
 tree:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 S="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py"
 
 git show "pr-<N>:uv.lock"    > "$SCRATCH/pr.uv.lock"
@@ -153,6 +157,10 @@ environment is the reliable path.
 between finding the change and missing it, and the wrong choice fails silently:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 G="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/gate_diff.py"
 
 python3 "$G" --tree "$SCRATCH/base-<N>" \

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1946,5 +1946,131 @@ class TestPhase4ReadsTheActionsInterfaceNotOnlyItsNotes(SkillHarness):
         )
 
 
+def _every_block() -> list[tuple[str, int, str]]:
+    """(file, phase, code) for every bash block in the skill and its references.
+
+    `SkillHarness.shell` concatenates a phase's blocks into one string, which is
+    right for the ordering guards and wrong here: the question below is asked of
+    each block *as a unit*, because a block is what a reader runs in one call.
+    Two blocks joined would let Phase 0's own reload satisfy a later phase's.
+    """
+    found: list[tuple[str, int, str]] = []
+    for path in (SKILL, PLUGIN / "references/uv-lock.md", PLUGIN / "references/actions.md"):
+        for number, body in phases(path.read_text(encoding="utf-8")):
+            found.extend((path.name, number, code) for code in bash_blocks(body))
+    return found
+
+
+class TestEveryConsumerReloadsTheHandoff(SkillHarness):
+    """Phase 0's handoff was written once, sourced once, and read by seven blocks.
+
+    `SKILL.md` states the measurement that makes this fatal, in its own Phase 0:
+
+        Measured against this harness, two separate calls: an `export` in the
+        first is **unset** in the second, shell functions likewise, and each call
+        is a new shell process.
+
+    Re-measured 2026-08-21 across two Bash calls in one session: `PROBE_VAR` set
+    and exported in the first reads `<UNSET>` in the second, a function defined
+    in the first is `not found`, and the pids differ.
+
+    0.26.0 fixed `$SCRATCH`'s *derivation* so the next call could name the
+    directory. The consequence — that the next call must then actually re-derive
+    it and re-source the file — never reached the phases that consume it, so
+    `. "$SCRATCH/phase0.env"` appeared exactly once in the plugin, inside the
+    phase that writes it.
+
+    Measured cost, running each consuming block in a fresh shell with nothing
+    sourced: Phases 1 (uv.lock), 4, 6 and 7 fail loudly — `Permission denied`,
+    two exit 2s, and exit 128 — while Phase 1's authorship gate **passes
+    silently**, because `for c in $BOT_COMMITS` over an unset variable iterates
+    zero times and the gate's file list is empty. `SKILL.md` names that outcome
+    "the one outcome worse than a false Hold".
+    """
+
+    def _handoff_names(self) -> set[str]:
+        """What the handoff carries: the emitter's names, plus `SCRATCH` itself.
+
+        `SCRATCH` never passes through `discover.py` — Phase 0's shell assigns it
+        — but it is lost across a call boundary exactly like the rest, and it is
+        the one every other value is reached *through*.
+        """
+        return _emitted_by_discover() | {"SCRATCH"}
+
+    def test_every_block_reading_a_handoff_value_reloads_it(self):
+        names = self._handoff_names()
+        for file, number, code in _every_block():
+            if number == 0 and file == SKILL.name:
+                continue  # Phase 0 writes it; it is the one block that need not reload
+            used = sorted(n for n in USED.findall(code) if n in names)
+            if not used:
+                continue
+            self.assertIn(
+                "phase0.env",
+                code,
+                f"{file} Phase {number} reads {used} in a block that never sources "
+                f"the handoff. Shell state does not cross a Bash call, so every one "
+                f"of those is the empty string when the block runs on its own",
+            )
+
+    def test_the_scratch_derivation_is_stated_identically_wherever_it_appears(self):
+        """Seven copies of a formula is seven places for it to drift.
+
+        The failure this guards is not hypothetical in shape: 0.26.0 changed the
+        derivation once already, and a copy left on the old `mktemp` form would
+        point a later phase at a directory the handoff is not in — which is the
+        same silent-empty outcome, reached through a different door.
+        """
+        # The assignment alone, not the line it sits on: Phase 0 appends
+        # `mkdir -p` to its copy and a later block has nothing to create.
+        forms = {
+            found for _, _, code in _every_block() for found in re.findall(r'SCRATCH="[^"]*"', code)
+        }
+        self.assertEqual(
+            len(forms),
+            1,
+            f"the $SCRATCH derivation appears in {len(forms)} different forms; every "
+            f"call has to resolve it to the same directory, so they must be one "
+            f"string: {sorted(forms)}",
+        )
+
+    def test_a_declared_unset_fallback_is_implemented_where_the_block_gates(self):
+        """The measured silent failure, stated as the document's own broken promise.
+
+        `for c in $BOT_COMMITS` over an unset variable iterates zero times and the
+        gate passes with an empty file list. `SKILL.md` already knows this and
+        says what to do instead — *"Where `$BOT_COMMITS` is unset, gate on the
+        whole `$BASE_SHA..pr-<N>` diff"* — but the fallback lived only in prose,
+        so the runnable block did the silent thing.
+
+        Keyed on the prose declaring a fallback rather than on a name: that is
+        what separates `$BOT_COMMITS`, which gates, from `$HUMAN_COMMITS`, which
+        is reported and where iterating zero times is the truthful answer. Any
+        future output whose absence the prose promises to handle is covered.
+        """
+        loop = re.compile(r"for\s+\w+\s+in\s+\$\{?([A-Z_][A-Z0-9_]*)\}?")
+        names = self._handoff_names()
+        bodies = dict(self.phases)
+        seen = 0
+        for file, number, code in _every_block():
+            if file != SKILL.name:
+                continue
+            for name in loop.findall(code):
+                if name not in names:
+                    continue
+                # Does this phase promise to handle the value being unset?
+                if not re.search(rf"\${name}[^\n]*is unset", bodies.get(number, "")):
+                    continue
+                seen += 1
+                self.assertRegex(
+                    code,
+                    re.compile(rf"\$\{{{name}[+:-]|-z\s+\"?\${name}|-n\s+\"?\${name}"),
+                    f"{file} Phase {number} promises a fallback for an unset ${name} "
+                    f"and then iterates it anyway; unset it iterates zero times and "
+                    f"the gate passes silently, which is worse than a false Hold",
+                )
+        self.assertGreater(seen, 0, "no phase declares an unset-fallback for a value it gates on")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #61.

Phase 0's handoff was written once, sourced once, and read by seven blocks that
never reloaded it. `SKILL.md` has stated the mechanism since 0.26.0 — shell state
does not cross a Bash call — and 0.26.0 fixed `$SCRATCH`'s *derivation* so the
next call could name the directory. **Recomputable is not recomputed:** nothing
told the next call to go and find it.

Four of the five consequences are loud. One is not.

| Block, run in a fresh call | Result |
|---|---|
| Phase 1, `uv.lock` | `Permission denied` |
| Phase 4, `gate_diff.py` | exit 2 |
| Phase 6, `ci_state.py` | exit 2 |
| Phase 7, cleanup | exit 128, worktrees left registered |
| **Phase 1, the authorship gate** | **passes silently** |

`for c in $BOT_COMMITS` over an unset variable iterates zero times. `SKILL.md`
names that outcome itself: *"the one outcome worse than a false Hold."*

## What changed

- Every consuming block opens with three lines that re-derive `$SCRATCH` and
  re-source the handoff, with `|| exit 2` — a `.` on a missing file returns 1 and
  keeps going.
- Phase 1's underivable fallback moved out of the prose and into the shell.
- `git` state is called out as the exception: `pr-<N>` lives in the repository and
  needs no reload. Only the shell handoff is lost.

## The replay

Two deliberately separate calls, two PRs for the two branches of the gate.

`fpga-board-sim` #363 (bot PR, `BOT_COMMITS` set) — call 2 opened with `SCRATCH`
and `BASE_SHA` unset, re-derived, re-sourced, gated correctly on
`.github/workflows/ci.yml`.

`dependabot-audit` #60 (human PR, `BOT_COMMITS` absent) is the discriminating one
— same handoff driving both blocks:

```
### OLD block (0.27.0):
    ^ that is the entire output: 0 files. The gate passes.

### NEW block:
BOT_COMMITS underivable — gating on the whole $BASE_SHA..pr-60 diff
CHANGELOG.md
.claude-plugin/plugin.json
skills/dependabot-audit/references/actions.md
tests/test_skill_prose.py
```

Four files, one inside the plugin's own `references/`, reported as a clean scope
by the shipped gate.

## Tests

Three guards, each mutation-checked against the pre-fix prose. The second was run
twice — the first attempt used a malformed `sed` that never landed and the guard
passed, which reads exactly like a guard that discriminates. 249 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)