### PR TITLE
Producer/consumer sweep: the handoff and the wiring (0.28.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,81 @@ a fallback is not a saving.
 `--json` now reports `parent_names: []` on a PR with nothing red. Nothing reads
 it there and no phase consumes `--json`, but it is visible.
 
+### `MAY_EXECUTE` was emitted, documented as load-bearing, and read by nothing
+
+`discover.py` derives the classification — a fork PR, a non-bot author, an
+account without `push` — and reduces it to one bit. Phase 0's prose said why:
+
+> Reducing it to the one bit later phases actually branch on is what
+> `MAY_EXECUTE` is.
+
+No phase branched on it. Every occurrence in the plugin was the emit, the
+key-list comment, and two sentences explaining its purpose; the gate itself lived
+only in Phase 0's own table, six phases before the phases that execute, as advice
+to *run `--no-execute`*.
+
+**Fixed.** Both `uv-lock.md` blocks that run the audited repo's code — `gate_diff.py`,
+and the frozen `uv sync` pair — open with the test, and both phases' contract
+lines say so. The test is **for `yes`, never against `no`**, measured across the
+three states a block can see:
+
+| | `[ = yes ]` | `[ != no ]` |
+|---|---|---|
+| `MAY_EXECUTE=yes` | proceeds | proceeds |
+| `MAY_EXECUTE=no` | refuses, exit 2 | refuses, exit 2 |
+| **unset** | **refuses, exit 2** | **proceeds** |
+
+A block whose handoff did not load sees the empty string, and the negative form
+passes it. The one direction this must never fail in is open.
+
+**`BRANCH_POINT` was the same defect**, found by the guard written for
+`MAY_EXECUTE`: emitted, said to be read by Phase 1, and read by no block — the
+rewritten-base substitution was prose telling the reader to use a different
+range. It is now a conditional in Phase 1's fallback, the one path where it still
+decides anything: with `$BOT_COMMITS` derivable the bot's own commits are the
+bump wherever the base moved to.
+
+**`BASE_REF` is declared a diagnostic**, in the line the new guard reads. 0.26.1
+settled that it is deliberately unconsumed; the exemption is now written down
+instead of inferred from nobody having used it.
+
+**Replayed.** The gate, derived live against four PRs:
+
+| Repo | `push` | Author | `MAY_EXECUTE` |
+|---|---|---|---|
+| `fpga-board-sim` #363 | true | `dependabot[bot]` | **yes** |
+| `dependabot-audit` #60 | true | human | no |
+| `BIRSAx2/mdcat` #6 | false | — | no |
+| `cli/cli` #14147 | false | — | no |
+
+Row two is the one worth reading: full `admin` on a repo this account owns, and
+still `no`, because the classification is two questions and only one is about
+permissions.
+
+The `BRANCH_POINT` substitution needed a base that had actually been rewritten,
+and no reachable PR is in that state — CONTRIBUTING's fifth row. Built one: a
+root commit, a commit vendoring a `supply-chain` tree, a third commit, a PR
+branching from the third and adding `manifest.txt`, then the base rewritten so
+the shared ancestor falls back past the vendored tree.
+
+```
+BRANCH_POINT=ok         -> 7 file(s): manifest.txt src.py vendor-{a..e}.txt
+BRANCH_POINT=rewritten  -> 1 file(s): manifest.txt
+```
+
+Without the conditional the fallback gates on seven files and Holds a one-file
+manifest bump for reaching beyond the manifest — the shape `SKILL.md` records
+from a real Cargo bump at 14 files and 3,682 deletions. A first attempt at that
+construction force-pushed *forward* rather than rewriting, so both ranges
+returned one file and agreed; agreement there would have read as *the conditional
+is unnecessary*.
+
+**Tests.** Four guards, mutation-checked in five directions. The completeness
+rule now runs **both** ways: 0.26.1's guards ask that every promised name is
+produced, these ask that every produced name is consumed or named inert. The
+drift was already bidirectional when 0.26.1 shipped — its own changelog says so —
+and only one direction had a guard.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,53 @@ produced, these ask that every produced name is consumed or named inert. The
 drift was already bidirectional when 0.26.1 shipped — its own changelog says so —
 and only one direction had a guard.
 
+### Phase 2 required an input the handoff never carried
+
+> *Requires: the Phase 1 script output, and the PR's `createdAt` from Phase 0.*
+
+`discover.py` renders `createdAt` and the emitter never wrote it, so the input
+crossed by being on screen. It is the class 0.26.1 closed for `$PERMS`, and it
+slipped that guard twice over on punctuation: the phrase is `Requires:` rather
+than `Requires from Phase 0:`, and the name is neither `$`-prefixed nor
+upper-case.
+
+**Fixed.** `CREATED_AT` is emitted, tabled, and read — Phase 2 computes the
+cooldown boundary from it rather than subtracting three days by eye, and the
+window is measured from when the **PR opened**, not from now, which is the drift
+Phase 7's table already calls out in itself. `python3` rather than `date -d`,
+which is GNU-only.
+
+**The pin's own publish date reaches the report.** `locked_published` was
+computed and rendered nowhere, so the currency block could say when the newer
+release landed and never when the current one did. On `fpga-board-sim`'s live
+lockfile:
+
+```
+=== pytest: locked 9.1.1 (published 2026-06-19T10:58:31Z) IS the latest
+=== ruff: locked 0.16.3 (published 2026-08-13T15:16:27Z), registry latest 0.16.4  <-- NOT CURRENT
+      0.16.4       published 2026-08-20T17:43:16Z
+```
+
+**And a hole in the guard itself**, which is the more useful half. Deleting the
+`CREATED_AT` emit left **every test green**. `_produced()` unions the emitter's
+names with `ASSIGNED.findall(self.shell[0])`, and Phase 0 documents the entire
+handoff in a bash fence of `#   NAME=<...>` comment lines — so a requires-line
+could be satisfied by the very key list it is meant to be checked against.
+Comments are now stripped before that scan. It is the same failure `_code_only`
+exists for one file over — *a rule must not be satisfiable by a comment claiming
+it* — and it had been sitting under 0.26.1's two guards since they were written.
+
+**Replayed.** `fpga-board-sim` #363, two deliberately separate calls:
+
+```
+call 1:  CREATED_AT=2026-08-17T13:07:54Z          # emitted
+call 2:  cooldown boundary: 2026-08-14T13:07:54+00:00   # sourced, computed
+```
+
+**Tests.** The requires-line guard is widened to `Requires:` and paired with a new
+one refusing a bare backticked name in such a line — the exact shape `createdAt`
+had, so the hole is closed as a class rather than at the instance.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,48 @@ second mutation was run twice — the first attempt used a malformed `sed` that
 never landed, and the guard passed. A mutation that does not mutate reads exactly
 like a guard that discriminates.
 
+### `ci_state.py` made five API calls on a green PR and read one
+
+Measured with a logging passthrough around `gh`, on `fpga-board-sim` #363:
+
+```
+CALL: api graphql <rollup>                                  <- the answer
+CALL: api repos/…/commits/bddcc474b7/check-runs --paginate  <- never read
+CALL: api repos/…/commits/bddcc474b7/status                 <- never read
+CALL: api repos/…/commits/bddcc474b7/check-runs --paginate  <- never read
+CALL: api repos/…/commits/bddcc474b7/status                 <- never read
+```
+
+Note the SHA. `pr-<N>^` and `$BASE_SHA` are the same commit on a genuine
+one-commit bot PR — `SKILL.md` says so and calls it the ordinary case — so the
+ordinary case fetched **the same two endpoints twice** and consulted neither.
+
+Every consumer is gated on red: `attribute()` runs once per red context, and
+`parent_names` renders only under `if report["red"] and …`. `conclusions_at()`
+ran before `analyse()` had computed `report["red"]`, so it could not know. The
+script already applied this reasoning one rung lower — *"Only worth two calls
+when there is a red row for them to qualify"*, on `committed_at` — and had never
+applied it to the pair above it, which is twice the calls and paginates.
+
+**Fixed.** `analyse()` hoisted above the comparison reads, both gated on
+`report["red"]`, and the merge base fetched only when the parent has no runs —
+the single branch `attribute()` reads it in. `committed_at` follows the dict it
+qualifies.
+
+**Replayed** live through the same tap, on the two PRs this phase's prose cites:
+`fpga-board-sim` #363 (green) **5 → 1** calls, verdict unchanged; `BIRSAx2/mdcat`
+#6 (red) **7 → 4**, verdict unchanged at `PRE-EXISTING — red at b1b0dd4c1
+(pr-<N>^) too`. The second is the one that had to be checked: it is the case the
+attribution comparison exists for, and the saving must not reach it. It does not.
+
+**Tests.** Three guards on the *shape of the work* rather than its output, each
+mutation-checked. The third — *a red PR with no runs at the parent still falls
+back to the base* — was written first, as the control: a saving that also removes
+a fallback is not a saving.
+
+`--json` now reports `parent_names: []` on a PR with nothing red. Nothing reads
+it there and no phase consumes `--json`, but it is visible.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,91 @@ patch.
 
 ## [Unreleased]
 
+## [0.28.0] — 2026-08-21
+
+One sprint, one release: a producer/consumer sweep of the plugin — for every
+value a phase produces, who consumes it; for every value a phase consumes, who
+reliably produces it. Six defects, each with its own commit below. Minor: several
+of them change what a phase verifies or what the report asserts.
+
+### Phase 0's handoff was sourced once, in Phase 0
+
+`discover.py --shell` writes `$SCRATCH/phase0.env` and Phase 0 sources it. That
+was the only `. "$SCRATCH/phase0.env"` in the plugin, and eleven blocks across
+`SKILL.md` and both references read what it carries.
+
+`SKILL.md` has stated the mechanism since 0.26.0, in its own Phase 0:
+
+> Measured against this harness, two separate calls: an `export` in the first is
+> **unset** in the second, shell functions likewise, and each call is a new shell
+> process.
+
+Re-measured across two Bash calls in one session: a variable exported in the
+first reads `<UNSET>` in the second, a function defined in the first is `not
+found`, the pids differ. 0.26.0 fixed `$SCRATCH`'s **derivation** so the next
+call could name the directory. **Recomputable is not recomputed** — nothing told
+the next call to go and find it.
+
+Each consuming block, run alone with nothing sourced:
+
+| Block | Result |
+|---|---|
+| Phase 1, `uv.lock` | `/base.uv.lock: Permission denied` — loud |
+| Phase 4, `gate_diff.py` | `error: /base-1 is not a git worktree`, exit 2 — loud |
+| Phase 6, `ci_state.py` | `Could not resolve to a Repository with the name '/'`, exit 2 — loud |
+| Phase 7, cleanup | `fatal: '/pr-1' is not a working tree`, exit 128 — loud, worktrees left registered |
+| Phase 0, the gate read | **exit 0, 17,623 bytes from the INDEX** |
+| **Phase 1, the authorship gate** | **silent** |
+
+Two of those are silent, and both are the failure this procedure is most explicit
+about. `for c in $BOT_COMMITS` over an unset variable iterates zero times, so the
+gate's file list is empty and it passes — *"the one outcome worse than a false
+Hold"*, in `SKILL.md`'s own words. And `git show ":path"` with an empty rev is
+the **index**, so Phase 0's gate list came from the user's working tree — the
+exact failure its *"read every one of them at a ref"* rule exists to prevent,
+reached through an empty variable rather than a forgotten ref.
+
+**Fixed.** Every block that consumes a Phase 0 output opens with three lines that
+re-derive `$SCRATCH` and re-source the handoff, `Phase 0's own later blocks
+included` — the exemption is the block that *writes* the handoff, keyed on
+`--shell >`, not the phase it sits in. Repeated in all eleven rather than stated
+once, because a step merely implied is one that gets skipped. The `||` is the
+load-bearing half: a `.` on a missing file returns 1 and keeps going.
+
+Phase 1's underivable fallback moved out of the prose and into the shell too:
+Phase 0 already emits `# BOT_COMMITS is absent` commented out so the variable
+stays unset, and the prose already said to gate on the whole diff instead. The
+block did not implement it.
+
+`git` state is the exception and now says so. The `pr-<N>` ref lives in the
+repository, so `git show "pr-<N>:…"` works from any call; only the shell handoff
+is lost, and conflating the two is what made the reload look unnecessary.
+
+**Replayed** two deliberately separate calls against two PRs, for the two
+branches of the gate. `fpga-board-sim` #363 (bot PR, `BOT_COMMITS` set): call 2
+opened with `SCRATCH` and `BASE_SHA` unset, re-derived, re-sourced, gated
+correctly on `.github/workflows/ci.yml`. `dependabot-audit` #60 (human PR, split
+absent) is the discriminating one — same handoff, both blocks:
+
+```
+OLD:  (empty)  0 files. The gate passes.
+NEW:  BOT_COMMITS underivable — gating on the whole $BASE_SHA..pr-60 diff
+      CHANGELOG.md
+      .claude-plugin/plugin.json
+      skills/dependabot-audit/references/actions.md
+      tests/test_skill_prose.py
+```
+
+Four files, one inside the plugin's own `references/`, reported as a clean scope
+by the shipped gate.
+
+**Tests.** Three guards, each mutation-checked: every block reading a handoff
+value sources it; the `$SCRATCH` derivation exists in exactly one form; a value
+the prose promises to handle when unset is tested rather than iterated. The
+second mutation was run twice — the first attempt used a malformed `sed` that
+never landed, and the guard passed. A mutation that does not mutate reads exactly
+like a guard that discriminates.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -260,6 +260,49 @@ call 2:  cooldown boundary: 2026-08-14T13:07:54+00:00   # sourced, computed
 one refusing a bare backticked name in such a line — the exact shape `createdAt`
 had, so the hole is closed as a class rather than at the instance.
 
+### Five findings had no row in Phase 7's verdict table
+
+The table exists for one reason, which it states: *"leaving that function
+implicit is how two audits with the same evidence reach different
+recommendations."* A finding that lands on the fall-through — *"Everything
+derived, nothing above matched → **Merge as-is**"* — is, in the report,
+indistinguishable from no finding at all.
+
+| Finding | Old verdict |
+|---|---|
+| a red required check labelled **underivable** | Merge as-is |
+| an actions pin that is **not a 40-hex SHA** | Merge as-is |
+| `BRANCH_POINT=rewritten` | Merge as-is |
+| `BRANCH_POINT=suspect` | Merge as-is |
+| `BRANCH_POINT=underivable` | Merge as-is |
+
+The first is the worst: `ci_state.py` has three labels and the table had two, so
+a red **required** check whose cause could not be established resolved to *Merge
+as-is* on a PR that cannot merge.
+
+**Fixed.** Five rows, in the *not a Hold on this bump* register the `pre-existing`
+row already uses. The top-down rule now admits that some rows do not end the read
+— *"take the first row that matches"* and a row saying *take the verdict from the
+remaining evidence* were already in tension, and the `pre-existing` row has worked
+that way since 0.20.0. `report-template.md` carries the reporting obligation,
+since the template is what gets copied.
+
+**Tests.** The label vocabularies are read from the **scripts' source** rather
+than typed — `attribute()`'s `label`, `branch_point()`'s `verdict` — so a fourth
+label in either script fails until the table names it. Two rounds of narrowing,
+both driven by mutation rather than by review:
+
+1. The first extractor took every lower-case string constant in the function and
+   returned `compared`, `basis`, `login`, `sha` — dict keys and API field names.
+   It would have demanded verdict rows for things that are not labels.
+2. The first *assertion* asked whether the label appeared anywhere in Phase 7.
+   Deleting the `underivable` attribution row left it **green**, because the word
+   also appears in the confidence table and in the `BRANCH_POINT` row two lines
+   below. A label now has to be found in a row that is **about** it.
+
+Seven mutations, each verified to have landed before its result was read. All
+seven caught.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -146,6 +146,10 @@ next section.
 Then the part that changes state, which is yours:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git fetch origin "pull/<N>/head:pr-<N>" "$DEFAULT"
 git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
@@ -170,6 +174,10 @@ these were not — they ran in the user's checkout, so the answers came from
 whatever branch happened to be there:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git show "pr-<N>:.github/dependabot.yml" 2>/dev/null || git show "pr-<N>:renovate.json"
 git show "pr-<N>:.github/workflows/<ci>.yml"       # the gates Phase 5 reproduces
 git show "pr-<N>:.pre-commit-config.yaml"
@@ -197,6 +205,10 @@ stale worktree silently audits the wrong commit and every result downstream is
 wrong. Compare against the pinned SHA rather than eyeballing a log line:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 test "$(git -C "$SCRATCH/pr-<N>" rev-parse HEAD)" = "$HEAD_SHA"
 git -C "$SCRATCH/pr-<N>" status --porcelain                       # must be empty
 ```
@@ -208,7 +220,7 @@ If either check fails, `git worktree remove` it and re-add.
 | | |
 |---|---|
 | `$DEFAULT` | the repo's default branch, derived |
-| `$SCRATCH` | scratch directory, outside the repo — and **derived, so every later call resolves it to the same place**. Nothing else here survives a call boundary |
+| `$SCRATCH` | scratch directory, outside the repo — and **derived, so every later call resolves it to the same place**. Nothing else here survives a call boundary, so every consuming block re-derives this and re-sources `phase0.env` before reading any row below |
 | `$HEAD_SHA` | the full 40-character commit under audit |
 | `$BASE_SHA` | the merge base, from GitHub's own `compare` endpoint — never a local `git merge-base` against `$DEFAULT`, which collapses onto the head once the PR lands. **And whether it is the bot's branch point**, which is a separate answer |
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
@@ -321,6 +333,35 @@ cwd reset back. `SCRATCH` is required to be outside the repo, so it can never be
 reached that way. Nothing ambient crosses the boundary — only a path each call
 can recompute from what it already has, which is the repo and `<N>`.
 
+**Recomputable is not recomputed, and that distinction shipped as a defect.**
+Deriving `$SCRATCH` made the handoff *findable* from a later call; it did not make
+any later call go and find it. So every block below that consumes a Phase 0 output
+opens with the same three lines, and they are not decoration:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+```
+
+Repeated rather than stated once, because a step that is merely implied is one
+that gets skipped — the same argument that put the gate list at a ref. The `||`
+is the load-bearing half: a `.` on a missing file returns 1 and keeps going, so
+without it the block runs on with every output empty, which is the state this
+whole phase exists to make impossible.
+
+**What that empties, measured**, running each consuming block in a fresh call with
+nothing sourced: Phase 1's lockfile read, Phase 4, Phase 6 and Phase 7's cleanup
+all fail loudly — a `Permission denied`, two exit 2s, an exit 128 — and Phase 1's
+**authorship gate passes silently**, because `for c in $BOT_COMMITS` over an unset
+variable iterates zero times and hands the gate an empty file list. That is why
+the block below tests the variable rather than trusting it: the fallback belongs
+in the shell, not only in the paragraph that describes it.
+
+`git` state is the exception and needs no reload. The `pr-<N>` ref Phase 0 fetches
+is in the repository, so `git show "pr-<N>:…"` works from any call. Only the shell
+handoff is lost.
+
 A harness-provided `SCRATCH` still wins, and now for a reason: if one is exported
 into every call's environment it is stable by definition. The derived default is
 what applies when it is not.
@@ -362,6 +403,10 @@ The substitutions, when `rewritten` fires:
   because the tree this PR would land on is the default branch's tip.
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git fetch origin "$DEFAULT"
 git worktree add --detach "$SCRATCH/tip-<N>" "origin/$DEFAULT"
 ```
@@ -426,10 +471,21 @@ Phase 0 derived both halves, so take the gate's diff from the bot's commits and
 report the human's separately:
 
 ```bash
-# what the bump itself changed — this is what the gate is about
-for c in $BOT_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# what the bump itself changed — this is what the gate is about.
+# Unset is Phase 0's third state, and an unset list iterates zero times: the
+# fallback has to fire here, or the gate passes on an empty diff.
+if [ -z "${BOT_COMMITS+set}" ]; then
+  echo "BOT_COMMITS underivable — gating on the whole \$BASE_SHA..pr-<N> diff" >&2
+  git diff --name-only "$BASE_SHA" "pr-<N>" | sort -u
+else
+  for c in $BOT_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+fi
 # a maintainer's commit on the bot's branch: read it, report it, do not Hold on it
-for c in $HUMAN_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+for c in $HUMAN_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
 ```
 
 A merge commit is in the second list and normally prints nothing — its content
@@ -693,6 +749,10 @@ in this file were here — each of them a real endpoint asked the wrong question
 answering in a well-formed way. A hand-run query cannot be regression-tested.
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 C="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/ci_state.py"
 PARENT=$(git rev-parse "pr-<N>^")
 
@@ -888,6 +948,10 @@ commit that no longer exists while Phase 6 reports on the new one — and the ta
 silently asserts that they agree:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 test "$(gh pr view <N> --json headRefOid --jq .headRefOid)" = "$HEAD_SHA"
 ```
 
@@ -1033,6 +1097,10 @@ stop, and the one that used to litter every time. Phase 7 is the only phase ever
 audit reaches, including the one that ends at the gate.
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 git worktree remove "$SCRATCH/pr-<N>"
 git worktree remove "$SCRATCH/base-<N>"
 git branch -D "pr-<N>"

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -229,6 +229,7 @@ If either check fails, `git worktree remove` it and re-add.
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
 | `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **Phase 1 reads it**, and the table below says what each one means |
+| `$MAY_EXECUTE` | `yes` or `no` — **Phases 4 and 5 gate on it**, and the gate tests for `yes` so an unset value refuses. The classification below is what sets it |
 | `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
 | `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
 
@@ -243,6 +244,24 @@ Phase 0's own working state.
 The reason is that `$PERMS` is a set of flags rather than a value: `$PERMS.push`
 is how the gate below addresses it, and there is no shell form of that. Reducing
 it to the one bit later phases actually branch on is what `MAY_EXECUTE` is.
+
+**And they branch on it, rather than being trusted to remember this table.** The
+blocks in Phases 4 and 5 that run the audited repo's code open with
+
+    [ "${MAY_EXECUTE:-}" = yes ] || { echo "not authorised" >&2; exit 2; }
+
+quoted here as an illustration — the runnable copies live in
+`references/uv-lock.md` § Phase 4 and § Phase 5, which is where they are read
+from.
+
+Tested **for** `yes`, never against `no`, and the difference is the whole guard:
+a block whose handoff did not load sees the empty string, and `!= no` is true of
+it. The one direction this must never fail in is open.
+
+**Diagnostics — emitted, deliberately unread:** `BASE_REF`. It is Phase 0's own
+cross-check on the `compare` call and no later phase consumes it. Every *other*
+name the emitter writes is read by a block; that is the rule, and an exemption is
+a decision written down here rather than a name nobody happened to use.
 
 If a later phase needs something not on this list, it belongs here rather than
 there. A phase that consumes what a later phase creates cannot be run in order,
@@ -479,8 +498,12 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 # Unset is Phase 0's third state, and an unset list iterates zero times: the
 # fallback has to fire here, or the gate passes on an empty diff.
 if [ -z "${BOT_COMMITS+set}" ]; then
-  echo "BOT_COMMITS underivable — gating on the whole \$BASE_SHA..pr-<N> diff" >&2
-  git diff --name-only "$BASE_SHA" "pr-<N>" | sort -u
+  # No split to gate on, so the range matters — and a rewritten base makes the
+  # merge-base range the whole divergence. Phase 0 already decided which; reading
+  # it here is what stops the substitution being something to remember.
+  [ "$BRANCH_POINT" = rewritten ] && RANGE="pr-<N>^..pr-<N>" || RANGE="$BASE_SHA..pr-<N>"
+  echo "BOT_COMMITS underivable — gating on the whole $RANGE diff" >&2
+  git diff --name-only $RANGE | sort -u
 else
   for c in $BOT_COMMITS; do git show --name-only --format= "$c"; done | sort -u
 fi
@@ -643,8 +666,8 @@ form returns zero.
 
 *Requires from Phase 0: the `$SCRATCH/base-<N>` worktree — or `$SCRATCH/tip-<N>`
 if Phase 0 found the base rewritten — and the repo's own gates.*
-*Executes code from the PR. Skipped under `--no-execute`; skip it if Phase 1
-found anything.*
+*Executes code from the PR. Requires `MAY_EXECUTE=yes`. Skipped under
+`--no-execute`; skip it if Phase 1 found anything.*
 
 **The question: does this change what runs here, or what this repo's gates
 accept?** Not "is it safe". For `uv.lock` you can measure it, and you must —
@@ -680,8 +703,8 @@ working; reaching it by not looking is the failure.
 ## Phase 5 — Independent reproduction
 
 *Requires from Phase 0: the `$SCRATCH/pr-<N>` worktree, `$HEAD_SHA`, `pr-<N>`.*
-*Executes code from the PR — the most of any phase. Skipped under
-`--no-execute`; skip it if Phase 1 found anything.*
+*Executes code from the PR — the most of any phase. Requires `MAY_EXECUTE=yes`.
+Skipped under `--no-execute`; skip it if Phase 1 found anything.*
 
 **The question: has this been shown to work, independently of the bot saying so?**
 For `uv.lock` you answer it by building and running the thing. For GitHub Actions

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -1041,7 +1041,13 @@ Verdicts are one of:
 
 Every row above is a finding; the verdict is a function of them, and leaving that
 function implicit is how two audits with the same evidence reach different
-recommendations. Read the table top-down and take the **first** row that matches:
+recommendations. Read the table top-down and take the **first** row that matches.
+
+Some rows say **not a Hold on this bump** rather than naming a verdict. Those are
+*reporting* rows: they settle that a real finding does not carry the verdict, and
+the read continues past them. They exist because the alternative is the reader
+reaching the fall-through — *"nothing above matched"* — and a finding that lands
+there by exhaustion is indistinguishable in the report from no finding at all.
 
 | Evidence | Verdict |
 |---|---|
@@ -1055,6 +1061,11 @@ recommendations. Read the table top-down and take the **first** row that matches
 | Phase 5: the frozen install failed, or a repo gate failed | **Hold** |
 | A red **required** check labelled **attributable** | **Hold** — the PR cannot merge either way. But read the failing step's log at **both commits** before the report says the bump *caused* it: green-then-red is consistent with the bump, not proof, and the wider the interval the weaker the claim |
 | A red required check labelled **pre-existing** | **Not a Hold on this bump.** Report it as its own finding, take the verdict from the remaining evidence, and say the PR is unmergeable until someone fixes it |
+| A red required check labelled **underivable** | **Not a Hold on this bump** — nothing established the cause, and a Hold that rests on an unattributed red row is correct only by accident. Report the red check *and* that the comparison could not be made; the PR is unmergeable until it is fixed. If this row would decide the verdict, confidence is **low** |
+| Actions: the pin is a tag or branch, **not a 40-hex SHA** | **Not a Hold on this bump** — the pin was mutable before this PR and the bump did not make it so. Report that what was audited is what runs *today*, so this repo's pins are not evidence, and take the verdict from the rest |
+| `BRANCH_POINT=rewritten` — the base branch was rewritten under this PR | **Not a Hold on this bump.** A fact about the branch, not the dependency. Report it with both substitutions Phase 0 named, and say that the scope diff and Phase 4's tree came from the substituted sources |
+| `BRANCH_POINT=suspect` — non-bot commits above the base, no force-push event | **Not a Hold.** Corroboration without the authority: read the commits, report what they changed, and say the base was *not* substituted on it alone |
+| `BRANCH_POINT=underivable` — the event list could not be read | **Not a Hold**, and not `ok` either. Report that the merge base was never proved to be the branch point, which caps confidence at **medium** — or **low** where the scope diff is what the verdict turns on |
 | Phase 4: base differs, PR agrees — real and already absorbed | **Merge as-is**, naming what the PR absorbed and how |
 | `mergeStateStatus: BLOCKED` with every check green | **Merge as-is** on the bump's merits; name what blocks it, usually `reviewDecision` |
 | Actions: the workflow file is generated (`DO NOT EDIT`) | **Merge as-is, then follow up** on the generator — this bump is transient without it |

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -124,6 +124,7 @@ defines:
 #   BASE_SHA=<40 hex>      the merge base, from GitHub's compare endpoint
 #   OWNER=<owner>          for Phase 6's GraphQL variables
 #   NAME=<name>
+#   CREATED_AT=<iso8601>   when the PR was opened — Phase 2's cooldown test
 #   BRANCH_POINT=<ok|rewritten|suspect|underivable>
 #   MAY_EXECUTE=<yes|no>   whether Phases 4 and 5 are authorised
 #   BOT_COMMITS=<shas>     the bot's own commits above the base — Phase 1's gate
@@ -228,6 +229,7 @@ If either check fails, `git worktree remove` it and re-add.
 | `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below. Same exception |
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
+| `$CREATED_AT` | when the PR was opened, ISO-8601. **Phase 2 compares release publish times against it** — the cooldown asks whether a release was three days old *then*, not now |
 | `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **Phase 1 reads it**, and the table below says what each one means |
 | `$MAY_EXECUTE` | `yes` or `no` — **Phases 4 and 5 gate on it**, and the gate tests for `yes` so an unset value refuses. The classification below is what sets it |
 | `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
@@ -580,7 +582,7 @@ Phase 6's CI state established, and name plainly what was not checked.
 
 ## Phase 2 — Currency
 
-*Requires: the Phase 1 script output, and the PR's `createdAt` from Phase 0.*
+*Requires from Phase 0: `$CREATED_AT`. Plus the Phase 1 script output.*
 
 **A bot's proposal is not evidence of "current".** Ask the registry what the
 latest version actually is, and compare publish timestamps against the PR's
@@ -609,6 +611,24 @@ phase reads for next: a `Security` entry or a destructive-fix bug in the gap. Th
 cooldown exempts Dependabot's *security updates* — the advisory-driven kind — and
 not a version update whose changelog happens to carry a privately disclosed fix,
 which is exactly the case below.
+
+**The cooldown boundary is a subtraction, so do it rather than eyeball it.** The
+window is measured from when the **PR opened**, not from now, so the same gap
+moves in and out of it as the audit ages — which is the failure Phase 7's table
+calls out in itself:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+python3 -c 'import datetime,sys; t=datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00")); print("cooldown boundary:", (t-datetime.timedelta(days=3)).isoformat())' "$CREATED_AT"
+```
+
+A gap release published **after** that boundary was inside the window when the
+bot decided; one published before it was not, and the bot is behind rather than
+waiting. `python3` rather than `date -d`, which is GNU-only — every script here
+already requires 3.11.
 
 **A bot's ignore state is not always in a config file.** `@dependabot ignore this
 major version` records the hold in the *PR*, not the repo, so a dependency can be

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -226,6 +226,10 @@ releaser; `action.yml` is what the runner loads, it ships in the action's own
 repo, and it is therefore readable at both pins:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 for R in <old-sha> <new-sha>; do
   gh api "repos/<owner>/<action>/contents/action.yml?ref=$R" --jq .content \
     | base64 -d > "$SCRATCH/action-$R.yml"

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -81,6 +81,13 @@ remaining evidence, and the separate fact that the PR cannot merge until someone
 fixes a failure it did not cause. Reporting only the first reads as "merge this"
 on a PR that will not merge; reporting only the second blames the bump.
 
+**Every "not a Hold" row in Phase 7's table is a row here too.** A mutable pin, a
+rewritten base, an unattributable red check — each is a real finding that does
+not carry the verdict, and each has to appear as its own line rather than being
+absorbed into the recommendation. The verdict says what to do; these say what the
+reader is being asked to accept while doing it. A report that reaches *merge
+as-is* and mentions none of them is indistinguishable from one where none applied.
+
 ## Reasoning
 
 Why the verdict follows from the evidence. This is where a finding that no

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -161,6 +161,8 @@ between finding the change and missing it, and the wrong choice fails silently:
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
 G="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/gate_diff.py"
 
 python3 "$G" --tree "$SCRATCH/base-<N>" \
@@ -225,6 +227,12 @@ Install **frozen** — that proves the lockfile is self-consistent and resolves
 nothing. For Python this is two commands, and they prove different things:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
+cd "$SCRATCH/pr-<N>"
 uv sync --locked --no-build --no-install-project   # every dep resolved to a wheel
 uv sync --locked                                   # then add the project itself
 ```

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -27,6 +27,10 @@ Both lockfiles come out of git at the ref Phase 0 pinned, never off the working
 tree:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 S="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py"
 
 git show "pr-<N>:uv.lock"    > "$SCRATCH/pr.uv.lock"
@@ -153,6 +157,10 @@ environment is the reliable path.
 between finding the change and missing it, and the wrong choice fails silently:
 
 ```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
 G="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/gate_diff.py"
 
 python3 "$G" --tree "$SCRATCH/base-<N>" \

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -895,12 +895,16 @@ def render(report: dict[str, Any]) -> None:
         )
 
     for cur in report["currency"]:
+        # How old the pin is, alongside how old the gap is. Phase 2 compares
+        # release times against the PR's `$CREATED_AT`, and a report that names
+        # only when the *newer* release landed gives the reader one end of that.
+        since = f" (published {cur['locked_published']})" if cur["locked_published"] else ""
         if cur["current"]:
-            print(f"=== {cur['name']}: locked {cur['locked']} IS the latest\n")
+            print(f"=== {cur['name']}: locked {cur['locked']}{since} IS the latest\n")
             continue
         if cur["held_back"]:
             print(
-                f"=== {cur['name']}: locked {cur['locked']}, registry latest "
+                f"=== {cur['name']}: locked {cur['locked']}{since}, registry latest "
                 f"{cur['latest']} — HELD BACK by resolution-markers"
             )
             print(
@@ -910,7 +914,7 @@ def render(report: dict[str, Any]) -> None:
             print("      trail the registry, so not a staleness finding\n")
             continue
         print(
-            f"=== {cur['name']}: locked {cur['locked']}, "
+            f"=== {cur['name']}: locked {cur['locked']}{since}, "
             f"registry latest {cur['latest']}  <-- NOT CURRENT"
         )
         if cur["constrained"]:
@@ -924,7 +928,7 @@ def render(report: dict[str, Any]) -> None:
         for rel in cur["gap"]:
             mark = " (yanked)" if rel["yanked"] else ""
             print(f"      {rel['version']:12s} published {rel['published']}{mark}")
-        print("      earliest first; compare it against the PR's createdAt\n")
+        print("      earliest first; compare these against $CREATED_AT, the PR's own\n")
 
     # A forked package is checked in full and installed in part, and nothing in
     # the output said so. Phase 1 verifies every fork's artifacts against the

--- a/skills/dependabot-audit/scripts/ci_state.py
+++ b/skills/dependabot-audit/scripts/ci_state.py
@@ -498,20 +498,35 @@ def main() -> int:
 
     report = rollup(args.owner, args.name, args.number)
     report["expected_head"] = args.head_sha
-
-    parent = conclusions_at(args.owner, args.name, args.parent) if args.parent else {}
-    base = conclusions_at(args.owner, args.name, args.base_sha) if args.base_sha else {}
-    report["parent_names"] = sorted(parent) or sorted(base)
-
+    # Before the reads below, because every one of them is gated on what it
+    # decides. The rollup already carries everything `analyse` needs.
     analyse(report)
-    # Only worth two calls when there is a red row for them to qualify.
-    spans = {}
+
+    # Attribution is the only consumer of any of this, and it runs once per red
+    # context — so with nothing red there is no row for an answer to qualify and
+    # no call worth making. Measured before this guard existed: five calls on an
+    # all-green PR, one of them read. The same reasoning already applied to
+    # `committed_at` below; it had never been applied to the pair above it, which
+    # is four calls rather than two and paginates.
+    parent: dict[str, str] = {}
+    base: dict[str, str] = {}
+    spans: dict[str, str] = {}
+    report["parent_names"] = []
     if report["red"]:
+        if args.parent:
+            parent = conclusions_at(args.owner, args.name, args.parent)
+        # The merge base answers a *different*, weaker question — red before this
+        # branch rather than before this commit — and `attribute` reaches for it
+        # only when the parent has no runs at all. Fetching it while the parent
+        # can answer buys nothing.
+        if not parent and args.base_sha:
+            base = conclusions_at(args.owner, args.name, args.base_sha)
+        report["parent_names"] = sorted(parent) or sorted(base)
         head_at = report["head_committed"]
-        spans = {
-            "parent": interval(head_at, committed_at(args.owner, args.name, args.parent)),
-            "base": interval(head_at, committed_at(args.owner, args.name, args.base_sha)),
-        }
+        if parent:
+            spans["parent"] = interval(head_at, committed_at(args.owner, args.name, args.parent))
+        if base:
+            spans["base"] = interval(head_at, committed_at(args.owner, args.name, args.base_sha))
     for ctx in report["red"]:
         ctx["attribution"] = attribute(ctx, parent, base, args.parent, args.base_sha, spans)
 

--- a/skills/dependabot-audit/scripts/discover.py
+++ b/skills/dependabot-audit/scripts/discover.py
@@ -431,6 +431,12 @@ def shell(report: dict[str, Any]) -> None:
         ("BASE_SHA", report["base_sha"]),
         ("OWNER", report["owner"]),
         ("NAME", report["name"]),
+        # Phase 2's other half. The cooldown question is whether the release was
+        # less than three days old *when the bot opened the PR*, so it needs the
+        # PR's own timestamp and not only the release's. It was rendered in the
+        # report and never emitted, which made it an input that crossed by being
+        # on screen.
+        ("CREATED_AT", report["created_at"]),
     ]
     print("# Phase 0 outputs. Sourced, not transcribed.")
     for key, value in pairs:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -874,6 +874,27 @@ class TestMainContract(_MainHarness):
         self.assertEqual(code, 2)
         self.assertNotIn("CLEAN", out)
 
+    def test_the_locked_versions_publish_date_reaches_the_report(self):
+        """Phase 2 compares two timestamps and the output carried only one.
+
+        The gap rows name when each newer release landed. How old the *pin* is
+        was computed — `locked_published` — and rendered nowhere, so the report
+        could say "the newer release landed on X" and never "and you have been
+        on a release from Y". Both halves are the comparison Phase 2 asks for.
+        """
+        _, out, _ = self._run(
+            [write_lock(self, self.LOCK), "--changed", "rumdl"],
+            meta=pypi_meta(
+                "0.2.53",
+                [pypi_file("rumdl-0.2.53-py3-none-any.whl", uploaded="2026-01-04T00:00:00Z")],
+            ),
+        )
+        self.assertIn(
+            "2026-01-04",
+            out,
+            f"the locked version's own publish date is computed and never printed:\n{out}",
+        )
+
     def test_verdict_line_carries_the_counts(self):
         code, out, _ = self._run(
             [write_lock(self, self.LOCK), "--changed", "rumdl"], meta=self._meta()

--- a/tests/test_ci_state.py
+++ b/tests/test_ci_state.py
@@ -612,5 +612,67 @@ class TestFailureIsNotAFinding(CiStateHarness):
         self.assertIn("not readable", err)
 
 
+class TestNoCallIsMadeForAnAnswerNothingReads(CiStateHarness):
+    """Four of five API calls on a green PR were fetched and never read.
+
+    Measured with an instrumented `gh` on `PATH` against an all-green rollup:
+    five calls out of the script, one of them consulted. The other four were
+    `conclusions_at()` at the parent and at the base — `check-runs` (paginated)
+    plus `status`, twice — issued before `analyse()` had computed
+    `report["red"]`.
+
+    Every consumer of those two dicts is gated on red: `attribute()` runs only
+    in `for ctx in report["red"]`, and `parent_names` renders only under
+    `if report["red"] and report["parent_names"]`. With nothing red, nothing
+    reads either.
+
+    `base` is redundant a second way, independent of the first: `attribute()`
+    reads it only in the `if not parent` branch, so a red PR whose parent has
+    runs never consults it either.
+
+    The script already applied this guard one rung lower — "Only worth two calls
+    when there is a red row for them to qualify", on `committed_at`, which is one
+    unpaginated call each. The more expensive pair was never covered.
+
+    Phase 7 requires CI rows to be re-derived on every report, *because* they are
+    cheap. That is the argument this count has to keep true.
+    """
+
+    GREEN: ClassVar = [check_run("test", "SUCCESS", required=True)]
+    RED: ClassVar = [check_run("test", "FAILURE", required=True)]
+
+    def _calls_for(self, nodes, **kw):
+        fake, calls = self._fake_gh([page(nodes)], **kw)
+        self._run(fake, ["--parent", PARENT, "--base-sha", BASE])
+        return calls
+
+    def test_a_green_pr_asks_github_once(self):
+        calls = self._calls_for(self.GREEN)
+        extra = [c for c in calls if "graphql" not in c]
+        self.assertEqual(
+            extra,
+            [],
+            f"nothing is red, so no attribution row exists to qualify; these "
+            f"{len(extra)} call(s) are fetched and never read: {extra}",
+        )
+
+    def test_a_red_pr_with_a_live_parent_never_reaches_for_the_base(self):
+        calls = self._calls_for(self.RED, runs={PARENT: [("test", "SUCCESS")]})
+        self.assertFalse(
+            [c for c in calls if BASE in c],
+            "the parent answered, and attribute() reads the base only when the "
+            "parent has no runs at all — the fallback was fetched unconditionally",
+        )
+
+    def test_a_red_pr_with_no_runs_at_the_parent_still_falls_back(self):
+        """The saving must not cost the fallback the comparison depends on."""
+        calls = self._calls_for(self.RED, runs={BASE: [("test", "FAILURE")]})
+        self.assertTrue(
+            [c for c in calls if BASE in c],
+            "with no runs at pr-<N>^ the merge base is the only comparison point "
+            "left; skipping it would mark a real pre-existing failure underivable",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1809,7 +1809,13 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
     Phase 0 actually produces — from the script's emitter or from its own shell.
     """
 
-    REQUIRES = re.compile(r"Requires from Phase 0:(.*)", re.IGNORECASE)
+    # `Requires:` as well as `Requires from Phase 0:`. Phase 2 used the shorter
+    # form and named its input in prose — `the PR's ``createdAt`` from Phase 0` —
+    # so it slipped this guard on punctuation, twice over: the phrase did not
+    # match, and the name was neither `$`-prefixed nor upper-case.
+    REQUIRES = re.compile(r"\*Requires(?: from Phase 0)?:(.*)", re.IGNORECASE)
+    # A bare backticked identifier in a requires-line: the shape `createdAt` had.
+    BARE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)`")
 
     def _produced(self) -> set[str]:
         """What a later phase can actually receive: the emitter, plus Phase 0's shell.
@@ -1818,7 +1824,18 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
         directly and never passes through `discover.py`, so a guard reading only
         the emitter would call the most-used output of all a broken promise.
         """
-        return _emitted_by_discover() | set(ASSIGNED.findall(self.shell[0]))
+        # Comment lines stripped, and that is load-bearing rather than tidy.
+        # Phase 0 documents the whole handoff in a bash fence of `#   NAME=<...>`
+        # lines, so an un-stripped scan lets a requires-line be satisfied by the
+        # very key list it is meant to be checked against. Caught by mutation:
+        # deleting `CREATED_AT` from the emitter left every guard green, because
+        # the comment describing it was still there. Same failure `_code_only`
+        # exists for one file over — a rule must not be satisfiable by a comment
+        # claiming it.
+        executable = "\n".join(
+            line for line in self.shell[0].splitlines() if not line.lstrip().startswith("#")
+        )
+        return _emitted_by_discover() | set(ASSIGNED.findall(executable))
 
     def test_every_requires_line_names_something_phase_0_produces(self):
         produced = self._produced()
@@ -1838,6 +1855,26 @@ class TestPhase0PromisesOnlyWhatItProduces(SkillHarness):
                         f"sourcing the handoff and reading it gets the empty string",
                     )
         self.assertGreater(seen, 0, "no phase states what it requires from Phase 0")
+
+    def test_no_requires_line_names_an_input_in_prose_instead_of_as_a_variable(self):
+        """The convention is the shell name, because that is what has to exist.
+
+        Phase 2's line read *"the PR's `createdAt` from Phase 0"*. `discover.py`
+        renders `createdAt` in its human-readable report and the emitter never
+        wrote it, so the input crossed by being on screen. Naming the variable is
+        what puts a requires-line under the guard above at all.
+        """
+        for number, body in self.phases:
+            for line in body.splitlines():
+                found = self.REQUIRES.search(line)
+                if not found:
+                    continue
+                for name in self.BARE.findall(found.group(1)):
+                    self.fail(
+                        f"Phase {number} requires `{name}`, named as prose rather than "
+                        f"as the variable the handoff carries. A name without a `$` is "
+                        f"one no guard can check and no block can source"
+                    )
 
     def test_the_outputs_table_lists_only_real_outputs(self):
         """The table says later phases consume these *and nothing else*."""

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1946,5 +1946,138 @@ class TestPhase4ReadsTheActionsInterfaceNotOnlyItsNotes(SkillHarness):
         )
 
 
+def _every_block() -> list[tuple[str, int, str]]:
+    """(file, phase, code) for every bash block in the skill and its references.
+
+    `SkillHarness.shell` concatenates a phase's blocks into one string, which is
+    right for the ordering guards and wrong here: the question below is asked of
+    each block *as a unit*, because a block is what a reader runs in one call.
+    Two blocks joined would let Phase 0's own reload satisfy a later phase's.
+    """
+    found: list[tuple[str, int, str]] = []
+    for path in (SKILL, PLUGIN / "references/uv-lock.md", PLUGIN / "references/actions.md"):
+        for number, body in phases(path.read_text(encoding="utf-8")):
+            found.extend((path.name, number, code) for code in bash_blocks(body))
+    return found
+
+
+class TestEveryConsumerReloadsTheHandoff(SkillHarness):
+    """Phase 0's handoff was written once, sourced once, and read by seven blocks.
+
+    `SKILL.md` states the measurement that makes this fatal, in its own Phase 0:
+
+        Measured against this harness, two separate calls: an `export` in the
+        first is **unset** in the second, shell functions likewise, and each call
+        is a new shell process.
+
+    Re-measured 2026-08-21 across two Bash calls in one session: `PROBE_VAR` set
+    and exported in the first reads `<UNSET>` in the second, a function defined
+    in the first is `not found`, and the pids differ.
+
+    0.26.0 fixed `$SCRATCH`'s *derivation* so the next call could name the
+    directory. The consequence — that the next call must then actually re-derive
+    it and re-source the file — never reached the phases that consume it, so
+    `. "$SCRATCH/phase0.env"` appeared exactly once in the plugin, inside the
+    phase that writes it.
+
+    Measured cost, running each consuming block in a fresh shell with nothing
+    sourced: Phases 1 (uv.lock), 4, 6 and 7 fail loudly — `Permission denied`,
+    two exit 2s, and exit 128 — while Phase 1's authorship gate **passes
+    silently**, because `for c in $BOT_COMMITS` over an unset variable iterates
+    zero times and the gate's file list is empty. `SKILL.md` names that outcome
+    "the one outcome worse than a false Hold".
+    """
+
+    def _handoff_names(self) -> set[str]:
+        """What the handoff carries: the emitter's names, plus `SCRATCH` itself.
+
+        `SCRATCH` never passes through `discover.py` — Phase 0's shell assigns it
+        — but it is lost across a call boundary exactly like the rest, and it is
+        the one every other value is reached *through*.
+        """
+        return _emitted_by_discover() | {"SCRATCH"}
+
+    def test_every_block_reading_a_handoff_value_reloads_it(self):
+        names = self._handoff_names()
+        for file, number, code in _every_block():
+            # Only the block that *writes* the handoff is exempt, not the whole
+            # phase. Phase 0's later blocks run in their own calls like any
+            # other, and the exemption being phase-wide left the sharpest case
+            # of all still open: `git show "$BASE_SHA:.github/workflows/ci.yml"`
+            # with $BASE_SHA empty exits **0** and serves 17,623 bytes from the
+            # index — the user's working tree — which is the exact failure
+            # Phase 0's "read every one of them at a ref" rule exists to prevent.
+            if "--shell >" in code:
+                continue
+            used = sorted(n for n in USED.findall(code) if n in names)
+            if not used:
+                continue
+            self.assertIn(
+                "phase0.env",
+                code,
+                f"{file} Phase {number} reads {used} in a block that never sources "
+                f"the handoff. Shell state does not cross a Bash call, so every one "
+                f"of those is the empty string when the block runs on its own",
+            )
+
+    def test_the_scratch_derivation_is_stated_identically_wherever_it_appears(self):
+        """Seven copies of a formula is seven places for it to drift.
+
+        The failure this guards is not hypothetical in shape: 0.26.0 changed the
+        derivation once already, and a copy left on the old `mktemp` form would
+        point a later phase at a directory the handoff is not in — which is the
+        same silent-empty outcome, reached through a different door.
+        """
+        # The assignment alone, not the line it sits on: Phase 0 appends
+        # `mkdir -p` to its copy and a later block has nothing to create.
+        forms = {
+            found for _, _, code in _every_block() for found in re.findall(r'SCRATCH="[^"]*"', code)
+        }
+        self.assertEqual(
+            len(forms),
+            1,
+            f"the $SCRATCH derivation appears in {len(forms)} different forms; every "
+            f"call has to resolve it to the same directory, so they must be one "
+            f"string: {sorted(forms)}",
+        )
+
+    def test_a_declared_unset_fallback_is_implemented_where_the_block_gates(self):
+        """The measured silent failure, stated as the document's own broken promise.
+
+        `for c in $BOT_COMMITS` over an unset variable iterates zero times and the
+        gate passes with an empty file list. `SKILL.md` already knows this and
+        says what to do instead — *"Where `$BOT_COMMITS` is unset, gate on the
+        whole `$BASE_SHA..pr-<N>` diff"* — but the fallback lived only in prose,
+        so the runnable block did the silent thing.
+
+        Keyed on the prose declaring a fallback rather than on a name: that is
+        what separates `$BOT_COMMITS`, which gates, from `$HUMAN_COMMITS`, which
+        is reported and where iterating zero times is the truthful answer. Any
+        future output whose absence the prose promises to handle is covered.
+        """
+        loop = re.compile(r"for\s+\w+\s+in\s+\$\{?([A-Z_][A-Z0-9_]*)\}?")
+        names = self._handoff_names()
+        bodies = dict(self.phases)
+        seen = 0
+        for file, number, code in _every_block():
+            if file != SKILL.name:
+                continue
+            for name in loop.findall(code):
+                if name not in names:
+                    continue
+                # Does this phase promise to handle the value being unset?
+                if not re.search(rf"\${name}[^\n]*is unset", bodies.get(number, "")):
+                    continue
+                seen += 1
+                self.assertRegex(
+                    code,
+                    re.compile(rf"\$\{{{name}[+:-]|-z\s+\"?\${name}|-n\s+\"?\${name}"),
+                    f"{file} Phase {number} promises a fallback for an unset ${name} "
+                    f"and then iterates it anyway; unset it iterates zero times and "
+                    f"the gate passes silently, which is worse than a false Hold",
+                )
+        self.assertGreater(seen, 0, "no phase declares an unset-fallback for a value it gates on")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2079,5 +2079,111 @@ class TestEveryConsumerReloadsTheHandoff(SkillHarness):
         self.assertGreater(seen, 0, "no phase declares an unset-fallback for a value it gates on")
 
 
+class TestEveryEmittedOutputIsConsumedOrDeclaredInert(SkillHarness):
+    """0.26.1 closed this class in one direction only.
+
+    Its two guards run table-and-requires-line -> emitter: every name a phase
+    *promises* must be one Phase 0 produces. Nothing ran the other way, and the
+    drift was already bidirectional when it shipped — the changelog says so:
+
+        the table promised `$PERMS` and `$SCRATCH` while the emitter writes ten
+        names including `BASE_REF`, `BRANCH_POINT` and `MAY_EXECUTE`.
+
+    `BASE_REF` was settled there deliberately — "Phase 0's own cross-check that
+    no later phase consumes" — and that is a fine answer. `MAY_EXECUTE` was not
+    in the same position. Phase 0's prose calls it *"the one bit later phases
+    actually branch on"*, offered as the value that crosses in `$PERMS`'s place,
+    and no phase branched on it: every occurrence in the plugin was the emit, the
+    key-list comment, and two sentences explaining why it exists.
+
+    So the completeness rule now runs both ways, with the exemption written down
+    rather than inferred: an emitted name is consumed, or it is named as a
+    diagnostic. That is what separates the two cases, and it is a decision
+    someone has to make rather than an omission nobody notices.
+    """
+
+    DIAGNOSTIC = re.compile(r"Diagnostics? —[^\n]*", re.IGNORECASE)
+
+    def _declared_inert(self) -> set[str]:
+        line = self.DIAGNOSTIC.search(dict(self.phases)[0])
+        return set(re.findall(r"`\$?([A-Z_][A-Z0-9_]*)`", line.group(0))) if line else set()
+
+    def test_every_emitted_name_is_read_somewhere_or_declared_inert(self):
+        inert = self._declared_inert()
+        read = {n for _, _, code in _every_block() for n in USED.findall(code)}
+        for name in sorted(_emitted_by_discover()):
+            if name in inert:
+                continue
+            self.assertIn(
+                name,
+                read,
+                f"discover.py --shell emits {name} and no block reads it. Either a "
+                f"phase should branch on it or Phase 0 should name it a diagnostic, "
+                f"the way BASE_REF is — an emitted value nobody reads and nobody "
+                f"exempted is a promise that quietly went false",
+            )
+
+    def test_the_diagnostics_line_names_only_things_that_are_emitted(self):
+        """The exemption must not drift into covering a name that no longer exists."""
+        emitted = _emitted_by_discover()
+        for name in sorted(self._declared_inert()):
+            self.assertIn(
+                name,
+                emitted,
+                f"Phase 0 exempts {name} as a diagnostic, but the emitter does not "
+                f"write it; a stale exemption silently widens to whatever is added next",
+            )
+
+
+class TestTheExecutionGateIsReadWhereExecutionHappens(SkillHarness):
+    """Phase 0 decided whether the PR may run, and the phases that run it never asked.
+
+    `discover.py` derives the classification — a fork PR, a non-bot author, or an
+    account without `push` — and reduces it to `MAY_EXECUTE`. The gate then lived
+    only in Phase 0's own prose table, which tells the reader to *run
+    `--no-execute`*, six phases before the phases that execute.
+
+    Measured on this plugin's handoff: `MAY_EXECUTE=yes` crosses on every audit
+    and nothing has ever read it.
+    """
+
+    def _executing(self) -> list[int]:
+        return [n for n, body in self.phases if n > 0 and "Executes code from the PR" in body]
+
+    def test_the_phases_that_execute_say_so_and_gate_on_it(self):
+        found = self._executing()
+        self.assertTrue(found, "no phase declares that it executes the PR's code")
+        for number in found:
+            self.assertIn(
+                "MAY_EXECUTE",
+                self.reachable(number),
+                f"Phase {number} declares that it executes code from the PR and never "
+                f"reads the bit Phase 0 derived to authorise it",
+            )
+
+    def test_the_gate_fails_closed_on_an_empty_value(self):
+        """An unset handoff yields the empty string, not `no`.
+
+        From the measurement rather than the fix: a block whose handoff never
+        loaded sees `MAY_EXECUTE` unset, and `!= no` is true of the empty string.
+        The test has to be *for* the authorising value, so anything that is not
+        `yes` — including nothing at all — refuses.
+        """
+        seen = 0
+        for file, number, code in _every_block():
+            # Uses it, rather than merely naming it: Phase 0's key-list block
+            # documents `MAY_EXECUTE=<yes|no>` and tests nothing.
+            if not re.search(r"\$\{?MAY_EXECUTE", code):
+                continue
+            seen += 1
+            self.assertRegex(
+                code,
+                re.compile(r"MAY_EXECUTE[^\n]*=\s*[\"']?yes"),
+                f"{file} Phase {number} tests MAY_EXECUTE without testing for `yes`; "
+                f"an unset handoff is the empty string, and a negative test passes it",
+            )
+        self.assertGreater(seen, 0, "no block gates on MAY_EXECUTE")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2222,5 +2222,152 @@ class TestTheExecutionGateIsReadWhereExecutionHappens(SkillHarness):
         self.assertGreater(seen, 0, "no block gates on MAY_EXECUTE")
 
 
+def _label_values(script: str, function: str, key: str) -> set[str]:
+    """Every value one function can put in `key` — its label vocabulary.
+
+    Read from the script's source rather than typed, for the reason the
+    required-context guard is: a typed list is a second copy, and it drifts
+    silently because the guard keeps passing against its own stale copy.
+
+    Narrow on purpose. A first version collected every lower-case string
+    constant in the function and came back with `compared`, `basis`, `login`
+    and `sha` — dict keys and API field names — which would have demanded rows
+    in Phase 7 for things that are not labels at all. Only two shapes carry a
+    label: a `"key": value` entry, and an assignment to a variable of that name.
+    Module-level constants (`UNDERIVABLE = "underivable"`) are resolved.
+    """
+    src = (PLUGIN / "scripts" / script).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    consts = {
+        t.id: n.value.value
+        for n in tree.body
+        if isinstance(n, ast.Assign) and isinstance(n.value, ast.Constant)
+        for t in n.targets
+        if isinstance(t, ast.Name) and isinstance(n.value.value, str)
+    }
+
+    def literal(node: ast.AST) -> set[str]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return {node.value}
+        if isinstance(node, ast.Name) and node.id in consts:
+            return {consts[node.id]}
+        if isinstance(node, ast.IfExp):
+            return literal(node.body) | literal(node.orelse)
+        return set()
+
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.FunctionDef) and node.name == function):
+            continue
+        found: set[str] = set()
+        for inner in ast.walk(node):
+            if isinstance(inner, ast.Dict):
+                for k, v in zip(inner.keys, inner.values, strict=True):
+                    if isinstance(k, ast.Constant) and k.value == key:
+                        found |= literal(v)
+            elif isinstance(inner, ast.Assign):
+                names = [t.id for t in inner.targets if isinstance(t, ast.Name)]
+                if key in names:
+                    found |= literal(inner.value)
+                for tgt in inner.targets:
+                    if isinstance(tgt, ast.Tuple) and isinstance(inner.value, ast.Tuple):
+                        for t, v in zip(tgt.elts, inner.value.elts, strict=False):
+                            if isinstance(t, ast.Name) and t.id == key:
+                                found |= literal(v)
+        if not found:
+            raise AssertionError(f"{script}:{function} sets no `{key}` this guard can read")
+        return found
+    raise AssertionError(f"{script} has no function {function}")
+
+
+class TestEveryDerivedLabelLandsInTheVerdictTable(SkillHarness):
+    """Phase 7's table is the reason two audits on the same evidence agree.
+
+        Every row above is a finding; the verdict is a function of them, and
+        leaving that function implicit is how two audits with the same evidence
+        reach different recommendations.
+
+    A label the mechanised phases can print and the table does not name falls
+    through to the last row — *"Everything derived, nothing above matched →
+    Merge as-is"* — and arrives there by exhaustion, which reads in the report
+    exactly like arriving there because nothing was wrong.
+
+    Three were in that state. `attributable` and `pre-existing` had rows;
+    **`underivable` did not**, so a red *required* check whose cause could not be
+    established fell through to `Merge as-is` on a PR that cannot merge. And
+    `discover.py` reports `rewritten` and `suspect` as findings, with no row for
+    either.
+
+    The table already handles the fourth case of this shape explicitly —
+    `$HUMAN_COMMITS` is "a **finding to report**, never a Hold" — which is the
+    pattern: where a finding must not carry the verdict, the procedure says so
+    rather than trusting the reader to reach the fall-through and read it right.
+    """
+
+    def _phase7(self) -> str:
+        return dict(self.phases)[7].lower()
+
+    def _verdict_rows(self) -> list[str]:
+        """Rows of the table headed `| Evidence | Verdict |`, lower-cased.
+
+        The whole phase is the wrong haystack, and mutation said so: deleting the
+        `underivable` attribution row left the guard green, because the word also
+        appears in the confidence table and in the `BRANCH_POINT` row two lines
+        down. A label has to be found in a row that is *about* it.
+        """
+        for rows in tables(dict(self.phases)[7]):
+            if rows and "verdict" in rows[0].lower() and "evidence" in rows[0].lower():
+                return [r.lower() for r in rows[2:]]
+        raise AssertionError("Phase 7 has no `| Evidence | Verdict |` table")
+
+    def _assert_row(self, label: str, about: str, why: str) -> None:
+        """A row naming both the label and what it is a label *of*."""
+        self.assertTrue(
+            any(label.lower() in r and about.lower() in r for r in self._verdict_rows()), why
+        )
+
+    def test_every_attribution_label_has_a_verdict_row(self):
+        labels = _label_values("ci_state.py", "attribute", "label")
+        self.assertIn("underivable", labels, "the three-state label set moved")
+        for label in sorted(labels):
+            self._assert_row(
+                label,
+                "check",
+                f"ci_state.py can label a red context `{label}` and no verdict row "
+                f"names that label against a check, so a red required check carrying "
+                f"it falls through to Merge as-is",
+            )
+
+    def test_every_branch_point_finding_has_a_verdict_row(self):
+        """`ok` is the no-finding case; the rest are what `analyse()` reports."""
+        verdicts = _label_values("discover.py", "branch_point", "verdict") - {"ok"}
+        self.assertEqual(
+            verdicts,
+            {"rewritten", "suspect", "underivable"},
+            "branch_point's verdict vocabulary moved; the table has to move with it",
+        )
+        for verdict in sorted(verdicts):
+            self._assert_row(
+                verdict,
+                "branch_point",
+                f"discover.py reports `{verdict}` as a finding and no verdict row "
+                f"names it against BRANCH_POINT; the reader reaches the fall-through",
+            )
+
+    def test_a_pin_that_is_not_a_sha_has_a_verdict_row(self):
+        """The instance, and it is the one that costs most to leave out.
+
+        `references/actions.md`: a tag or branch pin is "a **promise someone else
+        can revoke**", and "a repo whose pins are not evidence". Without a row,
+        *we verified the pin* and *this repo's pins are not evidence* produce the
+        same verdict and the report has nothing that separates them.
+        """
+        self.assertRegex(
+            self._phase7(),
+            re.compile(r"not a 40-hex sha|not sha-pinned|tag or branch"),
+            "actions.md makes a mutable pin a finding and the verdict table has no "
+            "row for it, so it lands on Merge as-is by exhaustion",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #61, #62, #63, #64, #65. Five commits, one release.

A sweep of the plugin asking two questions: for every value a phase **produces**,
who consumes it; for every value a phase **consumes**, who reliably produces it.
Review commit by commit — each is one defect with its own measurement.

| Commit | Defect |
|---|---|
| `4c3492b` | Phase 0's handoff was sourced once, in Phase 0. Eleven blocks read what it carries; **two failed silently** — the authorship gate passing on an empty list, and `git show ":path"` serving the gate list **from the index**, i.e. the user's working tree |
| `edfda52` | `ci_state.py` made five API calls on a green PR and read one. On a one-commit bot PR — the ordinary case — it fetched **the same two endpoints twice** and consulted neither |
| `2fb9b64` | `MAY_EXECUTE` was emitted, called *"the one bit later phases actually branch on"*, and no phase branched on it. `BRANCH_POINT` was the same defect, found by the guard written for it |
| `6c42086` | Phase 2 required `createdAt` and the handoff never carried it. Plus a hole in 0.26.1's own guard: **deleting the emit left every test green**, because a requires-line could be satisfied by the comment block documenting it |
| `a970672` | Five findings had no verdict row and fell through to *Merge as-is* by exhaustion — including a red **required** check whose cause could not be established, on a PR that cannot merge |

## Verification

- Every consuming block **replayed across a real two-call boundary** against
  `fpga-board-sim` #363 and `dependabot-audit` #60. On #60 the shipped gate reported
  **0 files** on a 4-file diff that reaches into the plugin's own `references/`.
- `MAY_EXECUTE` derived live against four PRs; `BRANCH_POINT` against a constructed
  rewritten base (7 files vs 1 — a false Hold on a one-file bump).
- `ci_state.py` **5 → 1** calls on a green PR, **7 → 4** on `mdcat` #6, verdicts
  unchanged on both.
- 263 tests, ruff, mypy, and the network integration suite (6 tests) green.

Three guards were themselves wrong first and corrected by mutation — a `sed` that
never landed, an extractor that returned dict keys, and an assertion satisfied by a
different line than the one it was about. Each is recorded in the commit that fixed it.