### PR TITLE
fix: the scope gate checks what produces its evidence (0.31.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,84 @@ patch.
 
 ## [Unreleased]
 
+## [0.31.2] — 2026-08-21
+
+Phase 1's scope gate read its evidence through a pipe, so a failing `git` passed
+the gate. Patch: 0.28.0 already claimed the gate gates; this makes it true.
+
+Found by running the gate block **as extracted from `SKILL.md`** rather than
+retyped — the verification pass after #71 — against `fpga-board-sim` #363.
+
+A pipeline's exit status is its **last** stage, and `sort` succeeds on empty
+input. So:
+
+```
+$ out=$(for c in deadbeefdeadbeef; do git show --name-only --format= "$c" 2>/dev/null; done | sort -u)
+  pipeline exit=0  files=[]
+
+$ out=$(git diff --name-only "deadbeef..pr-363" 2>/dev/null | sort -u)
+  pipeline exit=0  files=[]
+```
+
+An empty file list is exactly what the gate reads as *nothing outside the
+manifest and lockfile*. Both branches had it — including the fallback added in
+0.28.0, so that release put a second door on the room it had just locked.
+
+It fires on nothing more exotic than an unfetched ref. Hit by accident on a
+scratch clone where `pr-363` had been deleted: `fatal: ambiguous argument`,
+followed by exit 0 and a clean gate.
+
+**The plugin already states the rule, two phases away.** `SKILL.md` § Phase 5 and
+`references/uv-lock.md` § Phase 5:
+
+> Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing suite
+> sails through; use `set -o pipefail` or separate calls.
+
+Phase 1's gate is the highest-stakes command in the procedure — it is what stops
+the audit before Phases 4 and 5 execute the PR's code — and it was the one place
+the rule was not followed.
+
+### Fixed
+
+- **Capture, check, then print.** Both halves of the split are captured into a
+  variable with an explicit `|| … exit 2`, and printed afterwards. Exit 2 is this
+  plugin's *could not run*, which is the honest answer: no evidence is not
+  evidence of nothing.
+- **`$HUMAN_COMMITS` too.** It is a report rather than a gate, so a failing `git`
+  there does not pass a bad bump — but it does report *no human commits on this
+  branch* when the truth is *could not tell*, which is the three-state error one
+  artifact along.
+
+Measured, the extracted block in four states:
+
+| State | Before | After |
+|---|---|---|
+| `BOT_COMMITS` set, ref present | exit 0, one file | unchanged |
+| `BOT_COMMITS` absent, ref present | exit 0, one file | unchanged |
+| fallback, **ref missing** | exit 0, **empty list** | **exit 2** |
+| `BOT_COMMITS` naming a commit that does not exist | exit 0, **empty list** | **exit 2** |
+
+### Tests
+
+Three guards, mutation-checked. Two of the three needed correcting first, both
+found by mutation rather than by reading:
+
+- **The block selector matched a mention, not a use.** `"BOT_COMMITS" in code`
+  picked Phase 0's key-list fence — `#   BOT_COMMITS=<shas>` — where there is no
+  `git` and no pipe, so the pipe guard passed against a *comment*. Requiring a
+  `$` is what separates the two, and the guard now also asserts it found exactly
+  one block.
+- **The failure-path guard was satisfied by a different line than the one it was
+  about.** Searching the block for `|| … exit 2` matched the handoff preamble
+  added in 0.28.0, while both of the gate's captures went unchecked. It now
+  asserts per capture.
+- **The pipe regex counted `||` as a pipe**, so it fired on the fix. A single
+  `|`, never the logical-or.
+
+263 tests.
+
+Closes #72.
+
 ## [0.31.1] — 2026-08-21
 
 0.28.0's guard exempted **all** of Phase 0 from the reload rule, when only the

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -505,12 +505,20 @@ if [ -z "${BOT_COMMITS+set}" ]; then
   # it here is what stops the substitution being something to remember.
   [ "$BRANCH_POINT" = rewritten ] && RANGE="pr-<N>^..pr-<N>" || RANGE="$BASE_SHA..pr-<N>"
   echo "BOT_COMMITS underivable — gating on the whole $RANGE diff" >&2
-  git diff --name-only $RANGE | sort -u
+  SCOPE=$(git diff --name-only $RANGE) || { echo "cannot diff $RANGE" >&2; exit 2; }
 else
-  for c in $BOT_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+  SCOPE=$(for c in $BOT_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
+    || { echo "cannot read a commit in \$BOT_COMMITS" >&2; exit 2; }
 fi
+# Captured and checked, never piped: a pipeline reports its LAST stage, and
+# `sort` succeeds on empty input — so a failing git hands the gate an empty file
+# list at exit 0, which reads as a clean scope. Exit 2 is the honest answer; no
+# evidence is not evidence of nothing.
+printf '%s\n' "$SCOPE" | sort -u
 # a maintainer's commit on the bot's branch: read it, report it, do not Hold on it
-for c in $HUMAN_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
+HUMANS=$(for c in $HUMAN_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
+  || { echo "cannot read a commit in \$HUMAN_COMMITS" >&2; exit 2; }
+printf '%s\n' "$HUMANS" | sort -u
 ```
 
 A merge commit is in the second list and normally prints nothing — its content

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2369,5 +2369,88 @@ class TestEveryDerivedLabelLandsInTheVerdictTable(SkillHarness):
         )
 
 
+class TestTheScopeGateChecksWhatProducesItsEvidence(SkillHarness):
+    """The gate read its file list through a pipe, so a failing git passed it.
+
+    A pipeline's exit status is its **last** stage. `sort` succeeds on empty
+    input, so a `git` that fails yields an empty file list at exit 0 — and an
+    empty file list is exactly what the gate reads as *nothing outside the
+    manifest and lockfile*. Measured in a real clone:
+
+        out=$(for c in deadbeefdeadbeef; do git show --name-only --format= "$c" \
+              2>/dev/null; done | sort -u)
+        pipeline exit=0  files=[]
+
+    Both branches had it, the fallback added in 0.28.0 included — so that release
+    put a second door on the room it had just locked. Hit by accident on a
+    scratch clone where `pr-363` had been deleted: `fatal: ambiguous argument`,
+    and exit 0.
+
+    The plugin already states the rule, in Phase 5 and in `uv-lock.md` § Phase 5:
+    *"Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing
+    suite sails through."* Phase 1's gate is the highest-stakes command in the
+    procedure — it is what stops the audit before Phases 4 and 5 execute the PR's
+    code — and it was the one place the rule was not followed.
+    """
+
+    # A non-comment statement that runs git and pipes onward — the shape that
+    # discards git's status, whether the pipe hangs off the command itself or off
+    # the `done` of a loop containing it. Both were present.
+    # A single `|`, never `||`: the logical-or is how the fixed form *checks*
+    # git's status, so a guard that counts it as a pipe fires on the fix.
+    PIPED = re.compile(r"^(?!\s*#)[^\n]*\bgit\s[^\n]*(?<!\|)\|(?!\|)", re.MULTILINE)
+
+    def _gate_block(self) -> str:
+        """The block that *uses* the split, not the one that documents it.
+
+        `"BOT_COMMITS" in code` picked Phase 0's key-list fence — `#   BOT_COMMITS
+        =<shas>` — where there is no git and no pipe, so the pipe guard passed
+        against a comment. Requiring a `$` is what separates a use from a mention,
+        the same discriminator the MAY_EXECUTE guard needs.
+        """
+        found = [c for _, _, c in _every_block() if re.search(r"\$\{?BOT_COMMITS", c)]
+        self.assertTrue(found, "no block gates on $BOT_COMMITS")
+        self.assertEqual(len(found), 1, f"expected one gate block, found {len(found)}")
+        return found[0]
+
+    def test_the_gate_does_not_read_its_evidence_through_a_pipe(self):
+        piped = self.PIPED.findall(self._gate_block())
+        self.assertEqual(
+            piped,
+            [],
+            "Phase 1's gate pipes git output onward, so the pipeline reports "
+            "`sort`'s status and a failing git yields an empty file list at exit "
+            "0 — which the gate reads as a clean scope",
+        )
+
+    # `NAME=$(… git …)` and whatever follows the closing paren.
+    CAPTURE = re.compile(r"([A-Z_]+)=\$\((?P<body>(?:[^()]|\([^()]*\))*)\)(?P<after>[^\n]*)")
+
+    def test_every_capture_of_git_output_is_checked(self):
+        """Capturing is not enough on its own; something has to act on it.
+
+        Asserted per capture rather than once per block: the block opens with the
+        handoff preamble, whose own `|| … exit 2` satisfied a block-wide search
+        while the gate's two captures went unchecked. A guard that can be
+        satisfied by a *different* line than the one it is about is the same
+        failure as one satisfied by a comment.
+        """
+        block = self._gate_block()
+        seen = 0
+        for found in self.CAPTURE.finditer(block):
+            if "git " not in found.group("body"):
+                continue
+            seen += 1
+            tail = found.group("after") + block[found.end() : found.end() + 120]
+            self.assertRegex(
+                tail,
+                re.compile(r"\|\|\s*(?:\\\n\s*)?\{[^}]*exit 2"),
+                f"`{found.group(1)}` captures git output and nothing checks it. "
+                f"Exit 2 is this plugin's `could not run`, and it is the honest "
+                f"answer: no evidence is not evidence of nothing",
+            )
+        self.assertGreaterEqual(seen, 2, "the gate should capture both halves of the split")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #72. **Stacked on #71** — base is `fix/phase0-own-blocks`.

Phase 1's scope gate read its file list through a pipe, so a failing `git` passed
the gate. Found by running the block **as extracted from `SKILL.md`** rather than
retyped.

A pipeline's exit status is its last stage, and `sort` succeeds on empty input:

```
$ out=$(git diff --name-only "deadbeef..pr-363" 2>/dev/null | sort -u)
  pipeline exit=0  files=[]
```

An empty file list is exactly what the gate reads as *nothing outside the manifest
and lockfile*. Both branches had it — **including the fallback added in 0.28.0**,
so that release put a second door on the room it had just locked. It fires on
nothing more exotic than an unfetched ref.

The plugin already states the rule two phases away, in Phase 5: *"Gate on exit
codes. `cmd | tail && next` gates on `tail`, so a failing suite sails through."*
Phase 1's gate is the one place it was not followed — and it is what stops the
audit before Phases 4 and 5 execute the PR's code.

## Measured, the extracted block in four states

| State | Before | After |
|---|---|---|
| `BOT_COMMITS` set, ref present | exit 0, one file | unchanged |
| `BOT_COMMITS` absent, ref present | exit 0, one file | unchanged |
| fallback, **ref missing** | exit 0, **empty list** | **exit 2** |
| `BOT_COMMITS` naming a bad commit | exit 0, **empty list** | **exit 2** |

## Tests — two of three guards needed correcting first

Both found by mutation, not by reading:

- **The selector matched a mention, not a use.** `"BOT_COMMITS" in code` picked
  Phase 0's key-list *comment* fence, where there is no git and no pipe — so the
  pipe guard passed against a comment.
- **The failure-path guard was satisfied by a different line than the one it was
  about** — the handoff preamble's own `|| … exit 2` from 0.28.0, while both of
  the gate's captures went unchecked. It asserts per capture now.
- The pipe regex counted `||` as a pipe, so it fired on the fix.

263 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)