### PR TITLE
fix: stop ci_state.py fetching answers nothing reads (0.28.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,85 @@ patch.
 
 ## [Unreleased]
 
+## [0.28.1] — 2026-08-21
+
+`ci_state.py` made five API calls on a green PR and read one of them. Patch:
+nothing Phase 6 verifies or reports changes, and every call removed was one whose
+answer nothing consulted.
+
+Measured with a logging passthrough around `gh`, on `fpga-board-sim` #363:
+
+```
+CALL: api graphql <rollup>                                  <- the answer
+CALL: api repos/…/commits/bddcc474b7/check-runs --paginate  <- never read
+CALL: api repos/…/commits/bddcc474b7/status                 <- never read
+CALL: api repos/…/commits/bddcc474b7/check-runs --paginate  <- never read
+CALL: api repos/…/commits/bddcc474b7/status                 <- never read
+```
+
+Note the SHA. `pr-<N>^` and `$BASE_SHA` are the same commit on a genuine
+one-commit bot PR — `SKILL.md` says so, and calls it the ordinary case — so the
+ordinary case fetched the *same two endpoints twice*, and consulted neither.
+
+Every consumer is gated on red: `attribute()` runs once per red context, and
+`parent_names` renders only under `if report["red"] and …`. With nothing red
+there is no row for an answer to qualify. The script already applied exactly this
+reasoning one rung lower — *"Only worth two calls when there is a red row for
+them to qualify"*, on `committed_at` — and had never applied it to the pair above
+it, which is twice the calls and paginates.
+
+### Fixed
+
+- **`analyse()` runs before the comparison reads, and both are gated on
+  `report["red"]`.** It reads only what `rollup()` already returned, so hoisting
+  it costs nothing.
+
+- **The merge base is fetched only when the parent has no runs.** `attribute()`
+  reaches for it in one branch — `if not parent` — because it answers a
+  *different*, weaker question: red before this **branch** rather than before
+  this **commit**. Fetching it while the parent can answer buys nothing, and that
+  holds on red PRs too.
+
+- **The interval reads follow the dict they qualify.** `committed_at` is called
+  for the parent only when the parent answered, and for the base only when the
+  base did.
+
+### The replay
+
+Both live, through the same `gh` tap, on the two PRs this phase's own prose cites:
+
+| Replayed | 0.27.0 | 0.28.1 | Verdict |
+|---|---|---|---|
+| `fpga-board-sim` #363 — green | 5 calls | **1** | unchanged: `CLEAN`, 0 required failing |
+| `BIRSAx2/mdcat` #6 — red | 7 calls | **4** | unchanged: `PRE-EXISTING — red at b1b0dd4c1 (pr-<N>^) too` |
+
+The second is the one that had to be checked: it is the case the attribution
+comparison exists for, and the saving must not reach it. It does not — the base
+is never touched, because the parent answered.
+
+### Tests
+
+Three guards on the *shape of the work* rather than on its output, which is the
+only kind that catches this class. Each mutation-checked:
+
+- a green PR issues one call;
+- a red PR whose parent has runs never reaches for the base;
+- **a red PR with no runs at the parent still falls back to it** — the
+  over-saving direction, and the one worth having, since skipping the base there
+  would mark a real pre-existing failure `underivable`.
+
+The third guard was written first as the control: a saving that also removes a
+fallback is not a saving, and only that case discriminates between the two.
+
+### Changed
+
+`--json` reports `parent_names: []` on a PR with nothing red, where it previously
+carried the comparison point's check names. Nothing reads it there — `render()`
+gates on `report["red"]` — and no phase consumes `--json` at all, but it is a
+visible difference and belongs in the record.
+
+Closes #62.
+
 ## [0.28.0] — 2026-08-21
 
 Phase 0's handoff was written once, sourced once, and read by seven blocks that

--- a/skills/dependabot-audit/scripts/ci_state.py
+++ b/skills/dependabot-audit/scripts/ci_state.py
@@ -498,20 +498,35 @@ def main() -> int:
 
     report = rollup(args.owner, args.name, args.number)
     report["expected_head"] = args.head_sha
-
-    parent = conclusions_at(args.owner, args.name, args.parent) if args.parent else {}
-    base = conclusions_at(args.owner, args.name, args.base_sha) if args.base_sha else {}
-    report["parent_names"] = sorted(parent) or sorted(base)
-
+    # Before the reads below, because every one of them is gated on what it
+    # decides. The rollup already carries everything `analyse` needs.
     analyse(report)
-    # Only worth two calls when there is a red row for them to qualify.
-    spans = {}
+
+    # Attribution is the only consumer of any of this, and it runs once per red
+    # context — so with nothing red there is no row for an answer to qualify and
+    # no call worth making. Measured before this guard existed: five calls on an
+    # all-green PR, one of them read. The same reasoning already applied to
+    # `committed_at` below; it had never been applied to the pair above it, which
+    # is four calls rather than two and paginates.
+    parent: dict[str, str] = {}
+    base: dict[str, str] = {}
+    spans: dict[str, str] = {}
+    report["parent_names"] = []
     if report["red"]:
+        if args.parent:
+            parent = conclusions_at(args.owner, args.name, args.parent)
+        # The merge base answers a *different*, weaker question — red before this
+        # branch rather than before this commit — and `attribute` reaches for it
+        # only when the parent has no runs at all. Fetching it while the parent
+        # can answer buys nothing.
+        if not parent and args.base_sha:
+            base = conclusions_at(args.owner, args.name, args.base_sha)
+        report["parent_names"] = sorted(parent) or sorted(base)
         head_at = report["head_committed"]
-        spans = {
-            "parent": interval(head_at, committed_at(args.owner, args.name, args.parent)),
-            "base": interval(head_at, committed_at(args.owner, args.name, args.base_sha)),
-        }
+        if parent:
+            spans["parent"] = interval(head_at, committed_at(args.owner, args.name, args.parent))
+        if base:
+            spans["base"] = interval(head_at, committed_at(args.owner, args.name, args.base_sha))
     for ctx in report["red"]:
         ctx["attribution"] = attribute(ctx, parent, base, args.parent, args.base_sha, spans)
 

--- a/tests/test_ci_state.py
+++ b/tests/test_ci_state.py
@@ -612,5 +612,67 @@ class TestFailureIsNotAFinding(CiStateHarness):
         self.assertIn("not readable", err)
 
 
+class TestNoCallIsMadeForAnAnswerNothingReads(CiStateHarness):
+    """Four of five API calls on a green PR were fetched and never read.
+
+    Measured with an instrumented `gh` on `PATH` against an all-green rollup:
+    five calls out of the script, one of them consulted. The other four were
+    `conclusions_at()` at the parent and at the base — `check-runs` (paginated)
+    plus `status`, twice — issued before `analyse()` had computed
+    `report["red"]`.
+
+    Every consumer of those two dicts is gated on red: `attribute()` runs only
+    in `for ctx in report["red"]`, and `parent_names` renders only under
+    `if report["red"] and report["parent_names"]`. With nothing red, nothing
+    reads either.
+
+    `base` is redundant a second way, independent of the first: `attribute()`
+    reads it only in the `if not parent` branch, so a red PR whose parent has
+    runs never consults it either.
+
+    The script already applied this guard one rung lower — "Only worth two calls
+    when there is a red row for them to qualify", on `committed_at`, which is one
+    unpaginated call each. The more expensive pair was never covered.
+
+    Phase 7 requires CI rows to be re-derived on every report, *because* they are
+    cheap. That is the argument this count has to keep true.
+    """
+
+    GREEN: ClassVar = [check_run("test", "SUCCESS", required=True)]
+    RED: ClassVar = [check_run("test", "FAILURE", required=True)]
+
+    def _calls_for(self, nodes, **kw):
+        fake, calls = self._fake_gh([page(nodes)], **kw)
+        self._run(fake, ["--parent", PARENT, "--base-sha", BASE])
+        return calls
+
+    def test_a_green_pr_asks_github_once(self):
+        calls = self._calls_for(self.GREEN)
+        extra = [c for c in calls if "graphql" not in c]
+        self.assertEqual(
+            extra,
+            [],
+            f"nothing is red, so no attribution row exists to qualify; these "
+            f"{len(extra)} call(s) are fetched and never read: {extra}",
+        )
+
+    def test_a_red_pr_with_a_live_parent_never_reaches_for_the_base(self):
+        calls = self._calls_for(self.RED, runs={PARENT: [("test", "SUCCESS")]})
+        self.assertFalse(
+            [c for c in calls if BASE in c],
+            "the parent answered, and attribute() reads the base only when the "
+            "parent has no runs at all — the fallback was fetched unconditionally",
+        )
+
+    def test_a_red_pr_with_no_runs_at_the_parent_still_falls_back(self):
+        """The saving must not cost the fallback the comparison depends on."""
+        calls = self._calls_for(self.RED, runs={BASE: [("test", "FAILURE")]})
+        self.assertTrue(
+            [c for c in calls if BASE in c],
+            "with no runs at pr-<N>^ the merge base is the only comparison point "
+            "left; skipping it would mark a real pre-existing failure underivable",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #62. **Stacked on #66** — review that first; this PR's base is
`fix/handoff-never-reloaded`, so the diff here is only the `ci_state.py` change.

`ci_state.py` made five API calls on a green PR and read one of them. Measured
with a logging passthrough around `gh`, on `fpga-board-sim` #363:

```
CALL: api graphql <rollup>                                  <- the answer
CALL: api repos/…/commits/bddcc474b7/check-runs --paginate  <- never read
CALL: api repos/…/commits/bddcc474b7/status                 <- never read
CALL: api repos/…/commits/bddcc474b7/check-runs --paginate  <- never read
CALL: api repos/…/commits/bddcc474b7/status                 <- never read
```

Note the SHA. `pr-<N>^` and `$BASE_SHA` are the same commit on a genuine
one-commit bot PR — `SKILL.md` says so and calls it the ordinary case — so the
ordinary case fetched **the same two endpoints twice** and consulted neither.

Every consumer is gated on red. The script already applied this reasoning one rung
lower, on `committed_at`; it had never been applied to the pair above it, which is
twice the calls and paginates.

## The replay

Both live, through the same tap, on the two PRs this phase's prose cites:

| Replayed | 0.27.0 | 0.28.1 | Verdict |
|---|---|---|---|
| `fpga-board-sim` #363 — green | 5 calls | **1** | unchanged: `CLEAN` |
| `BIRSAx2/mdcat` #6 — red | 7 calls | **4** | unchanged: `PRE-EXISTING — red at b1b0dd4c1 (pr-<N>^) too` |

The second is the one that had to be checked — it is the case the attribution
comparison exists for, and the saving must not reach it. It does not.

## Tests

Three guards on the shape of the work, each mutation-checked. The third — *a red
PR with no runs at the parent still falls back to the base* — was written first as
the control: a saving that also removes a fallback is not a saving. 252 tests.

## Changed

`--json` reports `parent_names: []` on a green PR. Nothing reads it there and no
phase consumes `--json`, but it is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)