### PR TITLE
fix: give every derived label a row in the verdict table (0.31.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,66 @@ patch.
 
 ## [Unreleased]
 
+## [0.31.0] — 2026-08-21
+
+Five findings the procedure instructs you to report had no row in Phase 7's
+verdict table, so each fell through to *"Everything derived, nothing above
+matched → **Merge as-is**"* and arrived there by exhaustion. Minor: it changes
+what the report asserts.
+
+The table exists for exactly one reason, which it states:
+
+> Every row above is a finding; the verdict is a function of them, and leaving
+> that function implicit is how two audits with the same evidence reach different
+> recommendations.
+
+A finding that lands on the fall-through is, in the report, indistinguishable
+from no finding at all.
+
+### Fixed
+
+Five rows, in the **not a Hold on this bump** register the `pre-existing` row
+already uses:
+
+| Finding | Why it had to be named |
+|---|---|
+| a red required check labelled **underivable** | the worst of the five. `ci_state.py` has three labels and the table had two, so a red *required* check whose cause could not be established resolved to **Merge as-is** on a PR that cannot merge |
+| an actions pin that is **not a 40-hex SHA** | `actions.md` calls it "a repo whose pins are not evidence", and without a row *we verified the pin* and *the pins are not evidence* produced the same verdict |
+| `BRANCH_POINT=rewritten` | a fact about the branch, not the dependency — but the substitutions it forces belong in the report |
+| `BRANCH_POINT=suspect` | corroboration without the authority; the commits get read and reported, and the base is not substituted on it alone |
+| `BRANCH_POINT=underivable` | not `ok`, and it caps confidence rather than deciding the verdict |
+
+- **The top-down rule now admits that some rows do not end the read.** "Take the
+  first row that matches" and a row saying *not a Hold, take the verdict from the
+  remaining evidence* were already in tension — the `pre-existing` row has worked
+  that way since 0.20.0. Reporting rows are now named as a category.
+
+- **`report-template.md` carries the obligation**, since the template is what
+  gets copied and a rule only in `SKILL.md` drifts.
+
+### Tests
+
+Three guards, and the label vocabularies are read from the **scripts' source**
+rather than typed — `attribute()`'s `label` and `branch_point()`'s `verdict` —
+so adding a fourth label to either script fails until the table names it.
+
+Two rounds of narrowing, both driven by mutation rather than by review:
+
+1. The first extractor took every lower-case string constant in the function and
+   returned `compared`, `basis`, `login`, `sha` — dict keys and API field names.
+   It would have demanded verdict rows for things that are not labels.
+2. The first *assertion* asked whether the label appeared anywhere in Phase 7.
+   Deleting the `underivable` attribution row left it green, because the word
+   also appears in the confidence table and in the `BRANCH_POINT` row two lines
+   below. A label now has to be found in a row that is **about** it — matched on
+   the label *and* on `check` or `branch_point`.
+
+Seven mutations, each one verified to have landed before its result was read:
+every new row deleted in turn, the `pre-existing` row deleted, and a new
+`branch_point` label added with no row. All seven caught. 261 tests.
+
+Closes #65.
+
 ## [0.30.0] — 2026-08-21
 
 Phase 2 required an input the handoff never carried, and `audit.py` computed the

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -1023,7 +1023,13 @@ Verdicts are one of:
 
 Every row above is a finding; the verdict is a function of them, and leaving that
 function implicit is how two audits with the same evidence reach different
-recommendations. Read the table top-down and take the **first** row that matches:
+recommendations. Read the table top-down and take the **first** row that matches.
+
+Some rows say **not a Hold on this bump** rather than naming a verdict. Those are
+*reporting* rows: they settle that a real finding does not carry the verdict, and
+the read continues past them. They exist because the alternative is the reader
+reaching the fall-through — *"nothing above matched"* — and a finding that lands
+there by exhaustion is indistinguishable in the report from no finding at all.
 
 | Evidence | Verdict |
 |---|---|
@@ -1037,6 +1043,11 @@ recommendations. Read the table top-down and take the **first** row that matches
 | Phase 5: the frozen install failed, or a repo gate failed | **Hold** |
 | A red **required** check labelled **attributable** | **Hold** — the PR cannot merge either way. But read the failing step's log at **both commits** before the report says the bump *caused* it: green-then-red is consistent with the bump, not proof, and the wider the interval the weaker the claim |
 | A red required check labelled **pre-existing** | **Not a Hold on this bump.** Report it as its own finding, take the verdict from the remaining evidence, and say the PR is unmergeable until someone fixes it |
+| A red required check labelled **underivable** | **Not a Hold on this bump** — nothing established the cause, and a Hold that rests on an unattributed red row is correct only by accident. Report the red check *and* that the comparison could not be made; the PR is unmergeable until it is fixed. If this row would decide the verdict, confidence is **low** |
+| Actions: the pin is a tag or branch, **not a 40-hex SHA** | **Not a Hold on this bump** — the pin was mutable before this PR and the bump did not make it so. Report that what was audited is what runs *today*, so this repo's pins are not evidence, and take the verdict from the rest |
+| `BRANCH_POINT=rewritten` — the base branch was rewritten under this PR | **Not a Hold on this bump.** A fact about the branch, not the dependency. Report it with both substitutions Phase 0 named, and say that the scope diff and Phase 4's tree came from the substituted sources |
+| `BRANCH_POINT=suspect` — non-bot commits above the base, no force-push event | **Not a Hold.** Corroboration without the authority: read the commits, report what they changed, and say the base was *not* substituted on it alone |
+| `BRANCH_POINT=underivable` — the event list could not be read | **Not a Hold**, and not `ok` either. Report that the merge base was never proved to be the branch point, which caps confidence at **medium** — or **low** where the scope diff is what the verdict turns on |
 | Phase 4: base differs, PR agrees — real and already absorbed | **Merge as-is**, naming what the PR absorbed and how |
 | `mergeStateStatus: BLOCKED` with every check green | **Merge as-is** on the bump's merits; name what blocks it, usually `reviewDecision` |
 | Actions: the workflow file is generated (`DO NOT EDIT`) | **Merge as-is, then follow up** on the generator — this bump is transient without it |

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -81,6 +81,13 @@ remaining evidence, and the separate fact that the PR cannot merge until someone
 fixes a failure it did not cause. Reporting only the first reads as "merge this"
 on a PR that will not merge; reporting only the second blames the bump.
 
+**Every "not a Hold" row in Phase 7's table is a row here too.** A mutable pin, a
+rewritten base, an unattributable red check — each is a real finding that does
+not carry the verdict, and each has to appear as its own line rather than being
+absorbed into the recommendation. The verdict says what to do; these say what the
+reader is being asked to accept while doing it. A report that reaches *merge
+as-is* and mentions none of them is indistinguishable from one where none applied.
+
 ## Reasoning
 
 Why the verdict follows from the evidence. This is where a finding that no

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2215,5 +2215,152 @@ class TestTheExecutionGateIsReadWhereExecutionHappens(SkillHarness):
         self.assertGreater(seen, 0, "no block gates on MAY_EXECUTE")
 
 
+def _label_values(script: str, function: str, key: str) -> set[str]:
+    """Every value one function can put in `key` — its label vocabulary.
+
+    Read from the script's source rather than typed, for the reason the
+    required-context guard is: a typed list is a second copy, and it drifts
+    silently because the guard keeps passing against its own stale copy.
+
+    Narrow on purpose. A first version collected every lower-case string
+    constant in the function and came back with `compared`, `basis`, `login`
+    and `sha` — dict keys and API field names — which would have demanded rows
+    in Phase 7 for things that are not labels at all. Only two shapes carry a
+    label: a `"key": value` entry, and an assignment to a variable of that name.
+    Module-level constants (`UNDERIVABLE = "underivable"`) are resolved.
+    """
+    src = (PLUGIN / "scripts" / script).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    consts = {
+        t.id: n.value.value
+        for n in tree.body
+        if isinstance(n, ast.Assign) and isinstance(n.value, ast.Constant)
+        for t in n.targets
+        if isinstance(t, ast.Name) and isinstance(n.value.value, str)
+    }
+
+    def literal(node: ast.AST) -> set[str]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return {node.value}
+        if isinstance(node, ast.Name) and node.id in consts:
+            return {consts[node.id]}
+        if isinstance(node, ast.IfExp):
+            return literal(node.body) | literal(node.orelse)
+        return set()
+
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name == function):
+            continue
+        found: set[str] = set()
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Dict):
+                for k, v in zip(inner.keys, inner.values, strict=True):
+                    if isinstance(k, ast.Constant) and k.value == key:
+                        found |= literal(v)
+            elif isinstance(inner, ast.Assign):
+                names = [t.id for t in inner.targets if isinstance(t, ast.Name)]
+                if key in names:
+                    found |= literal(inner.value)
+                for tgt in inner.targets:
+                    if isinstance(tgt, ast.Tuple) and isinstance(inner.value, ast.Tuple):
+                        for t, v in zip(tgt.elts, inner.value.elts, strict=False):
+                            if isinstance(t, ast.Name) and t.id == key:
+                                found |= literal(v)
+        if not found:
+            raise AssertionError(f"{script}:{function} sets no `{key}` this guard can read")
+        return found
+    raise AssertionError(f"{script} has no function {function}")
+
+
+class TestEveryDerivedLabelLandsInTheVerdictTable(SkillHarness):
+    """Phase 7's table is the reason two audits on the same evidence agree.
+
+        Every row above is a finding; the verdict is a function of them, and
+        leaving that function implicit is how two audits with the same evidence
+        reach different recommendations.
+
+    A label the mechanised phases can print and the table does not name falls
+    through to the last row — *"Everything derived, nothing above matched →
+    Merge as-is"* — and arrives there by exhaustion, which reads in the report
+    exactly like arriving there because nothing was wrong.
+
+    Three were in that state. `attributable` and `pre-existing` had rows;
+    **`underivable` did not**, so a red *required* check whose cause could not be
+    established fell through to `Merge as-is` on a PR that cannot merge. And
+    `discover.py` reports `rewritten` and `suspect` as findings, with no row for
+    either.
+
+    The table already handles the fourth case of this shape explicitly —
+    `$HUMAN_COMMITS` is "a **finding to report**, never a Hold" — which is the
+    pattern: where a finding must not carry the verdict, the procedure says so
+    rather than trusting the reader to reach the fall-through and read it right.
+    """
+
+    def _phase7(self) -> str:
+        return dict(self.phases)[7].lower()
+
+    def _verdict_rows(self) -> list[str]:
+        """Rows of the table headed `| Evidence | Verdict |`, lower-cased.
+
+        The whole phase is the wrong haystack, and mutation said so: deleting the
+        `underivable` attribution row left the guard green, because the word also
+        appears in the confidence table and in the `BRANCH_POINT` row two lines
+        down. A label has to be found in a row that is *about* it.
+        """
+        for rows in tables(dict(self.phases)[7]):
+            if rows and "verdict" in rows[0].lower() and "evidence" in rows[0].lower():
+                return [r.lower() for r in rows[2:]]
+        raise AssertionError("Phase 7 has no `| Evidence | Verdict |` table")
+
+    def _assert_row(self, label: str, about: str, why: str) -> None:
+        """A row naming both the label and what it is a label *of*."""
+        self.assertTrue(
+            any(label.lower() in r and about.lower() in r for r in self._verdict_rows()), why
+        )
+
+    def test_every_attribution_label_has_a_verdict_row(self):
+        labels = _label_values("ci_state.py", "attribute", "label")
+        self.assertIn("underivable", labels, "the three-state label set moved")
+        for label in sorted(labels):
+            self._assert_row(
+                label,
+                "check",
+                f"ci_state.py can label a red context `{label}` and no verdict row "
+                f"names that label against a check, so a red required check carrying "
+                f"it falls through to Merge as-is",
+            )
+
+    def test_every_branch_point_finding_has_a_verdict_row(self):
+        """`ok` is the no-finding case; the rest are what `analyse()` reports."""
+        verdicts = _label_values("discover.py", "branch_point", "verdict") - {"ok"}
+        self.assertEqual(
+            verdicts,
+            {"rewritten", "suspect", "underivable"},
+            "branch_point's verdict vocabulary moved; the table has to move with it",
+        )
+        for verdict in sorted(verdicts):
+            self._assert_row(
+                verdict,
+                "branch_point",
+                f"discover.py reports `{verdict}` as a finding and no verdict row "
+                f"names it against BRANCH_POINT; the reader reaches the fall-through",
+            )
+
+    def test_a_pin_that_is_not_a_sha_has_a_verdict_row(self):
+        """The instance, and it is the one that costs most to leave out.
+
+        `references/actions.md`: a tag or branch pin is "a **promise someone else
+        can revoke**", and "a repo whose pins are not evidence". Without a row,
+        *we verified the pin* and *this repo's pins are not evidence* produce the
+        same verdict and the report has nothing that separates them.
+        """
+        self.assertRegex(
+            self._phase7(),
+            re.compile(r"not a 40-hex sha|not sha-pinned|tag or branch"),
+            "actions.md makes a mutable pin a finding and the verdict table has no "
+            "row for it, so it lands on Merge as-is by exhaustion",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #65. **Stacked on #69** — base is `fix/createdat-and-pin-age`.

Five findings the procedure instructs you to report had no row in Phase 7's
verdict table, so each fell through to *"Everything derived, nothing above matched
→ **Merge as-is**"* — by exhaustion, which in the report is indistinguishable from
no finding at all.

| Finding | Old verdict |
|---|---|
| a red required check labelled **underivable** | Merge as-is |
| an actions pin that is **not a 40-hex SHA** | Merge as-is |
| `BRANCH_POINT=rewritten` | Merge as-is |
| `BRANCH_POINT=suspect` | Merge as-is |
| `BRANCH_POINT=underivable` | Merge as-is |

The first is the worst: `ci_state.py` has three labels and the table had two, so a
red **required** check whose cause could not be established resolved to *Merge
as-is* on a PR that cannot merge.

## Tests, and two rounds of narrowing

Label vocabularies are read from the **scripts' source** — `attribute()`'s `label`,
`branch_point()`'s `verdict` — so a fourth label fails until the table names it.

Both narrowings came from mutation, not review:

1. The first extractor took every lower-case constant in the function and returned
   `compared`, `basis`, `login`, `sha` — dict keys and API field names. It would
   have demanded verdict rows for things that are not labels.
2. The first assertion asked whether the label appeared anywhere in Phase 7.
   Deleting the `underivable` attribution row left it **green** — the word also
   appears in the confidence table and in the `BRANCH_POINT` row two lines below.
   A label must now be found in a row that is *about* it.

Seven mutations, each verified to have landed before its result was read. All seven
caught. 261 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)