### PR TITLE
fix: carry CREATED_AT, and print the pin's own age (0.30.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,87 @@ patch.
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-08-21
+
+Phase 2 required an input the handoff never carried, and `audit.py` computed the
+other half of Phase 2's comparison and printed neither end. Minor: the currency
+row now asserts something it did not.
+
+Phase 2's contract read:
+
+> *Requires: the Phase 1 script output, and the PR's `createdAt` from Phase 0.*
+
+`discover.py` renders `createdAt` and the emitter never wrote it, so the input
+crossed by being on screen. It is the class 0.26.1 closed for `$PERMS`, and it
+slipped that guard twice over on punctuation: the phrase is `Requires:` rather
+than `Requires from Phase 0:`, and the name is neither `$`-prefixed nor
+upper-case.
+
+### Fixed
+
+- **`CREATED_AT` is emitted, tabled, and read.** Phase 2 computes the cooldown
+  boundary from it rather than subtracting three days by eye — and the window is
+  measured from when the **PR opened**, not from now, which is the drift Phase 7's
+  table already calls out in itself. `python3` rather than `date -d`, which is
+  GNU-only.
+
+- **The pin's own publish date reaches the report.** `locked_published` was
+  computed and rendered nowhere, so the currency block could say when the newer
+  release landed and never when the current one did. Both ends of the comparison
+  are the comparison. On `fpga-board-sim`'s live lockfile:
+
+  ```
+  === pytest: locked 9.1.1 (published 2026-06-19T10:58:31Z) IS the latest
+  === ruff: locked 0.16.3 (published 2026-08-13T15:16:27Z), registry latest 0.16.4  <-- NOT CURRENT
+        0.16.4       published 2026-08-20T17:43:16Z
+  ```
+
+- **A requires-line names the variable, never the field.** `createdAt` was prose;
+  `$CREATED_AT` is something a block can source and a guard can check.
+
+### Fixed — in the guard itself
+
+Found by mutation, and the more useful half of this release. Deleting the
+`CREATED_AT` emit left **every test green**. `_produced()` unions the emitter's
+names with `ASSIGNED.findall(self.shell[0])`, and Phase 0 documents the entire
+handoff in a bash fence of `#   NAME=<...>` comment lines — so a requires-line
+could be satisfied by the very key list it is meant to be checked against.
+
+Comments are now stripped before that scan. It is the same failure `_code_only`
+exists for one file over — *a rule must not be satisfiable by a comment claiming
+it* — and it had been sitting under 0.26.1's two guards since they were written.
+`$SCRATCH` still resolves, from the real assignment rather than from its
+description.
+
+### The replay
+
+`fpga-board-sim` #363, two deliberately separate calls:
+
+```
+call 1:  CREATED_AT=2026-08-17T13:07:54Z          # emitted
+call 2:  cooldown boundary: 2026-08-14T13:07:54+00:00   # sourced, computed
+```
+
+And `audit.py` against that repo's real `uv.lock`, 0.29.0 beside 0.30.0:
+
+```
+0.29.0:  === ruff: locked 0.16.3, registry latest 0.16.4  <-- NOT CURRENT
+0.30.0:  === ruff: locked 0.16.3 (published 2026-08-13T15:16:27Z), registry latest 0.16.4
+```
+
+`latest_published` stays unrendered and is now redundant rather than dropped: the
+latest version is the last row of the gap, which already carries its date, and
+when the pin *is* current the gap is empty and the two coincide.
+
+### Tests
+
+Three guards, mutation-checked. The requires-line guard is widened to `Requires:`
+and paired with a new one refusing a bare backticked name in such a line — the
+exact shape `createdAt` had, so the hole is closed as a class rather than at the
+instance. 258 tests.
+
+Closes #64.
+
 ## [0.29.0] — 2026-08-21
 
 Phase 0 decided whether the PR may run, and the phases that run it never asked.

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -124,6 +124,7 @@ defines:
 #   BASE_SHA=<40 hex>      the merge base, from GitHub's compare endpoint
 #   OWNER=<owner>          for Phase 6's GraphQL variables
 #   NAME=<name>
+#   CREATED_AT=<iso8601>   when the PR was opened — Phase 2's cooldown test
 #   BRANCH_POINT=<ok|rewritten|suspect|underivable>
 #   MAY_EXECUTE=<yes|no>   whether Phases 4 and 5 are authorised
 #   BOT_COMMITS=<shas>     the bot's own commits above the base — Phase 1's gate
@@ -216,6 +217,7 @@ If either check fails, `git worktree remove` it and re-add.
 | `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below. Same exception |
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
+| `$CREATED_AT` | when the PR was opened, ISO-8601. **Phase 2 compares release publish times against it** — the cooldown asks whether a release was three days old *then*, not now |
 | `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **Phase 1 reads it**, and the table below says what each one means |
 | `$MAY_EXECUTE` | `yes` or `no` — **Phases 4 and 5 gate on it**, and the gate tests for `yes` so an unset value refuses. The classification below is what sets it |
 | `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
@@ -562,7 +564,7 @@ Phase 6's CI state established, and name plainly what was not checked.
 
 ## Phase 2 — Currency
 
-*Requires: the Phase 1 script output, and the PR's `createdAt` from Phase 0.*
+*Requires from Phase 0: `$CREATED_AT`. Plus the Phase 1 script output.*
 
 **A bot's proposal is not evidence of "current".** Ask the registry what the
 latest version actually is, and compare publish timestamps against the PR's
@@ -591,6 +593,24 @@ phase reads for next: a `Security` entry or a destructive-fix bug in the gap. Th
 cooldown exempts Dependabot's *security updates* — the advisory-driven kind — and
 not a version update whose changelog happens to carry a privately disclosed fix,
 which is exactly the case below.
+
+**The cooldown boundary is a subtraction, so do it rather than eyeball it.** The
+window is measured from when the **PR opened**, not from now, so the same gap
+moves in and out of it as the audit ages — which is the failure Phase 7's table
+calls out in itself:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+python3 -c 'import datetime,sys; t=datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00")); print("cooldown boundary:", (t-datetime.timedelta(days=3)).isoformat())' "$CREATED_AT"
+```
+
+A gap release published **after** that boundary was inside the window when the
+bot decided; one published before it was not, and the bot is behind rather than
+waiting. `python3` rather than `date -d`, which is GNU-only — every script here
+already requires 3.11.
 
 **A bot's ignore state is not always in a config file.** `@dependabot ignore this
 major version` records the hold in the *PR*, not the repo, so a dependency can be

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -895,12 +895,16 @@ def render(report: dict[str, Any]) -> None:
         )
 
     for cur in report["currency"]:
+        # How old the pin is, alongside how old the gap is. Phase 2 compares
+        # release times against the PR's `$CREATED_AT`, and a report that names
+        # only when the *newer* release landed gives the reader one end of that.
+        since = f" (published {cur['locked_published']})" if cur["locked_published"] else ""
         if cur["current"]:
-            print(f"=== {cur['name']}: locked {cur['locked']} IS the latest\n")
+            print(f"=== {cur['name']}: locked {cur['locked']}{since} IS the latest\n")
             continue
         if cur["held_back"]:
             print(
-                f"=== {cur['name']}: locked {cur['locked']}, registry latest "
+                f"=== {cur['name']}: locked {cur['locked']}{since}, registry latest "
                 f"{cur['latest']} — HELD BACK by resolution-markers"
             )
             print(
@@ -910,7 +914,7 @@ def render(report: dict[str, Any]) -> None:
             print("      trail the registry, so not a staleness finding\n")
             continue
         print(
-            f"=== {cur['name']}: locked {cur['locked']}, "
+            f"=== {cur['name']}: locked {cur['locked']}{since}, "
             f"registry latest {cur['latest']}  <-- NOT CURRENT"
         )
         if cur["constrained"]:
@@ -924,7 +928,7 @@ def render(report: dict[str, Any]) -> None:
         for rel in cur["gap"]:
             mark = " (yanked)" if rel["yanked"] else ""
             print(f"      {rel['version']:12s} published {rel['published']}{mark}")
-        print("      earliest first; compare it against the PR's createdAt\n")
+        print("      earliest first; compare these against $CREATED_AT, the PR's own\n")
 
     # A forked package is checked in full and installed in part, and nothing in
     # the output said so. Phase 1 verifies every fork's artifacts against the

--- a/skills/dependabot-audit/scripts/discover.py
+++ b/skills/dependabot-audit/scripts/discover.py
@@ -431,6 +431,12 @@ def shell(report: dict[str, Any]) -> None:
         ("BASE_SHA", report["base_sha"]),
         ("OWNER", report["owner"]),
         ("NAME", report["name"]),
+        # Phase 2's other half. The cooldown question is whether the release was
+        # less than three days old *when the bot opened the PR*, so it needs the
+        # PR's own timestamp and not only the release's. It was rendered in the
+        # report and never emitted, which made it an input that crossed by being
+        # on screen.
+        ("CREATED_AT", report["created_at"]),
     ]
     print("# Phase 0 outputs. Sourced, not transcribed.")
     for key, value in pairs:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -874,6 +874,27 @@ class TestMainContract(_MainHarness):
         self.assertEqual(code, 2)
         self.assertNotIn("CLEAN", out)
 
+    def test_the_locked_versions_publish_date_reaches_the_report(self):
+        """Phase 2 compares two timestamps and the output carried only one.
+
+        The gap rows name when each newer release landed. How old the *pin* is
+        was computed — `locked_published` — and rendered nowhere, so the report
+        could say "the newer release landed on X" and never "and you have been
+        on a release from Y". Both halves are the comparison Phase 2 asks for.
+        """
+        _, out, _ = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"],
+            meta=pypi_meta(
+                "0.2.53",
+                [pypi_file("rumdl-0.2.53-py3-none-any.whl", uploaded="2026-01-04T00:00:00Z")],
+            ),
+        )
+        self.assertIn(
+            "2026-01-04",
+            out,
+            f"the locked version's own publish date is computed and never printed:\n{out}",
+        )
+
     def test_verdict_line_carries_the_counts(self):
         code, out, _ = self._run(
             [write_lock(self, self.LOCK), "--changed", "rumdl"], meta=self._meta()

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1809,7 +1809,13 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
     Phase 0 actually produces — from the script's emitter or from its own shell.
     """
 
-    REQUIRES = re.compile(r"Requires from Phase 0:(.*)", re.IGNORECASE)
+    # `Requires:` as well as `Requires from Phase 0:`. Phase 2 used the shorter
+    # form and named its input in prose — `the PR's ``createdAt`` from Phase 0` —
+    # so it slipped this guard on punctuation, twice over: the phrase did not
+    # match, and the name was neither `$`-prefixed nor upper-case.
+    REQUIRES = re.compile(r"\*Requires(?: from Phase 0)?:(.*)", re.IGNORECASE)
+    # A bare backticked identifier in a requires-line: the shape `createdAt` had.
+    BARE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)`")
 
     def _produced(self) -> set[str]:
         """What a later phase can actually receive: the emitter, plus Phase 0's shell.
@@ -1818,7 +1824,18 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
         directly and never passes through `discover.py`, so a guard reading only
         the emitter would call the most-used output of all a broken promise.
         """
-        return _emitted_by_discover() | set(ASSIGNED.findall(self.shell[0]))
+        # Comment lines stripped, and that is load-bearing rather than tidy.
+        # Phase 0 documents the whole handoff in a bash fence of `#   NAME=<...>`
+        # lines, so an un-stripped scan lets a requires-line be satisfied by the
+        # very key list it is meant to be checked against. Caught by mutation:
+        # deleting `CREATED_AT` from the emitter left every guard green, because
+        # the comment describing it was still there. Same failure `_code_only`
+        # exists for one file over — a rule must not be satisfiable by a comment
+        # claiming it.
+        executable = "\n".join(
+            line for line in self.shell[0].splitlines() if not line.lstrip().startswith("#")
+        )
+        return _emitted_by_discover() | set(ASSIGNED.findall(executable))
 
     def test_every_requires_line_names_something_phase_0_produces(self):
         produced = self._produced()
@@ -1838,6 +1855,26 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
                         f"sourcing the handoff and reading it gets the empty string",
                     )
         self.assertGreater(seen, 0, "no phase states what it requires from Phase 0")
+
+    def test_no_requires_line_names_an_input_in_prose_instead_of_as_a_variable(self):
+        """The convention is the shell name, because that is what has to exist.
+
+        Phase 2's line read *"the PR's `createdAt` from Phase 0"*. `discover.py`
+        renders `createdAt` in its human-readable report and the emitter never
+        wrote it, so the input crossed by being on screen. Naming the variable is
+        what puts a requires-line under the guard above at all.
+        """
+        for number, body in self.phases:
+            for line in body.splitlines():
+                found = self.REQUIRES.search(line)
+                if not found:
+                    continue
+                for name in self.BARE.findall(found.group(1)):
+                    self.fail(
+                        f"Phase {number} requires `{name}`, named as prose rather than "
+                        f"as the variable the handoff carries. A name without a `$` is "
+                        f"one no guard can check and no block can source"
+                    )
 
     def test_the_outputs_table_lists_only_real_outputs(self):
         """The table says later phases consume these *and nothing else*."""


### PR DESCRIPTION
Closes #64. **Stacked on #68** — base is `fix/may-execute-unconsumed`.

Phase 2 required an input the handoff never carried, and `audit.py` computed the
other half of Phase 2's comparison and printed neither end.

> *Requires: the Phase 1 script output, and the PR's `createdAt` from Phase 0.*

`discover.py` renders `createdAt`; the emitter never wrote it. Same class as
`$PERMS` in 0.26.1, and it slipped that guard twice over on punctuation — the
phrase is `Requires:`, and the name is neither `$`-prefixed nor upper-case.

## The more useful half is in the guard

Found by mutation: **deleting the `CREATED_AT` emit left every test green.**

`_produced()` unions the emitter's names with `ASSIGNED.findall(shell[0])`, and
Phase 0 documents the whole handoff in a bash fence of `#   NAME=<...>` comment
lines — so a requires-line could be satisfied by *the very key list it is meant to
be checked against*. Comments are now stripped before that scan.

Same failure `_code_only` exists for one file over: *a rule must not be satisfiable
by a comment claiming it.* It had been sitting under 0.26.1's two guards since they
were written.

## The replay

`fpga-board-sim` #363, two deliberately separate calls:

```
call 1:  CREATED_AT=2026-08-17T13:07:54Z
call 2:  cooldown boundary: 2026-08-14T13:07:54+00:00
```

`audit.py` against that repo's real `uv.lock`:

```
0.29.0:  === ruff: locked 0.16.3, registry latest 0.16.4  <-- NOT CURRENT
0.30.0:  === ruff: locked 0.16.3 (published 2026-08-13T15:16:27Z), registry latest 0.16.4
```

Both ends of Phase 2's comparison, where before there was one.

## Tests

Three guards, mutation-checked. The requires-line guard is widened to `Requires:`
and paired with a new one refusing a bare backticked name in such a line — the
exact shape `createdAt` had, closing the hole as a class. 258 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)