### PR TITLE
fix: exempt the block that writes the handoff, not all of Phase 0 (0.31.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,63 @@ patch.
 
 ## [Unreleased]
 
+## [0.31.1] — 2026-08-21
+
+0.28.0's guard exempted **all** of Phase 0 from the reload rule, when only the
+block that *writes* the handoff earns the exemption. Patch: it makes 0.28.0's
+claim true rather than adding one.
+
+Found by re-running the producer/consumer ledger against the finished stack —
+the same sweep that opened #61 — which still reported five orphaned consumers,
+all of them Phase 0's own later blocks.
+
+Phase 0 has six blocks. The first writes and sources the handoff; the rest fetch
+the ref, add the worktrees, read the repo's gates at a ref, and prove a reused
+worktree still points at `$HEAD_SHA`. They run in their own calls like any other
+block, and the exemption covered them by accident of being in the same phase.
+
+Measured, each block run alone with nothing sourced:
+
+| Block | Result |
+|---|---|
+| `git worktree add "$SCRATCH/base-<N>" "$BASE_SHA"` | `fatal: invalid reference:`, exit 128 — loud |
+| `git fetch origin "pull/<N>/head:pr-<N>" "$DEFAULT"` | **exit 0.** `pr-<N>` is created and the empty second refspec is ignored, so `$DEFAULT` is never fetched and the `tip-<N>` worktree has nothing to detach from |
+| `git show "$BASE_SHA:.github/workflows/<ci>.yml"` | **exit 0, 17,623 bytes** — from the **index** |
+
+The third is the one worth the patch. `:path` with an empty rev is the index, so
+the gate list came from the **user's working tree** — the exact failure Phase 0's
+*"Read every one of them at a ref"* rule exists to prevent, reached again through
+an empty variable rather than through a forgotten ref. With the preamble in place
+the same read resolves to `e414723c5` instead of `57861cb66`, and returns 17,614
+bytes rather than 17,623: it really was serving a different file.
+
+### Fixed
+
+- **Phase 0's four later blocks carry the preamble.** Same three lines as
+  everywhere else.
+- **The exemption is now the writing block, not the phase** — keyed on the block
+  containing `--shell >`, which is what makes it the writer.
+- **The `MAY_EXECUTE` illustration is no longer a `bash` fence.** It shows a line
+  that appears verbatim in two real blocks; demoting it to an indented example
+  says it is not a step, which is what the guard's subject actually is.
+
+### Measured, and worth recording
+
+The first pass at this measurement piped each command into `head` and read `$?`,
+which reported `exit=0` for the `worktree add` that had just printed
+`fatal: invalid reference:`. That is `SKILL.md`'s own Phase 5 warning —
+*"`cmd | tail && next` gates on `tail`, so a failing suite sails through"* —
+committed while measuring the plugin that documents it. The numbers above are
+from the unpiped re-run.
+
+### Tests
+
+The existing guard, tightened, and mutation-checked in both directions: reverting
+the exemption to phase-wide passes (which is why it had to be tightened), and
+dropping the preamble from any one Phase 0 block fails. 261 tests.
+
+Completes #61.
+
 ## [0.31.0] — 2026-08-21
 
 Five findings the procedure instructs you to report had no row in Phase 7's

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -147,6 +147,10 @@ next section.
 Then the part that changes state, which is yours:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git fetch origin "pull/<N>/head:pr-<N>" "$DEFAULT"
 git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
@@ -171,6 +175,10 @@ these were not — they ran in the user's checkout, so the answers came from
 whatever branch happened to be there:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git show "pr-<N>:.github/dependabot.yml" 2>/dev/null || git show "pr-<N>:renovate.json"
 git show "pr-<N>:.github/workflows/<ci>.yml"       # the gates Phase 5 reproduces
 git show "pr-<N>:.pre-commit-config.yaml"
@@ -198,6 +206,10 @@ stale worktree silently audits the wrong commit and every result downstream is
 wrong. Compare against the pinned SHA rather than eyeballing a log line:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 test "$(git -C "$SCRATCH/pr-<N>" rev-parse HEAD)" = "$HEAD_SHA"
 git -C "$SCRATCH/pr-<N>" status --porcelain                       # must be empty
 ```
@@ -238,9 +250,11 @@ it to the one bit later phases actually branch on is what `MAY_EXECUTE` is.
 **And they branch on it, rather than being trusted to remember this table.** The
 blocks in Phases 4 and 5 that run the audited repo's code open with
 
-```bash
-[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
-```
+    [ "${MAY_EXECUTE:-}" = yes ] || { echo "not authorised" >&2; exit 2; }
+
+quoted here as an illustration — the runnable copies live in
+`references/uv-lock.md` § Phase 4 and § Phase 5, which is where they are read
+from.
 
 Tested **for** `yes`, never against `no`, and the difference is the whole guard:
 a block whose handoff did not load sees the empty string, and `!= no` is true of
@@ -410,6 +424,10 @@ The substitutions, when `rewritten` fires:
   because the tree this PR would land on is the default branch's tip.
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git fetch origin "$DEFAULT"
 git worktree add --detach "$SCRATCH/tip-<N>" "origin/$DEFAULT"
 ```

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2037,8 +2037,15 @@ class TestEveryConsumerReloadsTheHandoff(SkillHarness):
     def test_every_block_reading_a_handoff_value_reloads_it(self):
         names = self._handoff_names()
         for file, number, code in _every_block():
-            if number == 0 and file == SKILL.name:
-                continue  # Phase 0 writes it; it is the one block that need not reload
+            # Only the block that *writes* the handoff is exempt, not the whole
+            # phase. Phase 0's later blocks run in their own calls like any
+            # other, and the exemption being phase-wide left the sharpest case
+            # of all still open: `git show "$BASE_SHA:.github/workflows/ci.yml"`
+            # with $BASE_SHA empty exits **0** and serves 17,623 bytes from the
+            # index — the user's working tree — which is the exact failure
+            # Phase 0's "read every one of them at a ref" rule exists to prevent.
+            if "--shell >" in code:
+                continue
             used = sorted(n for n in USED.findall(code) if n in names)
             if not used:
                 continue


### PR DESCRIPTION
Completes #61. **Stacked on #70** — base is `fix/verdict-table-completeness`.

Found by re-running the producer/consumer ledger against the finished stack — the
same sweep that opened #61. It still reported five orphaned consumers, all of them
Phase 0's own later blocks: 0.28.0's guard exempted the whole phase when only the
block that *writes* the handoff earns it.

Measured, each block alone with nothing sourced:

| Block | Result |
|---|---|
| `git worktree add "$SCRATCH/base-<N>" "$BASE_SHA"` | `fatal: invalid reference:`, exit 128 — loud |
| `git fetch origin "pull/<N>/head:pr-<N>" "$DEFAULT"` | **exit 0** — the empty refspec is ignored, so `$DEFAULT` is never fetched |
| `git show "$BASE_SHA:.github/workflows/<ci>.yml"` | **exit 0, 17,623 bytes from the INDEX** |

The third is why this is worth a patch. `:path` with an empty rev is the index, so
the gate list came from the **user's working tree** — the exact failure Phase 0's
*"read every one of them at a ref"* rule exists to prevent, reached again through
an empty variable. With the preamble the same read resolves to `e414723c5` instead
of `57861cb66` and returns 17,614 bytes rather than 17,623: it really was serving a
different file.

## Worth recording

My first pass at that measurement piped each command into `head` and read `$?`,
reporting `exit=0` for the `worktree add` that had just printed `fatal: invalid
reference:`. That is `SKILL.md`'s own Phase 5 warning — *"`cmd | tail && next`
gates on `tail`"* — hit while measuring the plugin that documents it. The numbers
above are from the unpiped re-run.

## Tests

The existing guard, tightened and mutation-checked both ways: reverting the
exemption to phase-wide **passes** (which is why it had to be tightened), and
dropping the preamble from any one Phase 0 block fails. 261 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)