### PR TITLE
Derive Phase 1's scope gate rather than judging it (0.29.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3278,7 +3278,9 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.28.0...v0.29.0
+[0.28.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.1...v0.27.0
 [0.26.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.25.0...v0.26.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@ the gate produced the false Hold the file-count rule exists to prevent, on two o
 the three PRs `actions.md` offers as its own measurement — and the synthetic
 patches in the first test pass could not see it.
 
+`actions.md` said *"a `uses:` line or its **trailing** version comment"*, which is
+the wording the first implementation was written from — so the reference was
+inaccurate against the very PRs it cites, and is corrected here too. It now names
+the comment half properly and points at `$SCOPE_GATE` rather than restating a rule
+the script owns.
+
 **Fixed in the same change**, not deferred: a YAML comment cannot execute, so it
 is inside the pin for a gate that asks what the diff makes *run*. Comment lines
 are counted and reported rather than ignored, because a pin manifest is how a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,187 @@ patch.
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-08-22
+
+Phase 1's scope gate — the branch that decides whether Phases 4 and 5 get a
+shell — was the reader's. `discover.py` derives it now, and the ecosystem with
+it. Minor: it changes what Phase 1 verifies and what Phase 0 hands over.
+
+### The gate's rule was already deterministic; only its execution was not
+
+`SKILL.md` stated both halves exactly. For a lockfile bump, *"the diff should
+touch **only** the manifest and the lockfile"*. For an actions bump,
+`actions.md`'s *"every changed line across them is a `uses:` line or its trailing
+version comment. That is the invariant."* A file-set test and a line-kind test —
+and the block under them printed a sorted file list and left the decision to
+whoever read it.
+
+Three properties made it worth a script rather than a paragraph:
+
+- **It is the highest-stakes branch in the procedure.** A gate that answers
+  *clean* is what lets the audit go on to install the PR's dependencies and run
+  its test suite. Every way it goes wrong goes wrong in that direction.
+- **Its failure modes are all silent.** An unset `$BOT_COMMITS` iterates zero
+  times; an empty file list has nothing to object to; the API caps a commit's
+  `files` at 300 and says nothing about the rest; a withheld `patch` reads as no
+  lines beyond the pin. Each arrives as *no objection*.
+- **The wrong heuristic is the reachable one.** `SKILL.md` warns that *"the count
+  of files is not the invariant and never was"*, which is a warning precisely
+  because a four-file diff invites the count.
+
+### Measured on the PRs the rule was written from
+
+`fpga-board-sim` #334 is the case 0.28.0 named and could not close. Its branch
+carries the bot's bump, a maintainer's `style: reformat docs for ruff 0.16`
+fixup, and a merge of `main`; gated on the union it reported eight files as
+*"this bump reaches beyond the manifest and lockfile"* and stopped **before Phase
+4** — the phase that would have measured `ruff` 0.15.22 → 0.16.0, this plugin's
+founding Phase 4 observation, occurring for real. 0.28.0 emitted the authorship
+split; the loop that consumed it stayed in the shell and the judgement stayed
+with the reader.
+
+Now, unchanged inputs:
+
+```
+=== scope: CLEAN  [uv.lock]
+    every changed file is the manifest or the lockfile
+    read from the bot's own commits
+      pyproject.toml
+      uv.lock
+```
+
+Every documented case, live:
+
+| PR | Result |
+|---|---|
+| `fpga-board-sim` #363 — `setup-uv` 9.0.0 → 10.0.1 | `CLEAN [github-actions]` |
+| `fpga-board-sim` #364 — grouped `python-deps`, 3 updates | `CLEAN [uv.lock]` |
+| `fpga-board-sim` #334 — bot + human fixup + merge | `CLEAN [uv.lock]` — the false Hold, closed |
+| `cli/cli` #14091 / #13981 / #14147 — two, three and four files | `CLEAN [github-actions]`, all three |
+| `cli/cli` #14049 — two-parent head | `CLEAN [github-actions]`, base not substituted |
+| `dependabot-audit` #60 — human PR, no bot commit | `BEYOND [unknown]`, the four files 0.28.0 named |
+
+### The first implementation failed two of the three PRs the rule cites
+
+Written from `actions.md`'s wording, the line test accepted a `uses:` line and
+its **trailing** comment. Replayed against `cli/cli` it fired on #13981 and
+#14147:
+
+```
+-#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
++#   - actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+```
+
+A compiler that emits workflows records the pins it wrote in a header block, so a
+correct bump changes the `uses:` line **and** the comment naming the same pin. The
+trailing version comment is not always trailing. Read as a line beyond the pin,
+the gate produced the false Hold the file-count rule exists to prevent, on two of
+the three PRs `actions.md` offers as its own measurement — and the synthetic
+patches in the first test pass could not see it.
+
+**Fixed in the same change**, not deferred: a YAML comment cannot execute, so it
+is inside the pin for a gate that asks what the diff makes *run*. Comment lines
+are counted and reported rather than ignored, because a pin manifest is how a
+generated workflow announces itself — which is a Phase 7 row of its own.
+
+### `$BOT_COMMITS` stops crossing the shell boundary
+
+It was emitted for Phase 1 to iterate, and `$SCOPE_GATE` is the answer that loop
+was computing. Emitting both would leave the shell holding everything it needs to
+roll a second gate by hand, which is how a prose copy and a script copy drift. It
+stays in the report output and in `--json`, where it is evidence rather than an
+input. `$HUMAN_COMMITS` has no script consumer and still crosses.
+
+Two new outputs replace it — `$ECOSYSTEM` and `$SCOPE_GATE` — and Phase 1's block
+is now the branch it always described:
+
+```bash
+[ "$SCOPE_GATE" = clean ] \
+  || { echo "scope $SCOPE_GATE — report it, and STOP before Phase 4" >&2; exit 1; }
+```
+
+Unset compares equal to nothing, so a missing handoff stops here rather than
+reading as clean.
+
+### The tip worktree was gated in prose only
+
+Removing Phase 1's `[ "$BRANCH_POINT" = rewritten ]` branch left `$BRANCH_POINT`
+with no shell consumer at all, and the completeness guard added in 0.26.1 said
+so. Following it found the block that creates `$SCRATCH/tip-<N>` running
+unconditionally under a paragraph that says to run it only when the base was
+rewritten — 0.28.0's own lesson, one phase along. It now tests the variable.
+
+Phase 0's substitution list also claimed *"Phase 1 takes its scope diff from
+`pr-<N>^..pr-<N>`"*, in `SKILL.md` and in `discover.py`'s report. Phase 1 needs no
+substitution now: it reads the bot's own commits, and a commit carries its own
+diff with no range to be wrong about. Where the split is *also* underivable the
+gate answers `underivable` rather than falling back to a range that, under a
+rewritten base, is the entire divergence.
+
+### Two more defects, found by review and by replay
+
+- **A patch withheld in one of the bot's commits was covered by another's.** The
+  union kept the half that *was* readable, so it read as "these are the lines
+  that changed" while the lines the API never sent were the ones the gate would
+  have objected to. Withheld on either side is now withheld for the union.
+- **The unrecognised-manifest branch could answer `beyond` while naming nothing.**
+  A `pyproject.toml`-only bump — pip with nothing locked — is all manifest, so the
+  beyond list filtered to empty and the verdict fired anyway. It reaches a report
+  as *"this bump reaches past the manifest"* over a blank list, which is the one
+  verdict a reader cannot act on. There is no scope rule for that ecosystem, and
+  `underivable` says so.
+
+### Replayed end to end
+
+`fpga-board-sim` #334 under `claude -p --plugin-dir`, in a fresh context against
+the unreleased plugin. Phase 0's report returned:
+
+```
+=== scope: CLEAN  [uv.lock]
+    every changed file is the manifest or the lockfile
+    read from the bot's own commits
+      pyproject.toml
+      uv.lock
+
+RESULT: ORDINARY — 0 finding(s)
+```
+
+Phase 1's block then ran as written, `[ "$SCOPE_GATE" = clean ]` passed, and the
+audit **continued into Phase 2** — reading `ruff` 0.16.0's release notes, which is
+the phase the gate used to stop one short of. The run ended on a spend limit
+rather than a verdict; what it establishes is the gate, and the gate is what
+changed.
+
+### Measured
+
+| | 0.28.0 | 0.29.0 |
+|---|---|---|
+| `SKILL.md` | 74,778 B / ~18,694 tok | **73,786 B / ~18,446 tok** |
+| `discover.py` output, `fpga-board-sim` #363 | 1,026 B | **1,201 B** |
+| `discover.py` output, `cli/cli` #14147 | 1,354 B | **1,889 B** |
+
+`SKILL.md` is re-read from cache every turn and the script's output only from the
+turn it lands on, so on the 52-turn shape measured in 0.16.0 the net is about
+**−11,000 token-turns for a lockfile bump and −7,000 for the worst actions case**
+— roughly half a cent a run. The saving is real and it is not the reason: a rule
+in prose costs tokens every turn *and* can be misapplied, and this one was
+misapplied on the PR that mattered most.
+
+### Tests
+
+Thirteen cases in `tests/test_discover.py`, each a failure the prose already
+names: the four-file trap, a `with:` edit past the pin, the generated pin
+manifest, the bot-versus-branch split, a withheld patch, an empty file list, the
+API's cap, an unsupported lockfile, a rewritten base with no split. Five
+load-bearing behaviours were mutation-checked and each was caught by exactly the
+intended case.
+
+Five prose guards moved with the rule rather than being deleted:
+`test_phase_1_gates_on_the_bots_own_commits` now reads Phase 1's prose (the claim
+the report makes) and requires the shell to consult `$SCOPE_GATE`;
+`test_every_capture_of_git_output_is_checked` covers the one remaining half of
+the split; the unset-fallback canary asserts the gate moved rather than vanished.
+
 ## [0.28.0] — 2026-08-22
 
 One sprint, one release: a producer/consumer sweep of the plugin — for every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,7 @@ No round of this has yet come back empty:
 | this repo's #26, against the corrected rule | `pr-<N>^` can have no runs to compare against, and the rule as committed discarded an answer sitting on the merge base |
 | `cli/cli` #13996, #13981, #14124 | Dependabot's 2026-07-14 default cooldown, which Phase 2 read as ingestion lag; and two actions facts the PR does not state — the versions adopted, and whether the file it edits is generated |
 | `cli/cli`, eleven bumps, against the *corrected* Phase 1 gate | `$BASE_SHA` collapses onto `$HEAD_SHA` on any PR that has landed, so Phase 1's diff is empty and Phase 4 measures the PR against itself |
+| `cli/cli` #13981 and #14147, against a Phase 1 gate mechanised **from `actions.md`'s own sentence** | the sentence was wrong about the PRs it cites. A compiler that emits workflows records its pins in a header comment block, so *"a `uses:` line or its **trailing** version comment"* fires on two of the three it names (0.29.0) |
 
 **The fourth row is why this is a gate and not a habit.** Three prose guards went
 with it, taking Phase 6's total to six, each mutation-checked against the previous
@@ -121,6 +122,19 @@ interpreters — and one of the three asserted that Phase 6 read `$BASE_SHA`, wh
 prose and the new. It says nothing about whether the new prose is right, and a
 guard written from the fix cannot supply that. The replay costs one `gh` call and
 would have caught this before the commit rather than one commit later.
+
+**The last row is a failure mode the others do not have, and it is the one to
+watch for when mechanising.** Every row above it is a *fix* that was wrong. That
+one is the **specification** being wrong: the rule had been stated in prose for
+five versions, with three merged PRs named as its measurement, and it did not
+describe two of them. A test written from that sentence passed, because it
+reproduced the author's reading of the sentence — which is the thing under test.
+
+So: **when you turn a prose rule into code, replay the PRs the prose cites, not
+PRs of that shape.** A synthetic fixture built from the rule can only ever agree
+with it. This is *"write the check from the evidence, not from the change"* one
+level up — here the change *was* the evidence, and the evidence was already in
+the repository, one `gh api` call away.
 
 **The fifth row is the same gate showing its limit.** `mdcat` #6 could not have
 found it — there the bot's parent has runs — so it took a second replay against a
@@ -285,10 +299,13 @@ after nine commits of growth.
 
 ## Constraints that are load-bearing
 
-- **`audit.py` and `gate_diff.py` import nothing outside the standard library.**
-  They run under whatever bare `python3` the audited repository has, and `tomllib`
-  puts the floor at 3.11. That is why CI runs 3.11 through 3.14 and why the local
-  hooks cannot be the whole story.
+- **Every script here imports nothing outside the standard library** — `audit.py`,
+  `discover.py`, `ci_state.py` and `gate_diff.py` alike. All four are invoked as
+  `python3 "$SCRIPT"` from the audited repository, so they run under whatever bare
+  interpreter it has, and `tomllib` puts the floor at 3.11. That is why CI runs
+  3.11 through 3.14 and why the local hooks cannot be the whole story. The rule
+  named two of the four until 0.29.0, which is the kind of list that silently
+  stops covering what it was written for.
 - **Do not extend a script to an ecosystem you have no repository to test it
   against.** The per-ecosystem references document what is in scope instead,
   deliberately.

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -127,8 +127,9 @@ defines:
 #   CREATED_AT=<iso8601>   when the PR was opened — Phase 2's cooldown test
 #   BRANCH_POINT=<ok|rewritten|suspect|underivable>
 #   MAY_EXECUTE=<yes|no>   whether Phases 4 and 5 are authorised
-#   BOT_COMMITS=<shas>     the bot's own commits above the base — Phase 1's gate
 #   HUMAN_COMMITS=<shas>   non-bot commits on the branch — a finding, not a gate
+#   ECOSYSTEM=<uv.lock|github-actions|unsupported|unknown|underivable>
+#   SCOPE_GATE=<clean|beyond|underivable>   Phase 1's gate, already decided
 ```
 
 **An underivable output is emitted commented-out, so it stays unset.** That is
@@ -230,9 +231,10 @@ If either check fails, `git worktree remove` it and re-add.
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
 | `$CREATED_AT` | when the PR was opened, ISO-8601. **Phase 2 compares release publish times against it** — the cooldown asks whether a release was three days old *then*, not now |
-| `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **Phase 1 reads it**, and the table below says what each one means |
+| `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **the tip-worktree block below gates on it**, and the table there says what each one means |
 | `$MAY_EXECUTE` | `yes` or `no` — **Phases 4 and 5 gate on it**, and the gate tests for `yes` so an unset value refuses. The classification below is what sets it |
-| `$BOT_COMMITS` | the bot's own commits above the base. **Phase 1's scope gate takes its diff from these**, because that is the invariant the gate is about |
+| `$ECOSYSTEM` | `uv.lock`, `github-actions`, `unsupported`, `unknown` or `underivable` — **which Phase 1, 3, 4 and 5 method applies**, derived from the files the bump changed rather than inferred from the PR |
+| `$SCOPE_GATE` | `clean`, `beyond` or `underivable` — **Phase 1's gate, already decided** from the bot's own commits. That is the invariant the gate is about, and it is why `$BOT_COMMITS` does not cross: the loop that consumed it is now the script's |
 | `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
 
 **`$PERMS` is not on that list, and the distinction is the point.** It is read off
@@ -345,8 +347,7 @@ harness, two separate calls: an `export` in the first is **unset** in the second
 shell functions likewise, and each call is a new shell process. So `${SCRATCH:-…}`
 found `SCRATCH` unset every time, `mktemp -d` returned a new directory, and the
 next call sourced a `phase0.env` that was not there — leaving `$BASE_SHA`,
-`$HEAD_SHA`, `$BOT_COMMITS` and `$DEFAULT` silently empty downstream rather than
-erroring.
+`$HEAD_SHA` and `$DEFAULT` silently empty downstream rather than erroring.
 
 **The working directory does survive, and is still not a way out.** It carried
 between calls when it stayed inside the project; a call that ends outside has its
@@ -374,10 +375,13 @@ whole phase exists to make impossible.
 **What that empties, measured**, running each consuming block in a fresh call with
 nothing sourced: Phase 1's lockfile read, Phase 4, Phase 6 and Phase 7's cleanup
 all fail loudly — a `Permission denied`, two exit 2s, an exit 128 — and Phase 1's
-**authorship gate passes silently**, because `for c in $BOT_COMMITS` over an unset
-variable iterates zero times and hands the gate an empty file list. That is why
-the block below tests the variable rather than trusting it: the fallback belongs
-in the shell, not only in the paragraph that describes it.
+**authorship gate passed silently**, because `for c in $BOT_COMMITS` over an unset
+variable iterates zero times and handed the gate an empty file list. The gate is
+`discover.py`'s from 0.29.0 and no longer reads that variable, but the class is
+unchanged and the handling belongs in the shell rather than only in the paragraph
+that describes it: an unset `$SCOPE_GATE` compares equal to nothing, so Phase 1's
+`[ "$SCOPE_GATE" = clean ]` fails **closed** into a stop rather than open into a
+pass.
 
 `git` state is the exception and needs no reload. The `pr-<N>` ref Phase 0 fetches
 is in the repository, so `git show "pr-<N>:…"` works from any call. Only the shell
@@ -418,8 +422,11 @@ interchangeable:
 
 The substitutions, when `rewritten` fires:
 
-- **Phase 1** takes its scope diff from `pr-<N>^..pr-<N>` rather than from the
-  merge base.
+- **Phase 1** needs no substitution: its gate reads the bot's own commits, and a
+  commit carries its own diff with no range to be wrong about. Where the
+  authorship split is *also* underivable there is nothing safe to fall back to —
+  the whole-diff range is the entire divergence — so the gate answers
+  `underivable` rather than guessing.
 - **Phase 4** measures in `$SCRATCH/tip-<N>` rather than `$SCRATCH/base-<N>`,
   because the tree this PR would land on is the default branch's tip.
 
@@ -428,6 +435,7 @@ The substitutions, when `rewritten` fires:
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
+[ "$BRANCH_POINT" = rewritten ] || { echo "base not rewritten — no tip worktree" >&2; exit 0; }
 git fetch origin "$DEFAULT"
 git worktree add --detach "$SCRATCH/tip-<N>" "origin/$DEFAULT"
 ```
@@ -473,93 +481,58 @@ them). Treat those as leads to check, not as facts — verify before repeating.
 
 ## Phase 1 — Scope and provenance
 
-*Requires from Phase 0: `$SCRATCH`, `$BASE_SHA`, `pr-<N>`.*
+*Requires from Phase 0: `$SCRATCH`, `$ECOSYSTEM`, `$SCOPE_GATE`, `$HUMAN_COMMITS`, `pr-<N>`.*
 
-**Check the branch point before you read the diff.** If Phase 0 found the base
-rewritten, a merge-base diff shows the whole divergence and the gate below will
-fire on files the bump never touched — so take the diff from `pr-<N>^..pr-<N>`
-and report the rewritten base as its own finding. Firing the gate on a stale
-base is not a safe default: it stops the audit for a reason that is not true, and
-it reads in the report exactly like a bump that reaches into source.
+**Phase 0 derived this gate; this phase acts on it.** `discover.py` reads the
+files **`$BOT_COMMITS`** changed — never the branch's, because a maintainer can
+land the fixup the bump *requires* on the bot's own branch, and gated on the
+union that produces a Hold in language that reads exactly like a bump reaching
+into source. It answers in Phase 0's three states:
 
-**Split the diff by authorship before you gate on it.** A bot PR's branch is not
-always all bot. A maintainer can land the fixup the bump *requires* on the bot's
-own branch, so a required check goes green again — and merging that is correct.
-Gated on the union of the branch's commits it produces a Hold, in language that
-reads exactly like a bump reaching into source.
+| `$SCOPE_GATE` | What it established | What this phase does |
+|---|---|---|
+| `clean` | every changed file is the manifest and the lockfile, or every changed **line** is a `uses:` pin | continue |
+| `beyond` | the diff reaches past the pin — the report output names the files or the lines | a finding. Report it and **stop before Phase 4** |
+| `underivable` | the gate could not be evaluated: a patch the API withheld, a file list at its cap, a lockfile from an ecosystem this plugin does not cover, or a rewritten base with no authorship split to fall back from | **not a clean scope.** Report what could not be established, and stop |
 
-Phase 0 derived both halves, so take the gate's diff from the bot's commits and
-report the human's separately:
+The count of files is not the invariant and never was: an action is pinned in
+every workflow that uses it, and a grouped bump moves several actions at once, so
+ordinary merged bumps touch two, three or four files. `references/actions.md` has
+the measurements, and the rule for reading the versions out of that diff rather
+than off the title.
+
+**`underivable` is not `clean`, and the asymmetry is the point.** Every way this
+gate fails quietly arrives as *no objection* rather than as an error — an unset
+`$BOT_COMMITS` iterating zero times, an empty file list, a capped page hiding
+file 301 — and it is the gate that refuses Phases 4 and 5 a shell. Where the
+split is underivable the script falls back to the whole `$BASE_SHA..pr-<N>` diff
+and prints which source it used; read that line before quoting the verdict.
 
 ```bash
 # Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
-# what the bump itself changed — this is what the gate is about.
-# Unset is Phase 0's third state, and an unset list iterates zero times: the
-# fallback has to fire here, or the gate passes on an empty diff.
-if [ -z "${BOT_COMMITS+set}" ]; then
-  # No split to gate on, so the range matters — and a rewritten base makes the
-  # merge-base range the whole divergence. Phase 0 already decided which; reading
-  # it here is what stops the substitution being something to remember.
-  [ "$BRANCH_POINT" = rewritten ] && RANGE="pr-<N>^..pr-<N>" || RANGE="$BASE_SHA..pr-<N>"
-  echo "BOT_COMMITS underivable — gating on the whole $RANGE diff" >&2
-  SCOPE=$(git diff --name-only $RANGE) || { echo "cannot diff $RANGE" >&2; exit 2; }
-else
-  SCOPE=$(for c in $BOT_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
-    || { echo "cannot read a commit in \$BOT_COMMITS" >&2; exit 2; }
-fi
-# Captured and checked, never piped: a pipeline reports its LAST stage, and
-# `sort` succeeds on empty input — so a failing git hands the gate an empty file
-# list at exit 0, which reads as a clean scope. Exit 2 is the honest answer; no
-# evidence is not evidence of nothing.
-printf '%s\n' "$SCOPE" | sort -u
+echo "ecosystem: $ECOSYSTEM"
 # a maintainer's commit on the bot's branch: read it, report it, do not Hold on it
 HUMANS=$(for c in $HUMAN_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
   || { echo "cannot read a commit in \$HUMAN_COMMITS" >&2; exit 2; }
 printf '%s\n' "$HUMANS" | sort -u
+# Last, so the half above still reports. Unset compares equal to nothing, so an
+# empty $SCOPE_GATE stops here rather than reading as clean.
+[ "$SCOPE_GATE" = clean ] \
+  || { echo "scope $SCOPE_GATE — report it, and STOP before Phase 4" >&2; exit 1; }
 ```
 
-A merge commit is in the second list and normally prints nothing — its content
-arrived from the branch it merged. What it *does* print is what the merge itself
-changed, which is the one thing worth seeing there.
+A merge commit is in that list and normally prints nothing — its content arrived
+from the branch it merged. What it *does* print is what the merge itself changed,
+which is the one thing worth seeing there.
 
-**Where `$BOT_COMMITS` is unset, gate on the whole `$BASE_SHA..pr-<N>` diff and
-say the split was underivable.** That is Phase 0's third state and the old
-behaviour: the right fallback, not the right default. Never gate on an *empty*
-list — it iterates zero times and the gate passes silently, which is the one
-outcome worse than a false Hold.
-
-**Two reasons a scope diff overshoots, and they present identically.** A moved
-base (`BRANCH_POINT=rewritten`, above) and a human fixup on the bot's branch.
-Both produce a diff far past the manifest, both read in the report as a bump
-reaching into source, and they take different fixes. Observed together on one
-PR: Phase 0 printed `HUMAN` against two of three commits above the base, and
-Phase 1 gated on all three.
-
-Getting this wrong costs more than the verdict. The gate stops the audit **before
-Phase 4** — and on that PR Phase 4 was the phase that would have measured the
-bump, `ruff` 0.15.22 → 0.16.0, this phase's own founding observation occurring
-for real. Phase 4 measures on the merge base precisely because a PR carrying the
-fixup reports no difference on its own tree; the base worktree was built, the
-measurement was available, and the gate stopped one phase short of it.
-
-**This phase is a gate, not just a step.** The diff should touch **only** the
-manifest and the lockfile — or, for an actions bump, **only `uses:` lines**, in
-however many workflow files pin that action. The count of files is not the
-invariant and never was: an action is pinned in every workflow that uses it, and
-a grouped bump moves several actions at once, so ordinary merged bumps touch
-two, three or four files. `references/actions.md` has the measurements, and
-the rule for reading the versions out of that diff rather than off the title.
-Anything else is a finding: report it, and **stop before Phase 4**. The same
-applies if provenance comes back with a discrepancy. Phases 4 and 5 execute the
-PR's code, and the whole point of running the cheap read-only checks first is that
-they can refuse to hand it a shell. Continuing anyway spends the ordering for
-nothing.
-
-Stopping here is not a failed audit. It is a complete one that reached a verdict
-early — write the report with the phases that ran and say which did not.
+A provenance discrepancy stops the audit here too. Phases 4 and 5 execute the
+PR's code, and the point of running the cheap read-only checks first is that they
+can refuse to hand it a shell; continuing anyway spends the ordering for nothing.
+Stopping here is not a failed audit but a complete one that reached a verdict
+early — write the report with the phases that ran, and say which did not.
 
 **The method is per-ecosystem; the gate above is not.** Each reference is
 sectioned by phase, so read the section for this one:
@@ -1076,7 +1049,7 @@ there by exhaustion is indistinguishable in the report from no finding at all.
 | A red required check labelled **pre-existing** | **Not a Hold on this bump.** Report it as its own finding, take the verdict from the remaining evidence, and say the PR is unmergeable until someone fixes it |
 | A red required check labelled **underivable** | **Not a Hold on this bump** — nothing established the cause, and a Hold that rests on an unattributed red row is correct only by accident. Report the red check *and* that the comparison could not be made; the PR is unmergeable until it is fixed. If this row would decide the verdict, confidence is **low** |
 | Actions: the pin is a tag or branch, **not a 40-hex SHA** | **Not a Hold on this bump** — the pin was mutable before this PR and the bump did not make it so. Report that what was audited is what runs *today*, so this repo's pins are not evidence, and take the verdict from the rest |
-| `BRANCH_POINT=rewritten` — the base branch was rewritten under this PR | **Not a Hold on this bump.** A fact about the branch, not the dependency. Report it with both substitutions Phase 0 named, and say that the scope diff and Phase 4's tree came from the substituted sources |
+| `BRANCH_POINT=rewritten` — the base branch was rewritten under this PR | **Not a Hold on this bump.** A fact about the branch, not the dependency. Report it, and say that Phase 4's tree came from `$SCRATCH/tip-<N>`. Phase 1's gate needs no substitution — it reads the bot's own commits — unless the authorship split was *also* underivable, where it answers `underivable` and that caps confidence |
 | `BRANCH_POINT=suspect` — non-bot commits above the base, no force-push event | **Not a Hold.** Corroboration without the authority: read the commits, report what they changed, and say the base was *not* substituted on it alone |
 | `BRANCH_POINT=underivable` — the event list could not be read | **Not a Hold**, and not `ok` either. Report that the merge base was never proved to be the branch point, which caps confidence at **medium** — or **low** where the scope diff is what the verdict turns on |
 | Phase 4: base differs, PR agrees — real and already absorbed | **Merge as-is**, naming what the PR absorbed and how |

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -26,9 +26,18 @@ neither is where the obvious source puts it:
   is pinned in every workflow that uses it, and a grouped bump moves several
   actions at once. Measured on `cli/cli`, all three merged: #14091 two files,
   #13981 three, #14147 four — and every changed line across them is a `uses:`
-  line or its trailing version comment. That is the invariant. A gate phrased as
-  "one workflow file" refuses the ordinary case, and refuses it in the report's
-  language for a bump reaching into source.
+  line or a comment. That is the invariant, and `scripts/discover.py` applies it:
+  Phase 0 hands Phase 1 `$SCOPE_GATE`, so read that answer rather than
+  re-deriving one here. A gate phrased as "one workflow file" refuses the
+  ordinary case, and refuses it in the report's language for a bump reaching into
+  source.
+- **The comment half is not only the trailing `# v1`.** A compiler that emits
+  workflows records the pins it wrote in a header block, so a correct bump
+  changes the `uses:` line **and** the comment naming the same pin — #13981 and
+  #14147 both do, and a rule reading "trailing version comment" literally fires
+  on two of the three PRs above. The count is reported rather than dropped: a pin
+  manifest is how a generated file announces itself, which is the `DO NOT EDIT`
+  finding below reached from the diff instead of a `grep`.
 - **The versions under audit are not readable from the title or the body.** Phase
   1's rule against reading package *names* off the title extends to versions
   here, where no script derives them. `cli/cli` #13981 — titled and summarised

--- a/skills/dependabot-audit/scripts/discover.py
+++ b/skills/dependabot-audit/scripts/discover.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from typing import Any, NoReturn
@@ -54,6 +55,59 @@ BOTS = frozenset({"dependabot[bot]", "renovate[bot]", "dependabot", "renovate"})
 DERIVED = "derived"
 ABSENT = "absent"
 UNDERIVABLE = "underivable"
+
+# Phase 1's gate, as data. Both rules were the reader's, both are mechanical, and
+# both fail quietly: a scope that reads clean is what hands Phases 4 and 5 a
+# shell.
+#
+# Filenames only. What a file *is* stays `audit.py`'s question — it sniffs
+# content because a `Cargo.lock` is TOML with `[[package]]` blocks and a name is
+# not evidence. This is the cheaper, earlier signal that decides which reference
+# and which Phase 1 method apply, and it is deliberately not a second opinion on
+# the sniff.
+MANIFESTS = frozenset({"uv.lock", "pyproject.toml"})
+WORKFLOW_DIRS = (".github/workflows/", ".github/actions/")
+
+# Named rather than lumped into "unknown": a Cargo bump is a **boundary**, and
+# reporting it as a scope finding says the bump reached into source when what
+# happened is that this plugin has no rule for it. An improvised recipe returned
+# matching checksums and a clean OSV batch on a real one.
+UNSUPPORTED_LOCKFILES = {
+    "Cargo.lock": "Rust / Cargo",
+    "package-lock.json": "JavaScript / npm",
+    "yarn.lock": "JavaScript / Yarn",
+    "pnpm-lock.yaml": "JavaScript / pnpm",
+    "poetry.lock": "Python / Poetry",
+    "Pipfile.lock": "Python / Pipenv",
+    "go.sum": "Go",
+    "Gemfile.lock": "Ruby / Bundler",
+    "composer.lock": "PHP / Composer",
+}
+
+# The API caps a commit's `files` array here and says nothing about the rest, so
+# file 301 is absent and indistinguishable from one that is in scope. Same
+# failure as `contexts(first:100)` in `ci_state.py`, one endpoint along.
+FILES_CAP = 300
+
+# `actions.md`: "every changed line across them is a `uses:` line or its trailing
+# version comment. That is the invariant." Not the number of files — a grouped
+# bump moves several actions and an action is pinned in every workflow using it.
+USES_LINE = re.compile(r"^\s*-?\s*uses:\s*\S+\s*(#.*)?$")
+
+# The trailing version comment is not always trailing. A compiler that emits
+# workflows records the pins it wrote in a header block, so a correct bump
+# changes the `uses:` line *and* the comment naming the same pin — measured on
+# `cli/cli` #13981 and #14147, both merged:
+#
+#     -#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+#     +#   - actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+#
+# Gated as a line beyond the pin that fires on two of the three PRs `actions.md`
+# cites as the measurement for its own rule. A YAML comment cannot execute, so it
+# is inside the pin for a gate that asks what the diff makes *run* — and it is
+# counted rather than ignored, because a pin manifest is how a generated workflow
+# announces itself, which is a Phase 7 row of its own.
+COMMENT_LINE = re.compile(r"^\s*#")
 
 
 def fail(what: str) -> NoReturn:
@@ -263,6 +317,223 @@ def branch_point(
     }
 
 
+def _changed_lines(patch: str) -> list[str]:
+    """The lines a patch added or removed, sign stripped, headers dropped."""
+    out: list[str] = []
+    for line in patch.splitlines():
+        if not line or line.startswith(("+++", "---", "@@")):
+            continue
+        if line[0] in "+-":
+            out.append(line[1:])
+    return out
+
+
+def bump_files(
+    owner: str,
+    name: str,
+    bot_commits: list[str],
+    compare: dict[str, Any] | None,
+    *,
+    commits_underivable: bool,
+    rewritten: bool,
+) -> tuple[list[dict[str, Any]] | None, str]:
+    """What the bump changed, or None and why it could not be established.
+
+    Phase 1 gates on **the bot's own commits**, not on the branch: a maintainer
+    can land the fixup the bump requires on the bot's branch, and gated on the
+    union that reads as a bump reaching into source. So each bot commit is read
+    on its own, which is also what makes this immune to a rewritten base — the
+    commit carries its own diff and no range is involved.
+
+    The fallback is the whole `$BASE_SHA..pr-<N>` diff, and it is the right
+    fallback rather than the right default. Under a **rewritten** base that diff
+    is the entire divergence — the input that once reported a two-file bump as
+    fourteen files and 3,682 deletions — so there it is refused outright.
+    """
+    if bot_commits:
+        merged: dict[str, dict[str, Any]] = {}
+        for sha in bot_commits:
+            body = _json_or_none(["api", f"repos/{owner}/{name}/commits/{sha}"])
+            if body is None or not isinstance(body.get("files"), list):
+                return None, f"the file list for the bot's commit {sha[:9]} could not be read"
+            files = body["files"]
+            if len(files) >= FILES_CAP:
+                return None, (
+                    f"commit {sha[:9]} reports {len(files)} files, at the API's cap of "
+                    f"{FILES_CAP} — the rest are absent, not shown to be in scope"
+                )
+            for entry in files:
+                filename = entry.get("filename") or ""
+                # A file touched by two of the bot's commits arrives twice, and
+                # the gate has to see every line either changed — so the patches
+                # accumulate rather than the later record winning.
+                if filename in merged:
+                    have, incoming = merged[filename].get("patch"), entry.get("patch")
+                    # Withheld on either side is withheld for the union. Keeping
+                    # the half that *is* readable reads as "these are the lines
+                    # that changed", and the lines the API never sent are the
+                    # ones the gate would have objected to.
+                    merged[filename]["patch"] = (
+                        None if have is None or incoming is None else f"{have}\n{incoming}"
+                    )
+                else:
+                    merged[filename] = dict(entry)
+        return list(merged.values()), "the bot's own commits"
+
+    why_split = (
+        "the authorship split was underivable"
+        if commits_underivable
+        else "no commit above the base is the bot's"
+    )
+    if rewritten:
+        return None, (
+            f"{why_split}, and the base was rewritten — the whole-diff fallback would be "
+            "the entire divergence rather than the bump"
+        )
+    if compare is None or not isinstance(compare.get("files"), list):
+        return None, f"{why_split}, and the PR's own file list could not be read"
+    files = compare["files"]
+    if len(files) >= FILES_CAP:
+        return None, (
+            f"{why_split}, and the diff reports {len(files)} files, at the API's cap of {FILES_CAP}"
+        )
+    return files, f"the whole $BASE_SHA..pr-<N> diff — {why_split}"
+
+
+def _ecosystem(names: list[str]) -> tuple[str, str]:
+    """Which Phase 1 method applies, from the filenames alone."""
+    for filename in names:
+        base = filename.rsplit("/", 1)[-1]
+        if base in UNSUPPORTED_LOCKFILES:
+            return "unsupported", (
+                f"the diff carries a {base} ({UNSUPPORTED_LOCKFILES[base]}). This plugin "
+                "verifies uv.lock and GitHub Actions end to end and nothing else — report "
+                "that boundary, and do not improvise a recipe from the shape of the ones "
+                "that are here"
+            )
+    if any(filename.rsplit("/", 1)[-1] == "uv.lock" for filename in names):
+        return "uv.lock", ""
+    if all(filename.startswith(WORKFLOW_DIRS) for filename in names):
+        return "github-actions", ""
+    return "unknown", ""
+
+
+def scope(files: list[dict[str, Any]] | None, source: str) -> dict[str, Any]:
+    """Phase 1's gate: does the diff stay inside what a bump is allowed to touch?
+
+    Three states like everything else here, and the third is the one that
+    matters. A gate that cannot be evaluated must not answer **clean** — that is
+    the answer which lets Phases 4 and 5 run.
+    """
+    empty: dict[str, Any] = {"files": [], "beyond": [], "comment_lines": 0, "source": source}
+    if files is None:
+        return {"verdict": UNDERIVABLE, "ecosystem": UNDERIVABLE, "why": source, **empty}
+
+    names = sorted(entry.get("filename") or "" for entry in files)
+    if not names:
+        return {
+            "verdict": UNDERIVABLE,
+            "ecosystem": UNDERIVABLE,
+            "why": (
+                f"no changed files came back from {source}. An empty list objects to "
+                "nothing and establishes nothing — the same shape as a gate list that "
+                "iterates zero times"
+            ),
+            **empty,
+        }
+
+    ecosystem, why = _ecosystem(names)
+    common = {"files": names, "comment_lines": 0, "source": source}
+
+    if ecosystem == "unsupported":
+        # Not `beyond`: nothing here says the bump reached into source, only that
+        # the rule for judging it is not in this plugin.
+        return {"verdict": UNDERIVABLE, "ecosystem": ecosystem, "why": why, "beyond": [], **common}
+
+    if ecosystem == "uv.lock":
+        beyond = [n for n in names if n.rsplit("/", 1)[-1] not in MANIFESTS]
+        return {
+            "verdict": "beyond" if beyond else "clean",
+            "ecosystem": ecosystem,
+            "beyond": beyond,
+            "why": (
+                "the diff reaches past the manifest and the lockfile"
+                if beyond
+                else "every changed file is the manifest or the lockfile"
+            ),
+            **common,
+        }
+
+    if ecosystem == "github-actions":
+        # The lockfile rule reads names; this one reads *lines*, so this is the
+        # only branch that needs the patch — and a withheld patch is therefore
+        # only underivable here.
+        withheld = [entry.get("filename") or "" for entry in files if entry.get("patch") is None]
+        if withheld:
+            return {
+                "verdict": UNDERIVABLE,
+                "ecosystem": ecosystem,
+                "beyond": [],
+                "why": (
+                    f"the API withheld the patch for {', '.join(sorted(withheld))} — binary, "
+                    "or past its size limit. No lines to read is not 'no lines beyond the pin'"
+                ),
+                **common,
+            }
+        beyond = []
+        comments = 0
+        for entry in files:
+            for line in _changed_lines(entry.get("patch") or ""):
+                if USES_LINE.match(line):
+                    continue
+                if COMMENT_LINE.match(line):
+                    comments += 1
+                    continue
+                beyond.append(f"{entry.get('filename')}: {line.strip()}")
+        return {
+            **common,
+            "verdict": "beyond" if beyond else "clean",
+            "ecosystem": ecosystem,
+            "beyond": beyond,
+            # After the spread: `common` carries the 0 every other branch wants,
+            # and a key repeated in a literal takes its last value.
+            "comment_lines": comments,
+            "why": (
+                "a changed line is neither a `uses:` pin nor a comment"
+                if beyond
+                else "every changed line across every file is a `uses:` line or a comment"
+            ),
+        }
+
+    beyond = [n for n in names if n.rsplit("/", 1)[-1] not in MANIFESTS]
+    if not beyond:
+        # Every file is a manifest this plugin knows and none is a lockfile — a
+        # `pyproject.toml`-only bump, pip with nothing locked. The filter empties
+        # and `beyond` naming nothing is the one verdict a reader cannot act on:
+        # it reaches the report as "this bump reaches past the manifest" over a
+        # blank list. No rule applied is the honest answer.
+        return {
+            "verdict": UNDERIVABLE,
+            "ecosystem": ecosystem,
+            "beyond": [],
+            "why": (
+                "every changed file is a manifest and none of them is a lockfile this "
+                "plugin covers — there is no scope rule to apply, so the gate was not "
+                "evaluated. Report the boundary"
+            ),
+            **common,
+        }
+    return {
+        "verdict": "beyond",
+        "ecosystem": ecosystem,
+        "beyond": beyond,
+        "why": (
+            "the diff matches no manifest this plugin knows and is not confined to workflow files"
+        ),
+        **common,
+    }
+
+
 def discover(owner: str, name: str, number: int) -> dict[str, Any]:
     repo = _required(["api", f"repos/{owner}/{name}"], f"{owner}/{name}")
     pull = _required(["api", f"repos/{owner}/{name}/pulls/{number}"], f"PR #{number}")
@@ -289,6 +560,23 @@ def discover(owner: str, name: str, number: int) -> dict[str, Any]:
     perms = repo.get("permissions")
     classification = classify(pull, perms)
 
+    bp = branch_point(
+        owner,
+        name,
+        number,
+        base_sha or "",
+        commits,
+        bot_authored=classification["is_bot"],
+    )
+    files, source = bump_files(
+        owner,
+        name,
+        [c["sha"] for c in bp["commits_above_base"] if c["bot"]],
+        compare,
+        commits_underivable=bp["commits_underivable"],
+        rewritten=bp["verdict"] == "rewritten",
+    )
+
     return {
         "owner": owner,
         "name": name,
@@ -301,14 +589,8 @@ def discover(owner: str, name: str, number: int) -> dict[str, Any]:
         "created_at": pull.get("created_at") or "",
         "perms": perms,
         "classification": classification,
-        "branch_point": branch_point(
-            owner,
-            name,
-            number,
-            base_sha or "",
-            commits,
-            bot_authored=classification["is_bot"],
-        ),
+        "branch_point": bp,
+        "scope": scope(files, source),
     }
 
 
@@ -359,7 +641,7 @@ def render(report: dict[str, Any]) -> None:
 
     if bp["verdict"] == "rewritten":
         print("\n    SUBSTITUTE, and report the rewritten base as its own finding:")
-        print("      Phase 1 takes its scope diff from `pr-<N>^..pr-<N>`")
+        print("      Phase 1's gate is unaffected — it reads the bot's own commits")
         print("      Phase 4 measures in $SCRATCH/tip-<N>, not $SCRATCH/base-<N>")
         print("    'The base branch was rewritten' and 'this bump reaches beyond the")
         print("    manifest' produce the same diff and are not the same finding.")
@@ -370,6 +652,32 @@ def render(report: dict[str, Any]) -> None:
         print("\n    Not sufficient to substitute on: a merge of the base *into* the")
         print("    branch looks similar and leaves the merge base correct. Read the")
         print("    commits above before deciding.")
+
+    sc = report["scope"]
+    print(f"\n=== scope: {sc['verdict'].upper()}  [{sc['ecosystem']}]")
+    print(f"    {sc['why']}")
+    print(f"    read from {sc['source']}")
+    for filename in sc["files"]:
+        print(f"      {filename}")
+    if sc["comment_lines"]:
+        print(f"    {sc['comment_lines']} changed line(s) are comments, inside the pin but")
+        print("    worth reading: a compiler that emits workflows records its pins in")
+        print("    one, and a generated file makes this bump transient (Phase 7 row).")
+    if sc["beyond"] and sc["beyond"] != sc["files"]:
+        # Suppressed when they are the same list: on an unrecognised manifest
+        # every file is beyond the pin, and printing the set twice pads the one
+        # output a reader is most likely to quote into the report.
+        print("    beyond the pin:")
+        for line in sc["beyond"]:
+            print(f"      {line}")
+    if sc["beyond"] or sc["verdict"] == "beyond":
+        print("\n    Phase 1 is a gate. Report this and STOP before Phase 4 — the")
+        print("    read-only phases refusing to hand a shell to the PR is what the")
+        print("    ordering buys, and continuing anyway spends it for nothing.")
+    elif sc["verdict"] == UNDERIVABLE:
+        print("\n    Not a clean scope. The gate could not be evaluated, and `clean`")
+        print("    is the answer that lets Phases 4 and 5 run — say so in the report")
+        print("    rather than reading silence as nothing to object to.")
 
     print(f"\n=== execution: {'PHASES 4 AND 5 MAY RUN' if cls['execute'] else 'USE --no-execute'}")
     print(f"    author {cls['author']}, cross-repository={str(cls['cross_repository']).lower()}")
@@ -407,6 +715,11 @@ def analyse(report: dict[str, Any]) -> dict[str, Any]:
         findings.append("non-bot commits above the base, with no force-push event")
     if not cls["execute"]:
         findings.append("Phases 4 and 5 must not run: " + "; ".join(cls["reasons"][:1]))
+    sc = report["scope"]
+    if sc["verdict"] == "beyond":
+        findings.append("Phase 1's scope gate fired: " + sc["why"])
+    elif sc["verdict"] == UNDERIVABLE:
+        findings.append("Phase 1's scope gate could not be evaluated: " + sc["why"])
     report["findings"] = findings
     return report
 
@@ -445,9 +758,16 @@ def shell(report: dict[str, Any]) -> None:
         else:
             print(f"# {key} is {state(value)} — deliberately unset, so a later")
             print("#   phase fails on an empty value rather than a plausible one")
-    bp, cls = report["branch_point"], report["classification"]
+    bp, cls, sc = report["branch_point"], report["classification"], report["scope"]
     print(f"BRANCH_POINT={bp['verdict']}")
     print(f"MAY_EXECUTE={'yes' if cls['execute'] else 'no'}")
+    # Phase 1's gate and the ecosystem it was judged under. Both were the
+    # reader's, and both decide whether Phases 4 and 5 get a shell.
+    print(f"ECOSYSTEM={sc['ecosystem']}")
+    print(f"SCOPE_GATE={sc['verdict']}")
+    if sc["verdict"] != "clean":
+        print("#   Not clean. Phase 1 stops the audit here; see the report output")
+        print("#   for which files or lines, and say so rather than continuing")
 
     # Phase 1's scope gate is about what the *bump* changed, and a bot PR's
     # branch is not always all bot: a maintainer can land the fixup the bump
@@ -458,18 +778,17 @@ def shell(report: dict[str, Any]) -> None:
     # more than anywhere else: an *empty* BOT_COMMITS makes `for c in
     # $BOT_COMMITS` iterate zero times, so the gate passes trivially — clean
     # rather than erroring, on the one phase whose whole job is to refuse.
-    split = {
-        "BOT_COMMITS": " ".join(c["sha"] for c in bp["commits_above_base"] if c["bot"]),
-        "HUMAN_COMMITS": " ".join(c["sha"] for c in bp["commits_above_base"] if not c["bot"]),
-    }
-    for key, value in split.items():
-        if not bp["commits_underivable"] and state(value) == DERIVED:
-            print(f'{key}="{value}"')
-        else:
-            print(f"# {key} is {'underivable' if bp['commits_underivable'] else ABSENT}")
-    if bp["commits_underivable"] or state(split["BOT_COMMITS"]) != DERIVED:
-        print("#   Phase 1 gates on the whole $BASE_SHA..pr-<N> diff and reports")
-        print("#   the split as underivable. An empty gate list would pass silently")
+    # Only the human half crosses. `$BOT_COMMITS` was emitted for Phase 1 to
+    # iterate, and `$SCOPE_GATE` above is the answer that loop was computing — so
+    # emitting it as well would leave the shell holding everything it needs to
+    # roll a second gate by hand, which is how the prose copy and the script copy
+    # drift. It stays in the report output and in `--json`, where it is evidence
+    # rather than an input. The human half has no script consumer and still does.
+    humans = " ".join(c["sha"] for c in bp["commits_above_base"] if not c["bot"])
+    if not bp["commits_underivable"] and state(humans) == DERIVED:
+        print(f'HUMAN_COMMITS="{humans}"')
+    else:
+        print(f"# HUMAN_COMMITS is {'underivable' if bp['commits_underivable'] else ABSENT}")
 
 
 def main() -> int:

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -63,6 +63,30 @@ def pull(
     }
 
 
+def changed(filename: str, patch: str | None = None) -> dict[str, Any]:
+    """One entry of the API's `files` array. `patch` absent is the real shape.
+
+    GitHub omits `patch` for a binary file, and for any file whose diff exceeds
+    its size limit. An omitted patch is the case the gate must not read as "no
+    lines beyond the pin".
+    """
+    record: dict[str, Any] = {"filename": filename, "status": "modified"}
+    if patch is not None:
+        record["patch"] = patch
+    return record
+
+
+def uses_bump(action: str = "actions/checkout") -> str:
+    """The whole content of an ordinary actions bump's diff for one file."""
+    return (
+        "@@ -12,7 +12,7 @@ jobs:\n"
+        "     steps:\n"
+        f"-      - uses: {action}@" + "a" * 40 + "  # v7.0.0\n"
+        f"+      - uses: {action}@" + "b" * 40 + "  # v7.0.1\n"
+        "       - run: make\n"
+    )
+
+
 class DiscoverHarness(unittest.TestCase):
     def _fake(
         self,
@@ -73,6 +97,8 @@ class DiscoverHarness(unittest.TestCase):
         commits: list[dict[str, Any]] | None = None,
         force_pushes: int = 0,
         fails: tuple[str, ...] = (),
+        commit_files: dict[str, list[dict[str, Any]]] | None = None,
+        compare_files: list[dict[str, Any]] | None = None,
     ) -> tuple[Any, list[str]]:
         """A `_gh` returning (exit code, stdout), dispatching on the call shape.
 
@@ -87,6 +113,11 @@ class DiscoverHarness(unittest.TestCase):
                    "created_at": "2026-08-02T00:00:00Z"}] * force_pushes  # fmt: skip
         calls: list[str] = []
 
+        # An ordinary bump, so the pre-existing cases model one. A fake with no
+        # files hands the gate an empty list, which is correctly underivable and
+        # would make every unrelated case fail for the wrong reason.
+        default_files = [changed("uv.lock"), changed("pyproject.toml")]
+
         def fake(args: list[str]) -> tuple[int, str]:
             joined = " ".join(args)
             calls.append(joined)
@@ -94,6 +125,14 @@ class DiscoverHarness(unittest.TestCase):
             for marker in fails:
                 if marker in joined:
                     return 1, error
+            # The single-commit call is `repos/O/N/commits/<sha>` and the list is
+            # `repos/O/N/pulls/N/commits` — both contain "/commits", so the
+            # single one has to be matched first or it falls through to the list
+            # and the gate reads a commit array as a file array.
+            if "/commits/" in joined:
+                sha = joined.rsplit("/commits/", 1)[1].split()[0]
+                served = default_files if commit_files is None else commit_files.get(sha, [])
+                return 0, json.dumps({"files": served})
             # `/commits` before `/pulls/`: the commits call is a `/pulls/N/commits`
             # URL with `--paginate` after it, so an `endswith` check misses and it
             # falls through to the pull body.
@@ -105,6 +144,8 @@ class DiscoverHarness(unittest.TestCase):
                 body: dict[str, Any] = {}
                 if merge_base is not None:
                     body["merge_base_commit"] = {"sha": merge_base}
+                if compare_files is not None:
+                    body["files"] = compare_files
                 return 0, json.dumps(body)
             if "/issues/" in joined:
                 return 0, json.dumps(events)
@@ -159,7 +200,13 @@ class TestTheBranchPointIsProvedRatherThanAssumed(DiscoverHarness):
         produce the same diff and are not the same finding."""
         fake, _ = self._fake(force_pushes=1)
         _, out, _ = self._run(fake)
-        self.assertIn("pr-<N>^..pr-<N>", out)
+        self.assertIn(
+            "reads the bot's own commits",
+            out,
+            "Phase 1 needs no substitution from 0.29.0 — a commit carries its own "
+            "diff, so there is no range to be wrong about. Saying it still takes "
+            "`pr-<N>^..pr-<N>` would send a reader to build a range by hand",
+        )
         self.assertIn("tip-<N>", out)
 
     def test_a_merge_commit_head_does_not_trigger_the_substitution(self):
@@ -348,10 +395,18 @@ class TestTheScopeDiffIsSplitByAuthorship(DiscoverHarness):
 
     def test_the_two_halves_are_emitted_for_phase_1_to_gate_on(self):
         _, out, _ = self._run(self._mixed(), ["--shell"])
-        self.assertIn(
-            f'BOT_COMMITS="{self.BOT_SHA}"',
+        self.assertNotIn(
+            "BOT_COMMITS=",
             out,
-            "the gate is about what the *bump* changed, and only the bot's own commits are that",
+            "the bot half stopped crossing in 0.29.0: `$SCOPE_GATE` is the answer the "
+            "loop that consumed it was computing, and emitting both leaves the shell "
+            "holding everything it needs to roll a second gate by hand",
+        )
+        self.assertIn(
+            "SCOPE_GATE=clean",
+            out,
+            "the gate is about what the *bump* changed, and only the bot's own commits "
+            "are that — here the human's two commits touch nothing the gate may see",
         )
         self.assertIn(
             f'HUMAN_COMMITS="{self.HUMAN_SHA} {self.MERGE_SHA}"',
@@ -394,9 +449,14 @@ class TestTheScopeDiffIsSplitByAuthorship(DiscoverHarness):
         1's fallback is the old whole-diff gate."""
         fake, _ = self._fake(fails=("/commits",))
         _, out, _ = self._run(fake, ["--shell"])
-        self.assertNotRegex(out, r"(?m)^BOT_COMMITS=")
         self.assertNotRegex(out, r"(?m)^HUMAN_COMMITS=")
-        self.assertIn("# BOT_COMMITS", out, "an underivable output is emitted commented-out")
+        self.assertIn("# HUMAN_COMMITS", out, "an underivable output is emitted commented-out")
+        self.assertIn(
+            "SCOPE_GATE=underivable",
+            out,
+            "and the half that used to be Phase 1's loop says so in its own three "
+            "states rather than handing over an empty list that iterates zero times",
+        )
 
     def test_no_bot_commits_leaves_the_gate_list_unset_rather_than_empty(self):
         """The dangerous shape, and the reason this cannot be a plain join.
@@ -496,6 +556,269 @@ class TestFailureIsNotAFinding(DiscoverHarness):
             main()
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("OWNER/NAME", err.getvalue())
+
+
+class TestThePhase1ScopeGateIsDerivedRatherThanJudged(DiscoverHarness):
+    """Phase 1's gate decided whether Phases 4 and 5 get a shell, by eye.
+
+    The bash block printed a sorted file list and the reader decided whether it
+    was "only the manifest and the lockfile" or "only `uses:` lines". Both rules
+    are mechanical, both fail quietly when misread, and the gate is the one
+    branch in this procedure whose wrong answer hands a shell to code that
+    should not have had one.
+
+    Every case below is a failure the prose already names.
+    """
+
+    BOT_SHA = "1" * 40
+    HUMAN_SHA = "2" * 40
+
+    def _bot_pr(self, files: list[dict[str, Any]], **kw: Any) -> Any:
+        fake, _ = self._fake(
+            commits=[commit(self.BOT_SHA, BOT)],
+            commit_files={self.BOT_SHA: files},
+            **kw,
+        )
+        return fake
+
+    def test_four_workflow_files_of_uses_lines_is_clean_scope(self):
+        """The count-of-files trap, and the one that refuses the ordinary case.
+
+        `actions.md`: "An action is pinned in every workflow that uses it, and a
+        grouped bump moves several actions at once. Measured on `cli/cli`, all
+        three merged: #14091 two files, #13981 three, #14147 four." A gate
+        phrased as "one workflow file" refuses all three, in the report's
+        language for a bump reaching into source.
+        """
+        fake = self._bot_pr(
+            [
+                changed(f".github/workflows/{name}.yml", uses_bump())
+                for name in ("ci", "release", "docs", "nightly")
+            ]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "clean")
+        self.assertEqual(report["scope"]["ecosystem"], "github-actions")
+
+    def test_a_changed_line_that_is_not_a_uses_line_fires_the_gate(self):
+        """The invariant is the kind of line, so a `with:` edit is beyond it."""
+        fake = self._bot_pr(
+            [
+                changed(
+                    ".github/workflows/ci.yml",
+                    "@@ -3,3 +3,4 @@\n"
+                    "-      - uses: actions/setup-python@" + "a" * 40 + "  # v7.0.0\n"
+                    "+      - uses: actions/setup-python@" + "b" * 40 + "  # v7.0.1\n"
+                    "+        with:\n"
+                    "+          python-version: '3.13'\n",
+                )
+            ]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "beyond")
+        self.assertTrue(
+            any("with:" in line for line in report["scope"]["beyond"]),
+            "the gate has to name the line it fired on, or the report cannot say why",
+        )
+
+    def test_a_generated_workflows_pin_manifest_is_not_beyond_the_pin(self):
+        """Measured on `cli/cli` #13981 and #14147, both merged actions bumps.
+
+        `gh-aw` compiles a `.lock.yml` whose header records every action it
+        pinned, so a correct bump changes the `uses:` line **and** the comment
+        recording the same pin:
+
+            @@ -44,7 +44,7 @@
+             # Custom actions used:
+            -#   - actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            +#   - actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+        Read as a line beyond the pin, the gate fires on two of the three PRs
+        `actions.md` cites as the measurement for its own rule — the same false
+        Hold the file-count rule exists to prevent, reached a different way. A
+        YAML comment cannot execute, and the pin it records is the one the
+        `uses:` line already carried into the check.
+        """
+        fake = self._bot_pr(
+            [
+                changed(
+                    ".github/workflows/issue-triage.lock.yml",
+                    "@@ -44,7 +44,7 @@\n"
+                    " # Custom actions used:\n"
+                    "-#   - actions/checkout@" + "9" * 40 + " # v7.0.0\n"
+                    "+#   - actions/checkout@" + "3" * 40 + " # v7.0.1\n"
+                    "@@ -212,7 +212,7 @@ jobs:\n"
+                    "-        uses: actions/checkout@" + "9" * 40 + " # v7.0.0\n"
+                    "+        uses: actions/checkout@" + "3" * 40 + " # v7.0.1\n",
+                )
+            ]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "clean", report["scope"]["beyond"])
+        self.assertEqual(
+            report["scope"]["comment_lines"],
+            2,
+            "counted and reported rather than waved through: a comment manifest is "
+            "how a generated workflow announces itself, which decides a Phase 7 row",
+        )
+
+    def test_a_manifest_and_lockfile_bump_is_clean_scope(self):
+        fake = self._bot_pr([changed("uv.lock"), changed("pyproject.toml")])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "clean")
+        self.assertEqual(report["scope"]["ecosystem"], "uv.lock")
+
+    def test_a_lockfile_bump_reaching_into_source_fires_the_gate(self):
+        fake = self._bot_pr([changed("uv.lock"), changed("src/app/core.py")])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "beyond")
+        self.assertIn("src/app/core.py", report["scope"]["beyond"])
+
+    def test_the_gate_reads_the_bots_commits_and_not_the_whole_branch(self):
+        """`fpga-board-sim` #334, mechanised.
+
+        A maintainer landed the fixup the bump required on the bot's own branch.
+        Gated on the union the audit reported "this bump reaches beyond the
+        manifest and lockfile", stopped before Phase 4 — and merging it was
+        correct. The split already reached the shell in 0.28.0; the gate that
+        consumes it was still the reader's.
+        """
+        fake, _ = self._fake(
+            commits=[
+                commit(self.BOT_SHA, BOT),
+                commit(self.HUMAN_SHA, "a-human", subject="style: reformat docs"),
+            ],
+            commit_files={
+                self.BOT_SHA: [changed("uv.lock"), changed("pyproject.toml")],
+                self.HUMAN_SHA: [changed("docs/guide.md"), changed("src/app/core.py")],
+            },
+        )
+        report = self._json(fake)
+        self.assertEqual(
+            report["scope"]["verdict"],
+            "clean",
+            "the human's files are a finding to report, never the bump's scope",
+        )
+
+    def test_a_file_whose_patch_the_api_withheld_is_underivable_not_clean(self):
+        """No patch is no evidence, and no evidence is not evidence of nothing.
+
+        GitHub omits `patch` for binary files and for any diff past its size
+        limit. Read as "no lines beyond the pin" it passes the gate on the file
+        least entitled to pass it.
+        """
+        fake = self._bot_pr(
+            [
+                changed(".github/workflows/ci.yml", uses_bump()),
+                changed(".github/workflows/big.yml"),
+            ]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+
+    def test_a_patch_withheld_in_one_commit_is_not_covered_by_another(self):
+        """Two of the bot's commits touch one file and only one carries a patch.
+
+        The union has to inherit the *withheld* state, not the readable one. A
+        merged record that keeps the patch it does have reads as "these are the
+        lines that changed", and the lines the API never sent are the ones the
+        gate would have objected to.
+        """
+        second = "4" * 40
+        fake, _ = self._fake(
+            commits=[commit(self.BOT_SHA, BOT), commit(second, BOT)],
+            commit_files={
+                self.BOT_SHA: [changed(".github/workflows/ci.yml")],
+                second: [changed(".github/workflows/ci.yml", uses_bump())],
+            },
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable", report["scope"]["why"])
+
+    def test_an_empty_file_list_is_underivable_rather_than_clean(self):
+        """The zero-iteration trap one artifact along.
+
+        0.28.0 found `for c in $BOT_COMMITS` over an unset variable iterating
+        zero times, so the gate's file list was empty and it passed. An empty
+        list of changed files is the same shape: nothing to object to, and
+        nothing established.
+        """
+        fake = self._bot_pr([])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+
+    def test_a_truncated_file_list_is_underivable_rather_than_clean(self):
+        """The `contexts(first:100)` failure, in a different endpoint.
+
+        The API caps a commit's `files` at 300 and says nothing about the rest,
+        so file 301 is absent and indistinguishable from one that is in scope.
+        """
+        fake = self._bot_pr(
+            [changed(f".github/workflows/w{i}.yml", uses_bump()) for i in range(300)]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+
+    def test_a_manifest_with_no_lockfile_is_underivable_rather_than_a_silent_beyond(self):
+        """A `pyproject.toml`-only bump — pip without a lockfile — names no ecosystem.
+
+        Every changed file is a manifest this plugin knows, so the beyond list
+        filters to empty; the verdict was `beyond` anyway. A gate that fires
+        while naming nothing is the one shape a reader cannot act on, and it
+        would reach the report as "this bump reaches beyond the manifest" with
+        an empty list under it.
+        """
+        fake = self._bot_pr([changed("pyproject.toml")])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+        self.assertEqual(report["scope"]["beyond"], [])
+
+    def test_an_unsupported_ecosystem_is_named_rather_than_gated(self):
+        """A `Cargo.lock` is a boundary, not a scope finding.
+
+        Followed faithfully against a real Cargo bump an improvised recipe
+        returned matching checksums and a clean OSV batch, on a PR that raised
+        the project's minimum Rust version past its own declared floor.
+        """
+        fake = self._bot_pr([changed("Cargo.lock"), changed("Cargo.toml")])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["ecosystem"], "unsupported")
+        self.assertIn("Cargo.lock", report["scope"]["why"])
+
+    def test_a_rewritten_base_with_no_split_leaves_the_scope_underivable(self):
+        """#19's false Hold, in the fallback path.
+
+        With `$BOT_COMMITS` underivable the gate falls back to the whole diff —
+        and under a rewritten base that diff is the entire divergence, which is
+        exactly the input that reported a two-file bump as fourteen files and
+        3,682 deletions.
+        """
+        # `commits=None` means "use the harness default"; an unreadable list is
+        # a failing call, which is the state the shell emits commented-out.
+        fake, _ = self._fake(
+            fails=("/pulls/1/commits",),
+            force_pushes=1,
+            compare_files=[changed("uv.lock"), changed("src/app/core.py")],
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+
+    def test_the_gate_reaches_the_shell_for_phase_1_to_read(self):
+        fake = self._bot_pr([changed("uv.lock"), changed("pyproject.toml")])
+        _, out, _ = self._run(fake, ["--shell"])
+        self.assertIn("ECOSYSTEM=uv.lock", out)
+        self.assertIn("SCOPE_GATE=clean", out)
+
+    def test_a_fired_gate_is_a_finding_and_a_clean_one_is_not(self):
+        beyond = self._bot_pr([changed("uv.lock"), changed("src/app/core.py")])
+        code, out, _ = self._run(beyond)
+        self.assertEqual(code, 1)
+        self.assertIn("=== scope: BEYOND", out)
+
+        clean = self._bot_pr([changed("uv.lock"), changed("pyproject.toml")])
+        code, out, _ = self._run(clean)
+        self.assertEqual(code, 0)
+        self.assertIn("=== scope: CLEAN", out)
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -388,7 +388,7 @@ class TestNoRepoSpecificLiterals(SkillHarness):
         that reaches into source.
         """
         self.assertIn(
-            "pr-<N>^..pr-<N>",
+            "reads the bot's own commits",
             self.text,
             "the fallback diff for a rewritten base must be the bot's own commit",
         )
@@ -850,12 +850,25 @@ class TestTheScopeGateIsAboutTheBumpNotTheBranch(SkillHarness):
     """
 
     def test_phase_1_gates_on_the_bots_own_commits(self):
+        """Moved from the shell to the prose in 0.29.0, with the rule itself.
+
+        The block used to iterate `$BOT_COMMITS` and the reader judged the file
+        list; `discover.py` derives both now, so what `SKILL.md` still owes the
+        reader is *which diff the gate was taken from* — the claim the report
+        makes. `test_discover.py` holds the mechanism.
+        """
         self.assertIn(
             "$BOT_COMMITS",
-            self.shell[1],
+            dict(self.phases)[1],
             "the gate's invariant is 'did the bump reach past the manifest and "
             "lockfile', not 'did this branch' — and only the bot's commits are "
             "the bump",
+        )
+        self.assertIn(
+            "$SCOPE_GATE",
+            self.shell[1],
+            "and the phase has to read the derived answer, or the gate is stated "
+            "and never consulted",
         )
 
     def test_the_human_half_reaches_phase_1_too(self):
@@ -2113,7 +2126,17 @@ class TestEveryConsumerReloadsTheHandoff(SkillHarness):
                     f"and then iterates it anyway; unset it iterates zero times and "
                     f"the gate passes silently, which is worse than a false Hold",
                 )
-        self.assertGreater(seen, 0, "no phase declares an unset-fallback for a value it gates on")
+        if not seen:
+            # From 0.29.0 nothing in SKILL.md hand-iterates a gating handoff
+            # value — `discover.py` derives the gate and its fallback. The
+            # per-loop check above still covers anything that comes back; this
+            # is what stops the class becoming a silent no-op in the meantime.
+            self.assertIn(
+                "$SCOPE_GATE",
+                dict(self.phases)[1],
+                "nothing gates on a handoff list any more and Phase 1 does not read "
+                "the derived gate either — the gate has gone missing rather than moved",
+            )
 
 
 class TestEveryEmittedOutputIsConsumedOrDeclaredInert(SkillHarness):
@@ -2411,8 +2434,8 @@ class TestTheScopeGateChecksWhatProducesItsEvidence(SkillHarness):
         against a comment. Requiring a `$` is what separates a use from a mention,
         the same discriminator the MAY_EXECUTE guard needs.
         """
-        found = [c for _, _, c in _every_block() if re.search(r"\$\{?BOT_COMMITS", c)]
-        self.assertTrue(found, "no block gates on $BOT_COMMITS")
+        found = [c for _, _, c in _every_block() if re.search(r"\$\{?HUMAN_COMMITS", c)]
+        self.assertTrue(found, "no block reads $HUMAN_COMMITS")
         self.assertEqual(len(found), 1, f"expected one gate block, found {len(found)}")
         return found[0]
 
@@ -2468,7 +2491,10 @@ class TestTheScopeGateChecksWhatProducesItsEvidence(SkillHarness):
                 f"Exit 2 is this plugin's `could not run`, and it is the honest "
                 f"answer: no evidence is not evidence of nothing",
             )
-        self.assertGreaterEqual(seen, 2, "the gate should capture both halves of the split")
+        # One from 0.29.0: the bot half is `discover.py`'s and never reaches a
+        # shell. The human half still is, and is still the shape that discards
+        # git's status when written as a pipeline.
+        self.assertGreaterEqual(seen, 1, "the reported half of the split is still captured")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Phase 1's gate is the branch that decides whether Phases 4 and 5 get a shell, and its rule was already deterministic in both ecosystems — for a lockfile bump, *"the diff should touch **only** the manifest and the lockfile"*; for actions, `actions.md`'s *"every changed line across them is a `uses:` line…"*. A file-set test and a line-kind test. The block under them printed a sorted file list and left the decision to whoever read it.

**What it did when it ran.** `fpga-board-sim` #334 — the bot's bump, a maintainer's `style: reformat docs for ruff 0.16` fixup landed on the bot's own branch, then a merge of `main` — was reported as eight files *"reaching beyond the manifest and lockfile"*, and the audit stopped **before Phase 4**. Phase 4 was the phase that would have measured `ruff` 0.15.22 → 0.16.0, this plugin's founding observation, occurring for real. 0.28.0 emitted the authorship split; the loop that consumed it stayed in the shell, so the judgement stayed with the reader.

`discover.py` now reads the files **the bot's own commits** changed and answers in Phase 0's three states. Reading each commit on its own is also what makes it immune to a rewritten base — a commit carries its own diff, no range is involved — so Phase 1 needs no substitution at all.

`$BOT_COMMITS` stops crossing the shell boundary: `$SCOPE_GATE` is the answer the loop that consumed it was computing, and emitting both leaves the shell holding everything it needs to roll a second gate by hand. `$ECOSYSTEM` crosses too, settling which Phase 1/3/4/5 method applies rather than leaving it inferred.

### Three defects in this change itself, folded in rather than deferred

- **The first line rule failed two of the three PRs the rule cites.** Written from `actions.md`'s *"trailing version comment"*, it fired on `cli/cli` #13981 and #14147 — a compiler that emits workflows records its pins in a header comment block, so a correct bump changes the `uses:` line **and** the comment naming the same pin. That is the false Hold the file-count rule exists to prevent, reached a different way, and the synthetic patches in the first test pass could not see it. `actions.md` is corrected in the second commit: it was the source of the defect, not merely imprecise.
- **A patch withheld in one of the bot's commits was covered by another's**, so the readable half read as the whole change.
- **The unrecognised-manifest branch could answer `beyond` while naming nothing**, on a `pyproject.toml`-only bump where the filter empties — the one verdict a reader cannot act on.

### Two pre-existing defects it exposed

Removing Phase 1's `[ "$BRANCH_POINT" = rewritten ]` branch left `$BRANCH_POINT` with no shell consumer, and 0.26.1's completeness guard said so. Following it found the block creating `$SCRATCH/tip-<N>` running **unconditionally** under a paragraph saying to run it only when the base was rewritten — 0.28.0's own lesson, one phase along. And two places claimed *"Phase 1 takes its scope diff from `pr-<N>^..pr-<N>`"*, which is no longer true anywhere.

### Cost

`SKILL.md` −992 B (~−248 tok, re-read every turn); `discover.py`'s output +43 to +133 tok, paid from the turn it lands on. About **−11,000 token-turns a run** for a lockfile bump, −7,000 for the worst actions case. The saving is real and it is not the reason: a rule in prose costs tokens every turn *and* can be misapplied, and this one was misapplied on the PR that mattered most.

### Tests

Fifteen cases in `tests/test_discover.py`, each a failure the prose already names. **Six load-bearing behaviours mutation-checked**, each caught by exactly the intended case. Five prose guards moved with the rule rather than being deleted — `test_phase_1_gates_on_the_bots_own_commits` now reads Phase 1's prose and requires the shell to consult `$SCOPE_GATE`; the unset-fallback canary asserts the gate moved rather than vanished.

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim #334`

Under `claude -p --plugin-dir`, fresh context, unreleased plugin. Phase 0's report:

```
=== scope: CLEAN  [uv.lock]
    every changed file is the manifest or the lockfile
    read from the bot's own commits
      pyproject.toml
      uv.lock

=== execution: PHASES 4 AND 5 MAY RUN
    author dependabot[bot], cross-repository=false

RESULT: ORDINARY — 0 finding(s)
```

Phase 1's block then ran as written and passed:

```
REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-334}"
. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }

echo "ecosystem: $ECOSYSTEM"
HUMANS=$(for c in $HUMAN_COMMITS; do git show --name-only --format= "$c" || exit 1; done) \
  || { echo "cannot read a commit in \$HUMAN_COMMITS" >&2; exit 2; }
printf '%s\n' "$HUMANS" | sort -u
[ "$SCOPE_GATE" = clean ] \
  || { echo "scope $SCOPE_GATE — report it, and STOP before Phase 4" >&2; exit 1; }
```

The audit **continued into Phase 2**, reading `ruff` 0.16.0's release notes — the phase the gate used to stop one short of. The run ended on a spend limit rather than a verdict; what it establishes is the gate, and the gate is what changed.

Every documented case, live against `discover.py`:

| PR | Result |
|---|---|
| `fpga-board-sim` #363 — `setup-uv` 9.0.0 → 10.0.1 | `CLEAN [github-actions]` |
| `fpga-board-sim` #364 — grouped `python-deps`, 3 updates | `CLEAN [uv.lock]` |
| `fpga-board-sim` #334 — bot + human fixup + merge | `CLEAN [uv.lock]` — the false Hold, closed |
| `cli/cli` #14091 / #13981 / #14147 — two, three, four files | `CLEAN [github-actions]`, all three |
| `cli/cli` #14049 — two-parent head | `CLEAN [github-actions]`, base not substituted |
| `dependabot-audit` #60 — human PR, no bot commit | `BEYOND [unknown]`, the four files 0.28.0 named |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
