### PR TITLE
The procedure never read an exit status, in three places (0.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,91 @@ both driven by mutation rather than by review:
 Seven mutations, each verified to have landed before its result was read. All
 seven caught.
 
+### The procedure never read an exit status, in three places
+
+A pipeline's exit status is its **last** stage, and `sort`, `sed` and `base64`
+all succeed on empty input. So a failing `git` or `gh` produced empty output at
+exit 0 — and in each case the empty result is the *reassuring* answer:
+
+| Block | Measured | Reads as |
+|---|---|---|
+| Phase 1's scope gate | exit 0, empty file list | **clean scope** — nothing outside the manifest |
+| Phase 6's trigger read | exit 0, empty output | **no `pull_request` trigger** → "CI is green for unrelated reasons" |
+| `actions.md` Phase 4's interface fetch | two empty files, `diff` exit 0 | **no interface change** |
+
+The third is the sharpest, because `actions.md` says of exactly this method:
+*"'Inert here' is a result, not silence. Reaching it deliberately is this phase
+working; reaching it by not looking is the failure."* The block could reach it by
+not looking.
+
+None of this is exotic to trigger: an unfetched ref is enough. Hit by accident on
+a scratch clone where `pr-363` had been deleted — `fatal: ambiguous argument`,
+then exit 0 and a clean gate.
+
+**And the plugin already states the rule, two phases away.** `SKILL.md` § Phase 5
+and `references/uv-lock.md` § Phase 5: *"Gate on exit codes. `cmd | tail && next`
+gates on `tail`, so a failing suite sails through."* Phase 1's gate is the
+highest-stakes command in the procedure — what stops the audit before Phases 4
+and 5 execute the PR's code — and it was among the places the rule was not
+followed.
+
+**Fixed** by capture-and-check in all three, plus `PARENT` in Phase 6, whose
+empty value silently weakened the attribution comparison. Exit 2 is this plugin's
+*could not run*, and it is the honest answer: no evidence is not evidence of
+nothing.
+
+**Not fixed with `set -o pipefail`, and the measurement says why.** It catches
+one of the three:
+
+| Instance | none | `pipefail` | `-eo pipefail` |
+|---|---|---|---|
+| Phase 1 gate (full block) | 0 | **0** | 128 |
+| Phase 6 trigger read | 0 | **128** ✓ | — |
+| `actions.md` fetch | 0 | **0** | 1 |
+
+It misses the gate because the failing pipeline is not the block's *last*
+statement, and misses the fetch because the status was already non-zero and was
+discarded by the control flow. Two of the three were *status unconsumed*, not
+*status wrong*, and `pipefail` only fixes the latter. It also cannot live in the
+shared preamble — the one instance it alone would catch is the block with no
+preamble — and after capture-and-check no meaningful pipes remain for it to
+guard.
+
+`set -e` catches all three and is ruled out on a different measurement: every
+script here exits **1** to mean *ran, found something*. Under `errexit` a
+`discover.py` that reports a human commit on the bot's branch kills the block,
+and Phase 7's head re-check aborts at exactly the moment the head moved.
+
+**Replayed**, each block extracted from the file rather than retyped:
+
+```
+Phase 1 gate, ref missing            exit 0, empty  ->  exit 2
+Phase 1 gate, bad commit in the list exit 0, empty  ->  exit 2
+Phase 6 triggers, workflow absent    exit 0, empty  ->  exit 2
+Phase 6 triggers, real workflow                     ->  exit 0, `on: push:`
+actions.md fetch, bad refs           exit 0, "no interface change"
+                                                    ->  exit 2, zero files written
+actions.md fetch, v9.0.0 -> v10.0.1                 ->  28 diff lines, the
+                                                       description-only change
+                                                       0.27.0 documents
+```
+
+The first attempt at that last replay reported `exit=2` for the right reason and
+the wrong cause — the preamble aborted on a missing `phase0.env` and the fetch
+never ran. Recorded because it is the trap this release is about, met while
+verifying the fix for it.
+
+**Tests.** One guard, class-wide: no block reads `git` or `gh` output through a
+pipe. jq's `|` inside a quoted `--jq` argument is stripped first, and **line
+continuations are joined** — `actions.md` wrote the fetch as `gh api … \` then
+`| base64 -d`, two physical lines and one statement, so a per-line regex went
+green against the very instance the guard was widened for. Found by mutation,
+which is the only reason it is not still green.
+
+Also in `CONTRIBUTING.md`: the replay gate now says **run the block as written,
+and read its exit status** — extracted rather than retyped, `$?` rather than
+output — with the three measured shapes that look identical to success.
+
 ## [0.27.0] — 2026-08-21
 
 Phase 4 for actions had one source and no way to check it. An action cannot be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ patch.
 
 ## [Unreleased]
 
-## [0.28.0] — 2026-08-21
+## [0.28.0] — 2026-08-22
 
 One sprint, one release: a producer/consumer sweep of the plugin — for every
 value a phase produces, who consumes it; for every value a phase consumes, who

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,32 @@ execution deliberately for that run and say so in the commit body, because the
 audit will otherwise report those rows as *not run* and the gate will read as
 satisfied when it was not.
 
+**Run the block as written, and read its exit status.** Both halves are the
+gate; neither is optional, and skipping either is how three replays of the same
+change came back clean while the defect stood.
+
+*As written* means extracted from the file, not retyped. A retyped approximation
+is a paraphrase of what you believe the block says, so it tests your reading
+rather than the file — and it silently drops whatever you were going to get
+wrong.
+
+*Its exit status* means `$?`, not the output. Reading only the output is the
+trap this repo documents in Phase 5 — `cmd | tail && next` gates on `tail` — and
+it was committed here while measuring the plugin that documents it: a
+`git worktree add` that had just printed `fatal: invalid reference:` was recorded
+as `exit=0`, because the measurement piped it into `head`. Measured shapes that
+look identical to success:
+
+| Shape | What it prints | `$?` |
+|---|---|---|
+| `git … \| sort -u` with a failing git | nothing | **0** |
+| `git show "$EMPTY:path"` | the file **from the index** | **0** |
+| a mutation applied by a `sed` that matched nothing | the guard passes | 0 |
+
+The third is the one that generalises: **verify the mutation landed before you
+read the result.** A mutation that does not mutate is indistinguishable from a
+guard that discriminates, and it fails in the reassuring direction.
+
 **This is a checklist item, and checklists are visibly skippable.** The box lives
 in `.github/PULL_REQUEST_TEMPLATE.md`, and it asks for what the replay showed
 rather than for a tick — a tick is an assertion, the pasted output is evidence,

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -505,12 +505,20 @@ if [ -z "${BOT_COMMITS+set}" ]; then
   # it here is what stops the substitution being something to remember.
   [ "$BRANCH_POINT" = rewritten ] && RANGE="pr-<N>^..pr-<N>" || RANGE="$BASE_SHA..pr-<N>"
   echo "BOT_COMMITS underivable — gating on the whole $RANGE diff" >&2
-  git diff --name-only $RANGE | sort -u
+  SCOPE=$(git diff --name-only $RANGE) || { echo "cannot diff $RANGE" >&2; exit 2; }
 else
-  for c in $BOT_COMMITS; do git show --name-only --format= "$c"; done | sort -u
+  SCOPE=$(for c in $BOT_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
+    || { echo "cannot read a commit in \$BOT_COMMITS" >&2; exit 2; }
 fi
+# Captured and checked, never piped: a pipeline reports its LAST stage, and
+# `sort` succeeds on empty input — so a failing git hands the gate an empty file
+# list at exit 0, which reads as a clean scope. Exit 2 is the honest answer; no
+# evidence is not evidence of nothing.
+printf '%s\n' "$SCOPE" | sort -u
 # a maintainer's commit on the bot's branch: read it, report it, do not Hold on it
-for c in $HUMAN_COMMITS;   do git show --name-only --format= "$c"; done | sort -u
+HUMANS=$(for c in $HUMAN_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
+  || { echo "cannot read a commit in \$HUMAN_COMMITS" >&2; exit 2; }
+printf '%s\n' "$HUMANS" | sort -u
 ```
 
 A merge commit is in the second list and normally prints nothing — its content
@@ -775,8 +783,12 @@ triggered only by `push: tags:` or `schedule:` never runs on a PR, so every chec
 on it comes from *other* workflows and none of them execute the changed line:
 
 ```bash
-# for each workflow the diff touched, read its triggers
-git show "pr-<N>:.github/workflows/<changed>.yml" | sed -n '/^on:/,/^[a-z]/p'
+# for each workflow the diff touched, read its triggers. Captured, not piped:
+# `sed` succeeds on empty input, so a failed read prints nothing at exit 0 and
+# reads as "this workflow has no pull_request trigger" — the reassuring answer.
+TRIGGERS=$(git show "pr-<N>:.github/workflows/<changed>.yml") \
+  || { echo "cannot read <changed>.yml at pr-<N>" >&2; exit 2; }
+printf '%s\n' "$TRIGGERS" | sed -n '/^on:/,/^[a-z]/p'
 ```
 
 If the intersection of "workflows the diff touched" and "workflows a
@@ -797,7 +809,8 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
 C="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/ci_state.py"
-PARENT=$(git rev-parse "pr-<N>^")
+PARENT=$(git rev-parse "pr-<N>^") \
+  || { echo "cannot resolve pr-<N>^ — was the ref fetched?" >&2; exit 2; }
 
 python3 "$C" --owner "$OWNER" --name "$NAME" --number <N> \
   --head-sha "$HEAD_SHA" --parent "$PARENT" --base-sha "$BASE_SHA"

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -231,8 +231,13 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
 for R in <old-sha> <new-sha>; do
+  # Two statements, each checked. Piped into `base64` and left unchecked, a
+  # failed fetch writes an empty file — and `diff` on two empty files exits 0,
+  # reporting "no interface change", which is this method's *finding*.
   gh api "repos/<owner>/<action>/contents/action.yml?ref=$R" --jq .content \
-    | base64 -d > "$SCRATCH/action-$R.yml"
+    > "$SCRATCH/action-$R.b64" || { echo "cannot read action.yml at $R" >&2; exit 2; }
+  base64 -d < "$SCRATCH/action-$R.b64" > "$SCRATCH/action-$R.yml" \
+    || { echo "action.yml at $R is not valid base64" >&2; exit 2; }
 done
 diff -u "$SCRATCH/action-<old-sha>.yml" "$SCRATCH/action-<new-sha>.yml"
 ```

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -2369,5 +2369,107 @@ class TestEveryDerivedLabelLandsInTheVerdictTable(SkillHarness):
         )
 
 
+class TestTheScopeGateChecksWhatProducesItsEvidence(SkillHarness):
+    """The gate read its file list through a pipe, so a failing git passed it.
+
+    A pipeline's exit status is its **last** stage. `sort` succeeds on empty
+    input, so a `git` that fails yields an empty file list at exit 0 — and an
+    empty file list is exactly what the gate reads as *nothing outside the
+    manifest and lockfile*. Measured in a real clone:
+
+        out=$(for c in deadbeefdeadbeef; do git show --name-only --format= "$c" \
+              2>/dev/null; done | sort -u)
+        pipeline exit=0  files=[]
+
+    Both branches had it, the fallback added in 0.28.0 included — so that release
+    put a second door on the room it had just locked. Hit by accident on a
+    scratch clone where `pr-363` had been deleted: `fatal: ambiguous argument`,
+    and exit 0.
+
+    The plugin already states the rule, in Phase 5 and in `uv-lock.md` § Phase 5:
+    *"Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing
+    suite sails through."* Phase 1's gate is the highest-stakes command in the
+    procedure — it is what stops the audit before Phases 4 and 5 execute the PR's
+    code — and it was the one place the rule was not followed.
+    """
+
+    # A non-comment statement that runs git and pipes onward — the shape that
+    # discards git's status, whether the pipe hangs off the command itself or off
+    # the `done` of a loop containing it. Both were present.
+    # A single `|`, never `||`: the logical-or is how the fixed form *checks*
+    # the status, so a guard that counts it as a pipe fires on the fix.
+    PIPED = re.compile(r"^(?!\s*#)[^\n]*\b(?:git|gh)\s[^\n]*(?<!\|)\|(?!\|)", re.MULTILINE)
+    # Quoted spans come out first. `--jq '.[] | "\(.x)"'` is jq's pipe inside a
+    # single-quoted argument, not a shell pipeline, and four blocks use it.
+    QUOTED = re.compile(r"'[^']*'|\"[^\"]*\"")
+
+    def _gate_block(self) -> str:
+        """The block that *uses* the split, not the one that documents it.
+
+        `"BOT_COMMITS" in code` picked Phase 0's key-list fence — `#   BOT_COMMITS
+        =<shas>` — where there is no git and no pipe, so the pipe guard passed
+        against a comment. Requiring a `$` is what separates a use from a mention,
+        the same discriminator the MAY_EXECUTE guard needs.
+        """
+        found = [c for _, _, c in _every_block() if re.search(r"\$\{?BOT_COMMITS", c)]
+        self.assertTrue(found, "no block gates on $BOT_COMMITS")
+        self.assertEqual(len(found), 1, f"expected one gate block, found {len(found)}")
+        return found[0]
+
+    def test_no_block_reads_git_or_gh_output_through_a_pipe(self):
+        """Class-wide, because the gate was one of three.
+
+        Measured, each in a real clone:
+
+            Phase 1 gate            exit 0, empty file list  -> "clean scope"
+            Phase 6 trigger read    exit 0, empty output     -> "no PR trigger"
+            actions.md Phase 4      two empty files, diff 0  -> "no interface change"
+
+        Every one lands on the reassuring answer, which is what makes the class
+        worth a guard rather than three fixes.
+        """
+        for file, number, code in _every_block():
+            # Line continuations joined first. `actions.md` wrote the fetch as
+            # `gh api … \` / `  | base64 -d > file` — two physical lines, one
+            # statement — and a per-line regex misses it, which is how the guard
+            # went green against the very instance it was widened for.
+            joined = re.sub(r"\\\n\s*", " ", code)
+            stripped = self.QUOTED.sub("''", joined)
+            for hit in self.PIPED.findall(stripped):
+                self.fail(
+                    f"{file} Phase {number} pipes git/gh output onward, so the "
+                    f"pipeline reports the LAST stage's status and a failure "
+                    f"yields empty output at exit 0: {hit.strip()[:70]}"
+                )
+
+    # `NAME=$(… git …)` and whatever follows the closing paren.
+    CAPTURE = re.compile(r"([A-Z_]+)=\$\((?P<body>(?:[^()]|\([^()]*\))*)\)(?P<after>[^\n]*)")
+
+    def test_every_capture_of_git_output_is_checked(self):
+        """Capturing is not enough on its own; something has to act on it.
+
+        Asserted per capture rather than once per block: the block opens with the
+        handoff preamble, whose own `|| … exit 2` satisfied a block-wide search
+        while the gate's two captures went unchecked. A guard that can be
+        satisfied by a *different* line than the one it is about is the same
+        failure as one satisfied by a comment.
+        """
+        block = self._gate_block()
+        seen = 0
+        for found in self.CAPTURE.finditer(block):
+            if "git " not in found.group("body"):
+                continue
+            seen += 1
+            tail = found.group("after") + block[found.end() : found.end() + 120]
+            self.assertRegex(
+                tail,
+                re.compile(r"\|\|\s*(?:\\\n\s*)?\{[^}]*exit 2"),
+                f"`{found.group(1)}` captures git output and nothing checks it. "
+                f"Exit 2 is this plugin's `could not run`, and it is the honest "
+                f"answer: no evidence is not evidence of nothing",
+            )
+        self.assertGreaterEqual(seen, 2, "the gate should capture both halves of the split")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #72. **Stacked on the sweep PR** — same release, separate review.

A pipeline's exit status is its **last** stage, and `sort`, `sed` and `base64` all
succeed on empty input. A failing `git` or `gh` therefore produced empty output at
exit 0 — and in each case the empty result is the *reassuring* answer:

| Block | Measured | Reads as |
|---|---|---|
| Phase 1's scope gate | exit 0, empty file list | **clean scope** |
| Phase 6's trigger read | exit 0, empty output | **no `pull_request` trigger** |
| `actions.md` Phase 4's interface fetch | two empty files, `diff` exit 0 | **no interface change** |

The third is sharpest: `actions.md` says of that method, *"'Inert here' is a result,
not silence. Reaching it deliberately is this phase working; reaching it by not
looking is the failure."* The block could reach it by not looking. An unfetched ref
is enough to trigger any of them.

## Why not `pipefail`

It catches **one of three**:

| Instance | none | `pipefail` | `-eo pipefail` |
|---|---|---|---|
| Phase 1 gate (full block) | 0 | **0** | 128 |
| Phase 6 trigger read | 0 | **128** ✓ | — |
| `actions.md` fetch | 0 | **0** | 1 |

It misses the gate because the failing pipeline isn't the block's *last* statement,
and misses the fetch because the status was already non-zero and was discarded by
control flow. Two of three were *status unconsumed*, not *status wrong*.

`set -e` catches all three and is ruled out on a different measurement: every script
here exits **1** to mean *ran, found something*. Under `errexit`, `discover.py`
reporting a human commit kills the block, and Phase 7's head re-check aborts exactly
when the head moved.

## The guard was green against its own instance

One class-wide guard: no block reads `git`/`gh` output through a pipe. jq's `|`
inside a quoted `--jq` argument is stripped, and **line continuations are joined** —
`actions.md` wrote the fetch as `gh api … \` then `| base64 -d`, two physical lines
and one statement, so the per-line regex passed against the very instance it was
widened for. Found by mutation.

## Also

`CONTRIBUTING.md`'s replay gate now says **run the block as written, and read its
exit status** — extracted rather than retyped, `$?` rather than output. My first
attempt at this PR's own replay reported `exit=2` for the right reason and the wrong
cause: the preamble aborted on a missing `phase0.env` and the code under test never
ran.

263 tests.