### PR TITLE
fix: gate Phases 4 and 5 on the bit Phase 0 derived for them (0.29.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,102 @@ patch.
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-08-21
+
+Phase 0 decided whether the PR may run, and the phases that run it never asked.
+Minor: Phases 4 and 5 now require `MAY_EXECUTE=yes`, which is a change to what
+they verify before executing.
+
+`discover.py` derives the classification — a fork PR, a non-bot author, or an
+account without `push` — and reduces it to one bit. Phase 0's prose said why:
+
+> Reducing it to the one bit later phases actually branch on is what
+> `MAY_EXECUTE` is.
+
+No phase branched on it. Every occurrence in the plugin was the emit, the
+key-list comment, and two sentences explaining its purpose. The gate itself lived
+only in Phase 0's own table, six phases before the phases that execute, as advice
+to *run `--no-execute`*.
+
+### Fixed
+
+- **Phases 4 and 5 gate on it, in the blocks that run the audited repo's code.**
+  Both `uv-lock.md` blocks — `gate_diff.py`, and the frozen `uv sync` pair — open
+  with the test, and both phases' contract lines say so.
+
+- **The test is for `yes`, never against `no`.** Measured across the three states
+  a block can see:
+
+  | | `= yes` | `!= no` |
+  |---|---|---|
+  | `MAY_EXECUTE=yes` | proceeds | proceeds |
+  | `MAY_EXECUTE=no` | refuses, exit 2 | refuses, exit 2 |
+  | **unset** | **refuses, exit 2** | **proceeds** |
+
+  A block whose handoff did not load sees the empty string, and the negative form
+  passes it. The one direction this must never fail in is open.
+
+- **`BRANCH_POINT` was the same defect, found by the guard written for
+  `MAY_EXECUTE`.** It is emitted, Phase 1 was said to read it, and no block did —
+  the rewritten-base substitution was prose telling the reader to use a different
+  range. It is now a conditional in Phase 1's fallback, which is the one path
+  where it still decides anything: with `$BOT_COMMITS` derivable the bot's own
+  commits are the bump wherever the base moved to, and only the underivable
+  fallback has a range to choose.
+
+- **`BASE_REF` is declared a diagnostic**, in Phase 0, in the line the new guard
+  reads. 0.26.1 settled that it is deliberately unconsumed; the exemption is now
+  written down instead of inferred from nobody having used it.
+
+### The replay
+
+**The execution gate**, derived live against four real PRs:
+
+| Repo | `push` | Author | `MAY_EXECUTE` |
+|---|---|---|---|
+| `fpga-board-sim` #363 | true | `dependabot[bot]` | **yes** |
+| `dependabot-audit` #60 | true | human | no |
+| `BIRSAx2/mdcat` #6 | false | — | no |
+| `cli/cli` #14147 | false | — | no |
+
+The second row is the one worth reading: full `admin` on a repo this account
+owns, and still `no`, because the classification is two questions and only one of
+them is about permissions.
+
+**The `BRANCH_POINT` substitution** needed a base that had actually been
+rewritten, and no reachable PR is in that state — CONTRIBUTING's fifth row. Built
+one instead: a root commit, a commit vendoring a `supply-chain` tree, a third
+commit, a PR branching from the third and adding `manifest.txt`, then the base
+rewritten so the shared ancestor falls back past the vendored tree.
+
+```
+BRANCH_POINT=ok         -> 7 file(s): manifest.txt src.py vendor-{a..e}.txt
+BRANCH_POINT=rewritten  -> 1 file(s): manifest.txt
+```
+
+Without the conditional the fallback gates on seven files, including a vendored
+tree the bump never touched, and Holds a one-file manifest bump for reaching
+beyond the manifest. That is the shape `SKILL.md` records from a real Cargo bump:
+14 files and 3,682 deletions on a two-file PR.
+
+A first attempt at this construction force-pushed *forward* rather than rewriting,
+so both ranges returned one file and agreed. Agreement there would have read as
+"the conditional is unnecessary" — a replay that quietly proves nothing, which is
+the failure mode the gate itself exists against.
+
+### Tests
+
+Four guards, each mutation-checked, in five directions — dropping the gate,
+flipping it to the negative form, emptying the diagnostics line, exempting a name
+the emitter does not write, and reverting the `BRANCH_POINT` substitution.
+
+The completeness rule now runs **both** ways. 0.26.1's guards ask that every
+promised name is produced; these ask that every produced name is consumed or
+named inert. The drift was already bidirectional when 0.26.1 shipped — its own
+changelog says so — and only one direction had a guard. 256 tests.
+
+Closes #63.
+
 ## [0.28.1] — 2026-08-21
 
 `ci_state.py` made five API calls on a green PR and read one of them. Patch:

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -217,6 +217,7 @@ If either check fails, `git worktree remove` it and re-add.
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
 | `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **Phase 1 reads it**, and the table below says what each one means |
+| `$MAY_EXECUTE` | `yes` or `no` — **Phases 4 and 5 gate on it**, and the gate tests for `yes` so an unset value refuses. The classification below is what sets it |
 | `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
 | `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
 
@@ -231,6 +232,22 @@ Phase 0's own working state.
 The reason is that `$PERMS` is a set of flags rather than a value: `$PERMS.push`
 is how the gate below addresses it, and there is no shell form of that. Reducing
 it to the one bit later phases actually branch on is what `MAY_EXECUTE` is.
+
+**And they branch on it, rather than being trusted to remember this table.** The
+blocks in Phases 4 and 5 that run the audited repo's code open with
+
+```bash
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+```
+
+Tested **for** `yes`, never against `no`, and the difference is the whole guard:
+a block whose handoff did not load sees the empty string, and `!= no` is true of
+it. The one direction this must never fail in is open.
+
+**Diagnostics — emitted, deliberately unread:** `BASE_REF`. It is Phase 0's own
+cross-check on the `compare` call and no later phase consumes it. Every *other*
+name the emitter writes is read by a block; that is the rule, and an exemption is
+a decision written down here rather than a name nobody happened to use.
 
 If a later phase needs something not on this list, it belongs here rather than
 there. A phase that consumes what a later phase creates cannot be run in order,
@@ -463,8 +480,12 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 # Unset is Phase 0's third state, and an unset list iterates zero times: the
 # fallback has to fire here, or the gate passes on an empty diff.
 if [ -z "${BOT_COMMITS+set}" ]; then
-  echo "BOT_COMMITS underivable — gating on the whole \$BASE_SHA..pr-<N> diff" >&2
-  git diff --name-only "$BASE_SHA" "pr-<N>" | sort -u
+  # No split to gate on, so the range matters — and a rewritten base makes the
+  # merge-base range the whole divergence. Phase 0 already decided which; reading
+  # it here is what stops the substitution being something to remember.
+  [ "$BRANCH_POINT" = rewritten ] && RANGE="pr-<N>^..pr-<N>" || RANGE="$BASE_SHA..pr-<N>"
+  echo "BOT_COMMITS underivable — gating on the whole $RANGE diff" >&2
+  git diff --name-only $RANGE | sort -u
 else
   for c in $BOT_COMMITS; do git show --name-only --format= "$c"; done | sort -u
 fi
@@ -627,8 +648,8 @@ form returns zero.
 
 *Requires from Phase 0: the `$SCRATCH/base-<N>` worktree — or `$SCRATCH/tip-<N>`
 if Phase 0 found the base rewritten — and the repo's own gates.*
-*Executes code from the PR. Skipped under `--no-execute`; skip it if Phase 1
-found anything.*
+*Executes code from the PR. Requires `MAY_EXECUTE=yes`. Skipped under
+`--no-execute`; skip it if Phase 1 found anything.*
 
 **The question: does this change what runs here, or what this repo's gates
 accept?** Not "is it safe". For `uv.lock` you can measure it, and you must —
@@ -664,8 +685,8 @@ working; reaching it by not looking is the failure.
 ## Phase 5 — Independent reproduction
 
 *Requires from Phase 0: the `$SCRATCH/pr-<N>` worktree, `$HEAD_SHA`, `pr-<N>`.*
-*Executes code from the PR — the most of any phase. Skipped under
-`--no-execute`; skip it if Phase 1 found anything.*
+*Executes code from the PR — the most of any phase. Requires `MAY_EXECUTE=yes`.
+Skipped under `--no-execute`; skip it if Phase 1 found anything.*
 
 **The question: has this been shown to work, independently of the bot saying so?**
 For `uv.lock` you answer it by building and running the thing. For GitHub Actions

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -161,6 +161,8 @@ between finding the change and missing it, and the wrong choice fails silently:
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
 G="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/gate_diff.py"
 
 python3 "$G" --tree "$SCRATCH/base-<N>" \
@@ -225,6 +227,12 @@ Install **frozen** — that proves the lockfile is self-consistent and resolves
 nothing. For Python this is two commands, and they prove different things:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
+cd "$SCRATCH/pr-<N>"
 uv sync --locked --no-build --no-install-project   # every dep resolved to a wheel
 uv sync --locked                                   # then add the project itself
 ```

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2072,5 +2072,111 @@ class TestEveryConsumerReloadsTheHandoff(SkillHarness):
         self.assertGreater(seen, 0, "no phase declares an unset-fallback for a value it gates on")
 
 
+class TestEveryEmittedOutputIsConsumedOrDeclaredInert(SkillHarness):
+    """0.26.1 closed this class in one direction only.
+
+    Its two guards run table-and-requires-line -> emitter: every name a phase
+    *promises* must be one Phase 0 produces. Nothing ran the other way, and the
+    drift was already bidirectional when it shipped — the changelog says so:
+
+        the table promised `$PERMS` and `$SCRATCH` while the emitter writes ten
+        names including `BASE_REF`, `BRANCH_POINT` and `MAY_EXECUTE`.
+
+    `BASE_REF` was settled there deliberately — "Phase 0's own cross-check that
+    no later phase consumes" — and that is a fine answer. `MAY_EXECUTE` was not
+    in the same position. Phase 0's prose calls it *"the one bit later phases
+    actually branch on"*, offered as the value that crosses in `$PERMS`'s place,
+    and no phase branched on it: every occurrence in the plugin was the emit, the
+    key-list comment, and two sentences explaining why it exists.
+
+    So the completeness rule now runs both ways, with the exemption written down
+    rather than inferred: an emitted name is consumed, or it is named as a
+    diagnostic. That is what separates the two cases, and it is a decision
+    someone has to make rather than an omission nobody notices.
+    """
+
+    DIAGNOSTIC = re.compile(r"Diagnostics? —[^\n]*", re.IGNORECASE)
+
+    def _declared_inert(self) -> set[str]:
+        line = self.DIAGNOSTIC.search(dict(self.phases)[0])
+        return set(re.findall(r"`\$?([A-Z_][A-Z0-9_]*)`", line.group(0))) if line else set()
+
+    def test_every_emitted_name_is_read_somewhere_or_declared_inert(self):
+        inert = self._declared_inert()
+        read = {n for _, _, code in _every_block() for n in USED.findall(code)}
+        for name in sorted(_emitted_by_discover()):
+            if name in inert:
+                continue
+            self.assertIn(
+                name,
+                read,
+                f"discover.py --shell emits {name} and no block reads it. Either a "
+                f"phase should branch on it or Phase 0 should name it a diagnostic, "
+                f"the way BASE_REF is — an emitted value nobody reads and nobody "
+                f"exempted is a promise that quietly went false",
+            )
+
+    def test_the_diagnostics_line_names_only_things_that_are_emitted(self):
+        """The exemption must not drift into covering a name that no longer exists."""
+        emitted = _emitted_by_discover()
+        for name in sorted(self._declared_inert()):
+            self.assertIn(
+                name,
+                emitted,
+                f"Phase 0 exempts {name} as a diagnostic, but the emitter does not "
+                f"write it; a stale exemption silently widens to whatever is added next",
+            )
+
+
+class TestTheExecutionGateIsReadWhereExecutionHappens(SkillHarness):
+    """Phase 0 decided whether the PR may run, and the phases that run it never asked.
+
+    `discover.py` derives the classification — a fork PR, a non-bot author, or an
+    account without `push` — and reduces it to `MAY_EXECUTE`. The gate then lived
+    only in Phase 0's own prose table, which tells the reader to *run
+    `--no-execute`*, six phases before the phases that execute.
+
+    Measured on this plugin's handoff: `MAY_EXECUTE=yes` crosses on every audit
+    and nothing has ever read it.
+    """
+
+    def _executing(self) -> list[int]:
+        return [n for n, body in self.phases if n > 0 and "Executes code from the PR" in body]
+
+    def test_the_phases_that_execute_say_so_and_gate_on_it(self):
+        found = self._executing()
+        self.assertTrue(found, "no phase declares that it executes the PR's code")
+        for number in found:
+            self.assertIn(
+                "MAY_EXECUTE",
+                self.reachable(number),
+                f"Phase {number} declares that it executes code from the PR and never "
+                f"reads the bit Phase 0 derived to authorise it",
+            )
+
+    def test_the_gate_fails_closed_on_an_empty_value(self):
+        """An unset handoff yields the empty string, not `no`.
+
+        From the measurement rather than the fix: a block whose handoff never
+        loaded sees `MAY_EXECUTE` unset, and `!= no` is true of the empty string.
+        The test has to be *for* the authorising value, so anything that is not
+        `yes` — including nothing at all — refuses.
+        """
+        seen = 0
+        for file, number, code in _every_block():
+            # Uses it, rather than merely naming it: Phase 0's key-list block
+            # documents `MAY_EXECUTE=<yes|no>` and tests nothing.
+            if not re.search(r"\$\{?MAY_EXECUTE", code):
+                continue
+            seen += 1
+            self.assertRegex(
+                code,
+                re.compile(r"MAY_EXECUTE[^\n]*=\s*[\"']?yes"),
+                f"{file} Phase {number} tests MAY_EXECUTE without testing for `yes`; "
+                f"an unset handoff is the empty string, and a negative test passes it",
+            )
+        self.assertGreater(seen, 0, "no block gates on MAY_EXECUTE")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #63. **Stacked on #67** (which is stacked on #66) — base is
`fix/ci-state-unread-calls`, so the diff here is only this change.

Phase 0 decided whether the PR may run, and the phases that run it never asked.
Phase 0's prose called `MAY_EXECUTE` *"the one bit later phases actually branch
on"*; no phase branched on it.

## The gate is for `yes`, never against `no`

Measured across the three states a block can see:

| | `[ = yes ]` | `[ != no ]` |
|---|---|---|
| `MAY_EXECUTE=yes` | proceeds | proceeds |
| `MAY_EXECUTE=no` | refuses, exit 2 | refuses, exit 2 |
| **unset** | **refuses, exit 2** | **proceeds** |

A block whose handoff did not load sees the empty string.

## `BRANCH_POINT` was the same defect

Found by the guard written for `MAY_EXECUTE`: emitted, said to be read by Phase 1,
read by no block — the rewritten-base substitution was prose. Now a conditional in
Phase 1's fallback, the one path where it still decides anything.

No reachable PR has a rewritten base, so I built the history (CONTRIBUTING's fifth
row):

```
BRANCH_POINT=ok         -> 7 file(s): manifest.txt src.py vendor-{a..e}.txt
BRANCH_POINT=rewritten  -> 1 file(s): manifest.txt
```

Without the conditional the fallback Holds a one-file manifest bump for reaching
beyond the manifest — the shape `SKILL.md` records from a real Cargo bump at 14
files and 3,682 deletions.

A first attempt force-pushed *forward* rather than rewriting, so both ranges
agreed at one file. Agreement there would have read as *the conditional is
unnecessary*.

## Live derivation

| Repo | `push` | Author | `MAY_EXECUTE` |
|---|---|---|---|
| `fpga-board-sim` #363 | true | `dependabot[bot]` | **yes** |
| `dependabot-audit` #60 | true | human | no |
| `BIRSAx2/mdcat` #6 | false | — | no |
| `cli/cli` #14147 | false | — | no |

Row two: full `admin` on a repo this account owns, and still `no`.

## Tests

Four guards, mutation-checked in five directions. The completeness rule now runs
**both** ways — 0.26.1's guards ask that every promised name is produced, these ask
that every produced name is consumed or named inert. 256 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)