### PR TITLE
The first uv.lock replay: reach the scripts from the handoff, and close four Phase 2/4/5 gaps (0.30.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,214 @@ patch.
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-08-24
+
+The `uv.lock` path had never been replayed in a fresh context. `fpga-board-sim`
+#363 is a `setup-uv` bump, and every round of the replay gate since 0.24.0 rode
+on it — so fifteen versions of the Python method shipped without a run against
+it. The first one handed back five things, and one of them was a line that could
+never have worked. Minor: it changes what Phase 2 verifies, what Phase 5's row
+asserts, and what Phase 0 hands over.
+
+### `references/uv-lock.md` named its scripts with a token nothing expands
+
+Two measurements this repo already had, never put together:
+
+- **0.24.0**: `${CLAUDE_PLUGIN_ROOT}` is expanded *textually at skill load*, into
+  `SKILL.md`'s injected text. That is why Phase 0's `D=` line resolves.
+- **#52**: `$CLAUDE_PLUGIN_ROOT` is *empty* in the Bash tool's environment —
+  `ROOT=[]`, marketplace install and `--plugin-dir` alike.
+
+A reference file is never injected. The model reads it off disk, so the token
+reaches the shell intact and the path collapses. Measured, both spellings, with a
+real handoff:
+
+| `S=` as the file wrote it | resolves to |
+|---|---|
+| `${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py` | `/skills/dependabot-audit/scripts/audit.py` — **exit 2** |
+| `${SCRIPTS:?not in the handoff — re-run Phase 0}/audit.py` | the real file |
+
+`references/actions.md` contains no occurrence, which is the whole reason three
+replay rounds on an actions bump never ran one.
+
+**#52 named this and closed with it still in.** Its premise was that *every*
+handoff fails and every audit silently substitutes an absolute path; 0.24.0
+corrected that for `SKILL.md` and nobody re-checked the files the harness never
+touches. Its option 1 is what ships here:
+
+> Drop the variable and have Phase 0 derive the plugin root once […] into a Phase
+> 0 output the later phases consume.
+
+`discover.py --shell` now emits `SCRIPTS=`, from
+`os.path.dirname(os.path.realpath(__file__))`. Derived rather than named, which
+also closes the hazard 0.23.0 flagged from the other side: an invented
+`export CLAUDE_PLUGIN_ROOT=…/0.22.1` pins a release into a cache that keeps every
+older copy, and carried forward it audits with a stale plugin silently and
+successfully. **A path taken from the file that just ran cannot name a different
+copy than the one running.** Phase 6's `ci_state.py` moved to the same spelling,
+so exactly one line in the plugin depends on the substitution — Phase 0's
+bootstrap — and a guard holds it there.
+
+### Phase 5 could report a green install of an environment without the package
+
+And the hand-back's reason for it was wrong, which is worth more than the fix.
+
+It proposed `uv sync --locked --group dev`, because *"for a dev-dependency bump
+the plain form installs none of the packages under audit"*. Measured on uv 0.12.5
+against a project with two groups:
+
+| Command | a `dev` package | a package in any other group |
+|---|---|---|
+| `uv sync --locked` | **installed** | absent |
+| `uv sync --locked --group lint` | installed | **installed** |
+
+`default-groups` defaults to `["dev"]`. `fpga-board-sim` declares its group as
+`dev` and has no `[tool.uv]` table at all, so the flag was a no-op and Phase 5
+did exercise the bump. **The row underneath is the defect**: a bump into `lint`,
+`test`, `docs` — or anything once `default-groups` is narrowed — is not
+installed, nothing fails, and the phase reports a reproduction for an environment
+that never held the package the PR is about.
+
+So the fix is not the flag. It is the fourth qualifier in the table Phase 5
+already keeps — *which install*, *which interpreter*, *which forks*, and now
+**which groups** — plus the reconciliation that closes it: Phase 1 derived which
+packages moved, and `uv pip list` will say which ones are there. A memorised
+`--group dev` is a no-op where it was proposed and still wrong where it matters.
+
+### Phase 4 isolated gates that cannot answer without the project
+
+`--no-project` was written for ruff and given for every gate. A type checker
+denied the project's dependencies degrades every expression from them to `Any`
+under `ignore_missing_imports`, and `warn_return_any` — implied by
+`strict = true` — fires on code that is fine. `gate_diff.py` reports the
+difference faithfully; the difference is the environment.
+
+The audited repo documents the trap in its own `.pre-commit-config.yaml`, as the
+reason its mypy hook is local rather than `mirrors-mypy` — and **so does this
+repo's**, one directory over, as the reason `mirrors-mypy` is safe here. Both
+were written before Phase 4 walked into it.
+
+**Measured while fixing it, and not in the hand-back: `--no-project` is not
+isolation.** uv 0.12.5, one command, one difference:
+
+| The working directory | a project dependency, under `--no-project --with …` |
+|---|---|
+| has a `.venv` beside it | **importable**, and the project's own `src/` is on `sys.path` |
+| has none | absent |
+
+The overlay layers on a `.venv` when it finds one. Phase 4's worktree is fresh,
+so isolation is what it gets — the half that is wrong for a type checker. Worth
+knowing anyway: a re-run after anything has synced there is a different
+measurement wearing an identical command, and the phase compares three of them.
+`--with` still pins the version under test without the flag, measured against a
+project locking `iniconfig 2.1.0` where `--with iniconfig==2.0.0` resolves to
+2.0.0.
+
+### Phase 2 called its scope test "one `grep`", and two ordinary cases fall outside it
+
+Both return a confident `inert here` nobody established. `references/uv-lock.md`
+gains a `## Phase 2` section for them, and Phase 2 joins the split phases.
+
+**A changelog entry naming a dependency.** `rumdl` 0.2.60 ships one line —
+`deps: update h2 to 0.4.16`, under **Fixed**, no `Security` heading — and that is
+RUSTSEC-2026-0258 / GHSA-q83h-524g-xf6h, *h2 unbounded empty DATA frames*. The
+crate is Rust inside a Python wheel, so `pip-audit` is clean under both
+`-s pypi` and `-s osv`, correctly, and this repo's config has never heard of
+`h2`. The wheel answers it — PEP 770 puts an SBOM in `.dist-info/sboms/`:
+
+```
+rumdl-0.2.60-py3-none-manylinux_2_28_x86_64.whl   6,657,559 bytes
+  dist-info/sboms/rumdl.cyclonedx.json   CycloneDX 1.5, 178 components
+  h2, reqwest, hyper, jsonschema         absent
+  tokio                                  present — so the document is the shipped set
+```
+
+**`Cargo.lock` says the opposite, and that is the trap.** It records
+`[dev-dependencies]`, and `rumdl`'s `Cargo.toml` at `v0.2.60` has
+`jsonschema = "0.46"` under exactly that heading — which is what pulls `reqwest`
+→ `h2`. Reaching for the lockfile finds the crate and calls it exposure.
+
+A wheel with no SBOM is **`underivable`, never clean**. PEP 770 coverage is
+partial, so absence of the file says nothing about absence of the crate, and the
+recipe exits non-zero saying so rather than printing an empty component list.
+
+**A rule the repo disables.** `rumdl` 0.2.59 fixed a *destructive* autofix — "stop
+reflow from joining a setext heading into its underline" — in a repo running
+`rumdl check --fix` on every Markdown commit. `disable = ["MD013", "MD036"]` is a
+claim about a file; the verdict is about the tool:
+
+```
+$ uv run rumdl check README.md                 Success: No issues found
+$ uv run rumdl check --no-config README.md     Issues: Found 32 issues
+```
+
+That is Phase 6's rule one phase over. A red check does not carry a verdict until
+it is attributed; a config line does not carry `inert` until the tool has been run
+both ways. The hand-back classified this row **correct** — ordinary judgement, not
+a gap — and it is promoted because the judgement was right and the procedure did
+not ask for it.
+
+### Tests
+
+Fifteen guards in `tests/test_skill_prose.py`, four classes, every one
+mutation-checked against the prose or the code it was written for, with the
+mutation asserted to have landed before the result was read.
+
+**Two did not discriminate as first written, and both are the house failure.**
+One asserted `"group"` appeared in Phase 5 and passed against `grouped`,
+`--group` and `default-groups` alike; it now reads the qualifier *table*. The
+other asserted `uv pip list` and passed against prose that has printed the
+installed versions since 0.20.0 to answer a different question — the same shape
+as the 0.24.0 guard satisfied by a narrative quoting the string it looked for. It
+now asserts the filter is fed from the set Phase 1 derived.
+
+`reachable()` had to learn the new spelling in the same commit, and the reason is
+its own docstring: converting Phase 6's `C=` line silently emptied
+`reachable(6)`, and four guards asserting on `ci_state.py`'s query went to
+matching nothing. They failed loudly, which is the only reason this is a footnote
+rather than an entry of its own.
+
+### The replay
+
+`fpga-board-sim` #365 — a grouped `python-deps` bump, mypy 2.3.0 → 2.3.1, ruff
+0.16.3 → 0.16.4, rumdl 0.2.55 → 0.2.58 — audited end to end in a fresh context
+via `claude -p --plugin-dir`, execution authorised deliberately because Phase 4
+and Phase 5 both changed and `fpga-board-sim` is a repo this account can push to.
+Checked against the session transcript's actual `Bash` calls, not the report's
+recollection.
+
+**It ran out of budget at Phase 7 and never printed a report, so there is no
+verdict and no Phase 8 hand-back from it.** What it did reach is every surface
+this release changes, and the transcript is the record:
+
+| Changed here | What the run did with it |
+|---|---|
+| `SCRIPTS=` in the handoff | emitted, sourced, and `S="${SCRIPTS:?…}/audit.py"` resolved — the Phase 1 block ran **as written** and verified all three packages against PyPI |
+| § Phase 2, the SBOM recipe | run against `rumdl` 0.2.58: `h2 -> no`, `hyper -> no`, `reqwest -> no`, `jsonschema -> no`, `tokio -> YES` |
+| § Phase 2, the config differential | `rumdl check README.md` clean against `--no-config` finding 32, reproduced — then it went further and grepped the repo for setext headings, which is the question behind the question |
+| § Phase 4, no `--no-project` for a type checker | `uv run --group dev --with mypy==2.3.0/2.3.1 mypy .`, both `Success: no issues found in 157 source files`. Under the old recipe those 157 files would have been resolved against nothing |
+| § Phase 5, reconcile against Phase 1's set | `uv pip list --format=freeze \| grep -iE '^(mypy\|ruff\|rumdl)='` → `mypy==2.3.1 ruff==0.16.4 rumdl==0.2.58`, and it read `[tool.uv]` for `default-groups` unprompted |
+
+**And it found a defect in the Phase 4 prose written one hour earlier.** Dropping
+`--no-project` means the diagnostics comparison is a capture of `uv run`, and the
+first invocation provisions the environment while the second does not. Both mypy
+runs printed `Success: no issues found in 157 source files`; the diff came back
+eight lines long, every one of them uv's own `Creating virtual environment` /
+`Installed 35 packages` / hardlink warning. A read-only gate has no tree diff to
+fall back on, so that capture *is* the measurement — a false difference of
+exactly the kind this phase exists to catch, introduced by the fix for the last
+one. Folded in rather than filed.
+
+Two deviations visible in the transcript, both minor: a repeat `gate_diff.py`
+call abbreviated `G="${SCRIPTS:?…}"` to `G="$SCRIPTS"`, dropping the fail-loudly
+guard the file writes; and `gate_diff.py --help` was invoked by absolute path for
+reconnaissance before first use. Neither changed a result.
+
+`uv sync --locked --no-build --no-install-project` failed on `actionlint-py`,
+exit 2, and step 2 succeeded — the known sdist-only case, reproduced, not a
+finding against this bump.
+
+
 ## [0.29.0] — 2026-08-22
 
 Phase 1's scope gate — the branch that decides whether Phases 4 and 5 get a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3486,7 +3486,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.26.1...v0.27.0

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -118,6 +118,9 @@ Source the outputs rather than transcribing them. Four of them are
 defines:
 
 ```bash
+#   SCRIPTS=<abs path>     this plugin's own scripts/ — the one output not about
+#                          the PR. Derived from discover.py's own location, so a
+#                          reference can name a script; see below
 #   DEFAULT=<branch>       the repo's default branch, derived
 #   HEAD_SHA=<40 hex>      the commit under audit
 #   BASE_REF=<40 hex>      GitHub's own base for the PR
@@ -221,6 +224,7 @@ If either check fails, `git worktree remove` it and re-add.
 
 | | |
 |---|---|
+| `$SCRIPTS` | this plugin's `scripts/` directory, absolute. **This is how `references/*.md` name a script**, and the only output that is not about the PR — `discover.py` derives it from its own location. See the paragraph below for why the references cannot use `${CLAUDE_PLUGIN_ROOT}` and Phase 0 can |
 | `$DEFAULT` | the repo's default branch, derived |
 | `$SCRATCH` | scratch directory, outside the repo — and **derived, so every later call resolves it to the same place**. Nothing else here survives a call boundary, so every consuming block re-derives this and re-sources `phase0.env` before reading any row below |
 | `$HEAD_SHA` | the full 40-character commit under audit |
@@ -236,6 +240,22 @@ If either check fails, `git worktree remove` it and re-add.
 | `$ECOSYSTEM` | `uv.lock`, `github-actions`, `unsupported`, `unknown` or `underivable` — **which Phase 1, 3, 4 and 5 method applies**, derived from the files the bump changed rather than inferred from the PR |
 | `$SCOPE_GATE` | `clean`, `beyond` or `underivable` — **Phase 1's gate, already decided** from the bot's own commits. That is the invariant the gate is about, and it is why `$BOT_COMMITS` does not cross: the loop that consumed it is now the script's |
 | `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
+
+**`$SCRIPTS` is on that list because `${CLAUDE_PLUGIN_ROOT}` reaches only this
+file.** The token is substituted into `SKILL.md`'s *text* at skill load — which
+is why the `D=` line above resolves, and why the variable itself measures empty
+in every shell (`ROOT=[]`, marketplace install and `--plugin-dir` alike). A
+reference file is never injected: the model reads it off disk, so the token
+arrives at the shell intact and the path collapses to
+`/skills/dependabot-audit/scripts/…`. Two lines of `references/uv-lock.md`
+shipped that way from 0.15.0 until the first `uv.lock` replay ran them.
+
+So the bootstrap happens **once, here**, and everything downstream derives from
+it. `discover.py` reports its own directory, and a path taken from the file that
+just ran cannot name a different copy than the one running — which is also the
+answer to the stale-cache hazard, where an invented
+`export CLAUDE_PLUGIN_ROOT=…/0.22.1` pins a release into a cache that keeps every
+older version and then audits with it, silently and successfully.
 
 **`$PERMS` is not on that list, and the distinction is the point.** It is read off
 `discover.py`'s report *here in Phase 0*, where the execution gate and the
@@ -638,10 +658,26 @@ takes the verdict from that answer, so it is a finding and not a footnote: read
 the advisory or the bug for the setting, flag or mode it lives in, and grep this
 repo's config for it. A `Security` entry whose leak path the repo never
 configures is a follow-up on the merits; a destructive fix in a write mode the
-repo runs on every commit is not. Same shape of evidence, two urgencies, and the
-distinction is one `grep` — it is the same question Phase 4 asks of an actions
-bump, where `references/actions.md` calls the answer "inert here", a result and
-not silence.
+repo runs on every commit is not. Same shape of evidence, two urgencies — it is
+the same question Phase 4 asks of an actions bump, where `references/actions.md`
+calls the answer "inert here", a result and not silence.
+
+**The grep answers it only when the change is in the tool's own surface**, and
+two cases fall outside that. Both are ordinary, and both return a confident
+`inert here` that was never established:
+
+| The entry names | Why the config cannot answer it | What does |
+|---|---|---|
+| a **dependency** rather than a rule or a flag | it is not in this repo's config, and for a compiled wheel it is not even in this repo's *ecosystem* — a Rust crate inside a Python package, where the advisory lives on crates.io and every PyPI-side scanner is correctly clean | `references/uv-lock.md` § Phase 2 — read the shipped set out of the wheel's own SBOM. `references/actions.md` § Phase 2 for the tag-line question |
+| a rule this repo **disables** | the claim is then about the config *file*, and the verdict is about the *tool*. Config is interpreted: another file can win, a key can be spelled for a different version, a section can go unread | run the gate twice, once with the config and once without, and read the difference |
+
+That second row is Phase 6's rule one phase over. A red check does not carry a
+verdict until it is attributed; a config line does not carry `inert` until the
+tool has been run both ways. Measured on `rumdl` 0.2.59's destructive `MD013`
+fix, against a repo that runs `rumdl check --fix` on every Markdown commit:
+`rumdl check README.md` is clean, `rumdl check --no-config README.md` finds 32.
+The suppression is real — and one command is the difference between reporting
+that and asserting it.
 
 ## Phase 3 — Known vulnerabilities
 
@@ -728,12 +764,16 @@ report.
 
 **Say what the row actually covered.** A green reproduction is true of *one*
 configuration and reads as true of every one, so name which install ran, which
-interpreter produced it, and anything verified but not installed. "Frozen install
-passed under `--no-build --no-install-project` on CPython 3.14; the 3.11 fork of
+interpreter produced it, which dependency groups it covered, and anything
+verified but not installed. "Frozen install passed under `--no-build
+--no-install-project` on CPython 3.14, `dev` group included; the 3.11 fork of
 `rpds-py` was verified but not installed" is a stronger row than "frozen install
-passed", because it is one a reader can falsify. `uv run python -V` from inside
-the synced environment is where the interpreter comes from — not the auditor's
-own `python3` — and `resolution-markers` is why the two can differ.
+passed", because it is one a reader can falsify. A bump into a group the sync
+does not install is absent from the environment with nothing to show for it —
+the reference has the measurement and the reconciliation that catches it.
+`uv run python -V` from inside the synced environment is where the interpreter
+comes from — not the auditor's own `python3` — and `resolution-markers` is why
+the two can differ.
 
 Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing suite sails
 through; use `set -o pipefail` or separate calls.
@@ -781,7 +821,7 @@ answering in a well-formed way. A hand-run query cannot be regression-tested.
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
-C="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/ci_state.py"
+C="${SCRIPTS:?not in the handoff — re-run Phase 0}/ci_state.py"
 PARENT=$(git rev-parse "pr-<N>^") \
   || { echo "cannot resolve pr-<N>^ — was the ref fetched?" >&2; exit 2; }
 

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -31,7 +31,7 @@ tree:
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
-S="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/audit.py"
+S="${SCRIPTS:?not in the handoff — re-run Phase 0}/audit.py"
 
 git show "pr-<N>:uv.lock"    > "$SCRATCH/pr.uv.lock"
 git show "$BASE_SHA:uv.lock" > "$SCRATCH/base.uv.lock"
@@ -127,6 +127,107 @@ hand, do not assume one block per name. Do not report the *lower* block as stale
 — but do check the highest one, which carries markers just the same and is still
 expected to track the registry.
 
+## Phase 2 — Currency
+
+The mechanical half — the registry's true latest, with publish timestamps — is
+**already done** by the Phase 1 script. What is left is the question `SKILL.md`
+sends here: this repo runs the tool, so is it in the change's scope?
+
+### When the changelog entry names a dependency
+
+A compiled Python package vendors another ecosystem's dependency graph into its
+wheel — `ruff`, `uv`, `rumdl` and `pydantic-core` are Rust — and its changelog
+says so in the terms of *that* ecosystem. Two consequences, and the second is the
+one that bites:
+
+- **No Python-side scanner can see the advisory.** It is filed against a crate on
+  crates.io. `pip-audit` reporting clean under both `-s pypi` and `-s osv` is
+  correct and means nothing here.
+- **Grepping this repo's config answers nothing**, because the crate was never in
+  this repo's config. The question is whether it is in the binary this repo
+  installs.
+
+**Read the shipped set out of the wheel.** PEP 770 wheels carry their own SBOM:
+
+```bash
+python3 - "<pkg>" "<version>" <<'EOF'
+import io, json, sys, urllib.request, zipfile
+pkg, version = sys.argv[1], sys.argv[2]
+req = urllib.request.Request(f"https://pypi.org/simple/{pkg}/",
+                             headers={"Accept": "application/vnd.pypi.simple.v1+json"})
+files = json.load(urllib.request.urlopen(req, timeout=60))["files"]
+# Any wheel for the release: the vendored set is the same across platforms.
+name = f"{pkg}-{version}-"
+wheels = [f for f in files
+          if f["filename"].startswith(name) and f["filename"].endswith(".whl")]
+if not wheels:
+    sys.exit(f"no wheel for {pkg} {version} — sdist-only, or a version that is not there")
+wheel = wheels[0]
+zf = zipfile.ZipFile(io.BytesIO(urllib.request.urlopen(wheel["url"], timeout=180).read()))
+found = [n for n in zf.namelist() if "/sboms/" in n]
+if not found:
+    sys.exit(f"{wheel['filename']} carries no SBOM — exposure is UNDERIVABLE, not clean")
+for name in found:
+    doc = json.loads(zf.read(name))
+    print(name, doc.get("bomFormat"), doc.get("specVersion"),
+          len(doc.get("components", [])), "components")
+    print(sorted(c["name"] for c in doc.get("components", [])))
+EOF
+```
+
+Measured on the case this section came from. `rumdl` 0.2.60's release notes carry
+one line — `deps: update h2 to 0.4.16`, under **Fixed**, with no `Security`
+heading — and that is RUSTSEC-2026-0258, *h2 unbounded empty DATA frames*:
+
+| Question | Answer |
+|---|---|
+| `rumdl-0.2.60-py3-none-manylinux_2_28_x86_64.whl` | `dist-info/sboms/rumdl.cyclonedx.json`, CycloneDX 1.5, 178 components |
+| `h2` among them | **no** — nor `reqwest`, `hyper`, `jsonschema` |
+| `tokio` among them | yes, so the SBOM is the real shipped set and not a stub |
+
+Not exposed, established rather than assumed.
+
+**`Cargo.lock` would have said the opposite, and that is the trap.** It records
+`[dev-dependencies]`, which are built for the project's own tests and are not in
+the binary anyone installs. `rumdl`'s `Cargo.toml` at `v0.2.60` has
+`jsonschema = "0.46"` under exactly that heading, and `jsonschema` is what pulls
+`reqwest` → `h2`. Reaching for the lockfile finds the crate and calls it
+exposure. The SBOM is the shipped set.
+
+**A wheel with no SBOM is `underivable`, never clean.** PEP 770 is recent and
+coverage is partial, so absence of the file says nothing about absence of the
+crate. Report it the way Phase 0 reports an output it could not derive — the
+distinction this plugin preserves everywhere else — and say which of the two the
+row is.
+
+### When the entry names a rule this repo disables
+
+Then the claim rests on a config line, and a config line is an assertion about a
+*file* while the verdict is about the *tool*. Run it both ways:
+
+```bash
+uv run <tool> check <one representative file>              # as this repo runs it
+uv run <tool> check --no-config <the same file>            # with the config out
+```
+
+Measured on `rumdl` 0.2.59's destructive `MD013` fix — *"stop reflow from joining
+a setext heading into its underline"* — in a repo running `rumdl check --fix` on
+every Markdown commit, where the claim was `disable = ["MD013", "MD036"]`:
+
+```
+$ uv run rumdl check README.md
+Success: No issues found in 1 file (6ms)
+
+$ uv run rumdl check --no-config README.md
+Issues: Found 32 issues in 1 file (14ms)
+```
+
+32 findings suppressed. The rule really is off, the destructive fix really is
+inert here, and the difference between reporting that and asserting it is one
+command. The escape hatch is spelled differently per tool — `--no-config`,
+`--isolated`, `--config=/dev/null` — and every one of them is cheaper than being
+wrong about which mode runs on every commit.
+
 ## Phase 3 — Known vulnerabilities
 
 Batch-query OSV across the whole locked set, then corroborate with the
@@ -163,7 +264,7 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 
 [ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
 
-G="${CLAUDE_PLUGIN_ROOT}/skills/dependabot-audit/scripts/gate_diff.py"
+G="${SCRIPTS:?not in the handoff — re-run Phase 0}/gate_diff.py"
 
 python3 "$G" --tree "$SCRATCH/base-<N>" \
   --run locked   "uv run --no-project --with ruff==<locked> ruff format ." \
@@ -187,6 +288,50 @@ questions, and together they say something neither says alone:
 | differs | agrees | a real behaviour change, and this PR already absorbs it — check *how* |
 | differs | differs | a real behaviour change the PR does **not** handle — it will land on you |
 | agrees | agrees | no behaviour change on this repo's code |
+
+**`--no-project` is right for a self-contained tool and wrong for a gate that
+imports the project.** ruff needs nothing but the files; a type checker or a test
+suite needs the project's dependencies to say anything true. Denied them, every
+expression coming from one degrades to `Any` under `ignore_missing_imports`, and
+`warn_return_any` — which `strict = true` implies — then fires on code that is
+fine. `gate_diff.py` reports the difference faithfully and the difference is an
+artifact of the environment. Drop the flag for those gates; `--with` still pins
+the version under test, measured on uv 0.12.5 against a project locking
+`iniconfig 2.1.0`, where `uv run --with iniconfig==2.0.0` resolves to 2.0.0:
+
+```bash
+  --run proposed "uv run --group <group> --with mypy==<proposed> mypy ."
+```
+
+**Compare the tool's output, not `uv run`'s.** The first invocation provisions
+the environment and says so — `Creating virtual environment`, `Installed 35
+packages`, the hardlink warning — and the second, warm, says none of it. Captured
+whole and diffed, every comparison therefore reports a difference on the first
+run alone. Measured on this phase's own replay, where two mypy runs both
+reported `Success: no issues found in 157 source files` and the diff came back
+eight lines long, all of them uv's. Warm the cache with a throwaway run, or strip
+what uv wrote before comparing; a read-only gate has no tree diff to fall back
+on, so this capture *is* the measurement.
+
+Repos that have been bitten by this say so in their own configuration. The one
+this section came from pins its mypy hook local rather than to `mirrors-mypy`,
+and the comment gives the reason: *"the isolated env that mirrors-mypy builds
+lacks those deps, degrading expressions to Any and tripping warn_return_any —
+false failures that CI's `uv run mypy .` never sees."*
+
+**And `--no-project` does not mean isolated.** Measured, uv 0.12.5, one command
+and one difference:
+
+| The working directory | a project dependency, under `--no-project --with …` |
+|---|---|
+| has a `.venv` beside it | **importable**, and the project's own `src/` is on `sys.path` |
+| has none | absent |
+
+The overlay is layered on a `.venv` when it finds one. Phase 4's worktree is
+fresh, so isolation is what it gets today — which is the half that is wrong for a
+type checker. It is worth knowing anyway, because a re-run after anything has
+synced into that tree is a different measurement wearing an identical command,
+and this phase compares three of them.
 
 **Give the tool's write mode, not `--check`** — the measurement is what each
 version does to the files, and `--check` does nothing to them. Run it once per
@@ -236,6 +381,33 @@ cd "$SCRATCH/pr-<N>"
 uv sync --locked --no-build --no-install-project   # every dep resolved to a wheel
 uv sync --locked                                   # then add the project itself
 ```
+
+**First check that what you installed contains what the PR changed.** uv's
+`default-groups` is `["dev"]`, so the plain command covers a bump into `dev` and
+covers nothing else. Measured on uv 0.12.5:
+
+| Command | a `dev` package | a package in any other group |
+|---|---|---|
+| `uv sync --locked` | **installed** | absent |
+| `uv sync --locked --group <name>` | installed | **installed** |
+
+A bump into `lint`, `test`, `docs` — or into anything at all once
+`tool.uv.default-groups` is narrowed — is therefore *not installed*, and nothing
+fails. Phase 5 then reports a green frozen install for an environment that never
+contained the package under audit, which reads exactly like a reproduction.
+
+The fix is not a flag to memorise: `--group dev` is a no-op where the group is
+already default and still wrong where it is not. **Reconcile instead** — Phase 1
+already derived which packages moved, and the environment will say which ones it
+has:
+
+```bash
+uv pip list --format=freeze | grep -E '^(<the packages Phase 1 named>)='
+```
+
+Every name Phase 1 listed should come back at the version the PR proposes. A name
+that does not is the group question, and re-syncing with `--group <name>` is what
+answers it. Say in the report which groups the row covers.
 
 Step 1 is the one with the security value: if it succeeds, every dependency in
 the lockfile resolved to a **wheel** and no third-party build code ran at all. If
@@ -302,7 +474,7 @@ that was — is honest and is what this phase requires. The second sync is worth
 it when the fork you did *not* install is one of the packages under audit, and
 the report should say which of the two you did.
 
-**Three things qualify this phase's row, and "reproduced" alone asserts past all
+**Four things qualify this phase's row, and "reproduced" alone asserts past all
 of them.** Each has a green result that is true of *one* configuration and reads
 as true of every one:
 
@@ -311,11 +483,12 @@ as true of every one:
 | **which install** | the script-suppressing flags are the documented default and they weaken the proof: a package that genuinely needs its install script is not exercised. Re-running without them is a legitimate choice — say which produced the row |
 | **which interpreter** | the install materialised one fork of a forked lockfile. `uv run python -V`, not the auditor's `python3` |
 | **which forks were only verified** | Phase 1 checked all of them and Phase 5 installed one. Name the others rather than letting the install stand for them |
+| **which groups** | the sync installs the default groups, and a bump outside them is absent with nothing to show for it. Reconcile against the set Phase 1 named, above |
 
-None of the three is a failure to disclose. "Frozen install passed under
-`--no-build --no-install-project` on CPython 3.14; the 3.11 fork of `rpds-py` was
-verified but not installed" is a stronger row than "frozen install passed",
-because it is one a reader can falsify.
+None of the four is a failure to disclose. "Frozen install passed under
+`--no-build --no-install-project` on CPython 3.14, `dev` group included; the 3.11
+fork of `rpds-py` was verified but not installed" is a stronger row than "frozen
+install passed", because it is one a reader can falsify.
 
 Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing suite sails
 through; use `set -o pipefail` or separate calls.

--- a/skills/dependabot-audit/scripts/discover.py
+++ b/skills/dependabot-audit/scripts/discover.py
@@ -752,6 +752,25 @@ def shell(report: dict[str, Any]) -> None:
         ("CREATED_AT", report["created_at"]),
     ]
     print("# Phase 0 outputs. Sourced, not transcribed.")
+
+    # Where this plugin's scripts live, derived from the file emitting the line
+    # rather than named by anyone. It is the one output that is not about the PR,
+    # and it is here because it is the only place the answer is known for certain.
+    #
+    # `${CLAUDE_PLUGIN_ROOT}` is substituted into `SKILL.md`'s *text* at skill
+    # load, so it resolves there and nowhere else. `references/*.md` are read off
+    # disk; the token reaches the shell intact, where the variable is empty and
+    # the path collapses to `/skills/dependabot-audit/scripts/…`. Every reference
+    # block already reloads this handoff, so this is what lets one name a script.
+    #
+    # Deliberately not routed through `state()`: the other outputs can be
+    # underivable, and this one cannot — the script answering is the script being
+    # located. That also settles the version question 0.23.0 raised, where an
+    # invented `export CLAUDE_PLUGIN_ROOT=…/0.22.1` pinned a release into a cache
+    # that keeps every older copy and ran a stale plugin silently. A path taken
+    # from the running file cannot name a version other than the one running.
+    print(f"SCRIPTS={os.path.dirname(os.path.realpath(__file__))}")
+
     for key, value in pairs:
         if state(value) == DERIVED:
             print(f"{key}={value}")

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -46,11 +46,16 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 PLUGIN = ROOT / "skills/dependabot-audit"
 SKILL = PLUGIN / "SKILL.md"
 
-# Names the skill is entitled to use without defining: the harness supplies them.
-# Supplied by the environment, never by a phase, so the forward-reference guard
-# must not read them as outputs one phase owes another. `TMPDIR` joined them in
-# 0.26.0: Phase 0 derives `$SCRATCH` under `${TMPDIR:-/tmp}` so the path is the
+# Names the skill is entitled to use without defining, so the forward-reference
+# guard must not read them as outputs one phase owes another. `TMPDIR` joined them
+# in 0.26.0: Phase 0 derives `$SCRATCH` under `${TMPDIR:-/tmp}` so the path is the
 # same on every call, and macOS sets TMPDIR where Linux leaves it unset.
+#
+# `CLAUDE_PLUGIN_ROOT` is here on a different footing, and the comment used to say
+# "the harness supplies them", which is measurably false — it is empty in every
+# shell. What the harness supplies is the *substitution*, into `SKILL.md`'s text
+# at load. So it resolves in this one file and the guard below is what keeps it
+# there; everywhere else the plugin's scripts are reached through `$SCRIPTS`.
 EXTERNAL = {"CLAUDE_PLUGIN_ROOT", "HOME", "PATH", "IFS", "TMPDIR"}
 
 PHASE_HEADING = re.compile(r"^## Phase (\d+)\b", re.MULTILINE)
@@ -80,6 +85,12 @@ REF_MADE = re.compile(r"git fetch \S+ \"pull/<N>/head:pr-<N>\"")
 # script. Module-level because both the path-existence guard and `reachable()`
 # read it, and two copies would drift.
 PLUGIN_PATH = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([A-Za-z0-9_./-]+)")
+
+# The same handoff as the reader now spells it outside Phase 0's bootstrap:
+# `$SCRIPTS` is the Phase 0 output carrying this plugin's own `scripts/`. The
+# optional `:?message` is bash's fail-on-unset, which the blocks use so an
+# unsourced handoff stops rather than running `/ci_state.py`.
+SCRIPTS_PATH = re.compile(r"\$\{?SCRIPTS(?::[^}]*)?\}?/([A-Za-z0-9_.-]+)")
 
 # A reference the prose hands off to, e.g. `references/actions.md`.
 REFERENCE = re.compile(r"references/([a-z0-9_-]+\.md)")
@@ -141,6 +152,30 @@ def _code_only(source: str) -> str:
     return ast.unparse(tree)
 
 
+def _scripts_named_in(text: str) -> list[pathlib.Path]:
+    """Every plugin script `text` invokes, under either spelling.
+
+    Two exist because only one of them works in only one place. Phase 0
+    bootstraps with `${CLAUDE_PLUGIN_ROOT}`, substituted into `SKILL.md`'s text at
+    skill load; everything after it reads `$SCRIPTS` out of the handoff, because
+    a file the harness never injects reaches the shell with the token intact and
+    an empty variable.
+
+    Kept in one function because `reachable()` and the path-existence guard both
+    ask it, and because forgetting the second spelling is not a loud failure:
+    converting Phase 6's `C=` line silently emptied `reachable(6)`, and four
+    guards asserting on `ci_state.py`'s query went to matching nothing. That is
+    the exact defect the `reachable()` docstring was written for, one spelling
+    later.
+    """
+    found = []
+    for rel in PLUGIN_PATH.findall(text):
+        found.append(ROOT / rel)
+    for name in SCRIPTS_PATH.findall(text):
+        found.append(PLUGIN / "scripts" / name)
+    return [p for p in found if p.suffix == ".py" and p.exists()]
+
+
 def first_phase(hits: dict[str, list[int]], name: str) -> int:
     return min(hits[name])
 
@@ -187,10 +222,8 @@ class SkillHarness(unittest.TestCase):
         for name, section in self._handoffs(number):
             del name
             parts.extend(bash_blocks(section))
-        for rel in PLUGIN_PATH.findall(dict(self.phases)[number]):
-            path = ROOT / rel
-            if path.suffix == ".py" and path.exists():
-                parts.append(_code_only(path.read_text(encoding="utf-8")))
+        for path in _scripts_named_in(dict(self.phases)[number]):
+            parts.append(_code_only(path.read_text(encoding="utf-8")))
         return "\n".join(parts)
 
     def _handoffs(self, number: int) -> list[tuple[str, str]]:
@@ -479,10 +512,15 @@ class TestEveryHandoffLands(SkillHarness):
     breaks the target, and dropping a mention breaks the pointer.
     """
 
-    # Phases doing ecosystem-specific work. Phase 2's uv answer comes out of the
-    # Phase 1 script rather than a section of its own, so it is not on this list;
-    # Phase 6 is ecosystem-independent by construction.
-    SPLIT_PHASES = (1, 3, 4, 5)
+    # Phases doing ecosystem-specific work. Phase 6 is ecosystem-independent by
+    # construction and stays off the list.
+    #
+    # Phase 2 joined in 0.30.0. Its uv answer used to be nothing but the Phase 1
+    # script's `latest` line, which is why it was exempt — but the scope half of
+    # the phase is per-ecosystem and always was: a vendored crate is read out of
+    # a wheel's SBOM, a moving major tag out of a `compare`. Both had a home in
+    # `actions.md` and only one had one anywhere.
+    SPLIT_PHASES = (1, 2, 3, 4, 5)
     ECOSYSTEMS = ("uv-lock.md", "actions.md")
 
     def test_every_split_phase_names_both_ecosystem_references(self):
@@ -2499,3 +2537,297 @@ class TestTheScopeGateChecksWhatProducesItsEvidence(SkillHarness):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestThePluginRootResolvesWhereItIsUsed(SkillHarness):
+    """`references/uv-lock.md` named its scripts with a token nothing expands.
+
+    Two measurements this repo already had, never put together:
+
+    - `${CLAUDE_PLUGIN_ROOT}` is substituted into `SKILL.md`'s **text** at skill
+      load (0.24.0, settled from a 62,674-character injection whose `D=` line
+      reads as an absolute path against a file holding the token on disk).
+    - `$CLAUDE_PLUGIN_ROOT` is **empty** in the Bash tool's environment, on
+      marketplace install and `--plugin-dir` alike (#52, `ROOT=[]`).
+
+    A reference file is never injected — the model reads it off disk — so the
+    token arrives at the shell intact and the path collapses to
+    `/skills/dependabot-audit/scripts/audit.py`. Two lines shipped that way from
+    0.15.0, and `references/actions.md` happens to contain none, which is why
+    three replay rounds on an actions bump never ran one.
+
+    The old guards blessed it: `EXTERNAL` called the variable harness-supplied,
+    and the path check asked only whether the *target file* exists. Both pass on
+    a line that cannot execute.
+    """
+
+    def _docs(self):
+        yield SKILL
+        yield from sorted((PLUGIN / "references").glob("*.md"))
+
+    def test_the_token_is_absent_from_every_file_the_harness_does_not_inject(self):
+        for doc in sorted((PLUGIN / "references").glob("*.md")):
+            found = PLUGIN_PATH.findall(doc.read_text(encoding="utf-8"))
+            self.assertEqual(
+                [],
+                found,
+                f"{doc.name} names ${{CLAUDE_PLUGIN_ROOT}}/{found[0] if found else ''}. "
+                f"Only SKILL.md is substituted at skill load; a reference is read off "
+                f"disk, so the token reaches the shell where the variable is empty and "
+                f"the path resolves to /skills/... — use $SCRIPTS from the handoff",
+            )
+
+    def test_the_bootstrap_happens_once_and_in_phase_0(self):
+        """One line may depend on the substitution, because one line has to."""
+        whole = SKILL.read_text(encoding="utf-8")
+        self.assertEqual(
+            1,
+            len(PLUGIN_PATH.findall(whole)),
+            "SKILL.md should reach the plugin root exactly once — Phase 0's "
+            "bootstrap. Every later use is a second dependency on a substitution "
+            "that holds in one file and one file only",
+        )
+        self.assertTrue(
+            PLUGIN_PATH.search(dict(self.phases)[0]),
+            "the one bootstrap is not in Phase 0, so a phase that runs earlier "
+            "than the derivation depends on it",
+        )
+
+    def test_every_script_reached_through_the_handoff_exists(self):
+        for doc in self._docs():
+            for name in SCRIPTS_PATH.findall(doc.read_text(encoding="utf-8")):
+                self.assertTrue(
+                    (PLUGIN / "scripts" / name).exists(),
+                    f"{doc.name} runs $SCRIPTS/{name}, which is not in scripts/",
+                )
+
+    def test_the_scripts_directory_is_an_output_phase_0_actually_emits(self):
+        self.assertIn(
+            "SCRIPTS",
+            _emitted_by_discover(),
+            "the references name $SCRIPTS and discover.py --shell does not write "
+            "it, so every one of them resolves to /audit.py",
+        )
+
+    def test_the_directory_is_derived_from_the_script_rather_than_written_down(self):
+        """A literal path pins a version; `__file__` cannot name the wrong copy.
+
+        0.23.0 recorded the hazard from the other direction — an invented
+        `export CLAUDE_PLUGIN_ROOT=…/0.22.1` pins a release into a cache that
+        keeps every older copy, and carried forward it audits with a stale plugin
+        silently and successfully. The emitter closes it only while the value
+        comes from the file doing the emitting.
+        """
+        src = (PLUGIN / "scripts/discover.py").read_text(encoding="utf-8")
+        emitter = next(
+            ast.unparse(node)
+            for node in ast.walk(ast.parse(src))
+            if isinstance(node, ast.FunctionDef)
+            and "Phase 0 outputs. Sourced, not transcribed." in ast.unparse(node)
+        )
+        line = next(ln for ln in emitter.splitlines() if "SCRIPTS=" in ln)
+        self.assertIn(
+            "__file__",
+            line,
+            f"SCRIPTS is emitted as {line.strip()!r} rather than derived from the "
+            f"script's own location; a written-down path is one that can name a "
+            f"different version than the one running",
+        )
+
+
+class TestPhase5NamesTheGroupsTheInstallCovered(SkillHarness):
+    """A frozen install can contain none of the packages under audit and pass.
+
+    `uv sync --locked` installs `tool.uv.default-groups`, which defaults to
+    `["dev"]`. Measured on uv 0.12.5 against a project with two groups:
+
+        uv sync --locked                  dev package installed, other absent
+        uv sync --locked --group lint     both installed
+
+    So a bump into `lint`, `test`, `docs` — or into anything once
+    `default-groups` is narrowed — is not installed, nothing fails, and Phase 5
+    reports a green reproduction for an environment that never held the package
+    the PR is about.
+
+    The `fpga-board-sim` #365 hand-back proposed `--group dev` as the fix, on the
+    reasoning that the plain form installs nothing under audit for a dev bump.
+    The table above says otherwise: that repo declares its group as `dev` and no
+    `[tool.uv]` at all, so the flag was a no-op and the bump *was* exercised. The
+    defect is the row underneath, and a memorised flag does not close it — the
+    environment has to be asked, which is what the phase already does for the
+    interpreter and the forks.
+    """
+
+    def test_the_row_is_qualified_by_which_groups_it_covered(self):
+        """Asserted against the qualifier table, not the phase body.
+
+        A body-wide search for "group" passes on `--group`, on `default-groups`,
+        and on the word appearing anywhere at all — mutation-checked and it did.
+        The claim is narrower than that: the table listing what "reproduced"
+        asserts past must carry a row for this, because that table is what a
+        writer reads when composing the row.
+        """
+        qualifiers = [
+            table
+            for table in tables(self.material(5))
+            if any("which install" in row.lower() for row in table)
+        ]
+        self.assertTrue(qualifiers, "Phase 5 has no table of what qualifies its row")
+        rows = "\n".join(qualifiers[0]).lower()
+        self.assertIn(
+            "which groups",
+            rows,
+            "the qualifier table names which install, which interpreter and which "
+            "forks. A bump outside the default groups is absent from the "
+            "environment in the same way and with nothing to show for it, so it "
+            "belongs in the same table rather than in prose beside it",
+        )
+
+    def test_the_default_is_measured_rather_than_assumed_either_way(self):
+        """Both wrong readings are live: that `dev` needs a flag, and that no group does."""
+        phase5 = self.material(5)
+        self.assertIn(
+            "default-groups",
+            phase5,
+            "Phase 5 must name what the plain command actually installs. Without "
+            "it, `--group dev` reads as necessary where it is a no-op and as "
+            "sufficient where the group is called something else",
+        )
+
+    def test_the_installed_set_is_reconciled_against_the_packages_that_moved(self):
+        """Phase 1 derived the set; the environment will say what it has.
+
+        Not `uv pip list` on its own: § Phase 5 has printed the installed
+        versions since 0.20.0, to answer *which interpreter*, and a guard
+        asserting the command passes without the reconciliation ever being
+        written. Mutation-checked, and it did — the same shape as the 0.24.0
+        guard satisfied by a narrative quoting the string it looked for.
+
+        What is new is where the filter comes from. A hand-typed list of names
+        re-introduces the defect one layer up, because the names would be read
+        off the PR title, which a grouped bump does not carry.
+        """
+        self.assertRegex(
+            self.reachable(5),
+            r"uv pip list[^\n]*Phase 1 named",
+            "nothing checks the bumped packages against what was installed. That "
+            "is the one test a wrong dependency group cannot pass, and the set to "
+            "check against has to be the one Phase 1 derived",
+        )
+
+
+class TestPhase4DoesNotIsolateAGateThatNeedsTheProject(SkillHarness):
+    """`--no-project` was written for ruff and applied to every gate.
+
+    A type checker denied the project's dependencies degrades every expression
+    from them to `Any` under `ignore_missing_imports`, and `warn_return_any` —
+    implied by `strict = true` — then fires on code that is fine. `gate_diff.py`
+    reports the difference faithfully; the difference is the environment.
+
+    The repo this came from documents the trap in its own pre-commit config, as
+    the reason its mypy hook is local rather than `mirrors-mypy`. Phase 4 walked
+    into it anyway.
+
+    Measured while fixing it, and not in the hand-back: `--no-project` is not
+    isolation. With a `.venv` beside the working directory the `--with` overlay
+    is layered on it and the project's dependencies are importable; with none
+    they are absent. Same command, uv 0.12.5.
+    """
+
+    def test_the_flag_is_qualified_rather_than_given_for_every_gate(self):
+        phase4 = self.material(4)
+        self.assertIn(
+            "--no-project",
+            phase4,
+            "Phase 4's recipe is built on the flag; the guard below is about "
+            "whether the exception to it is stated",
+        )
+        self.assertRegex(
+            phase4.lower(),
+            r"--no-project[^.]{0,200}(wrong|right for)",
+            "Phase 4 gives `--no-project` three times and never says which gates "
+            "it is wrong for, so the recipe reads as universal",
+        )
+
+    def test_the_symptom_is_named_so_a_false_difference_is_recognisable(self):
+        phase4 = self.material(4)
+        self.assertIn(
+            "warn_return_any",
+            phase4,
+            "the failure is a difference that looks real. Naming the mechanism is "
+            "what lets a reader tell it from a behaviour change",
+        )
+
+    def test_the_flag_is_not_described_as_isolation_it_does_not_give(self):
+        self.assertIn(
+            ".venv",
+            self.material(4),
+            "`--no-project` layers on a `.venv` when it finds one, so what the "
+            "flag means depends on a directory. A phase that runs three of these "
+            "and compares them has to say so",
+        )
+
+
+class TestExposureIsEstablishedRatherThanAssumed(SkillHarness):
+    """Phase 2 answered "is this repo in scope" with one grep over repo config.
+
+    That works for a rule or a flag. Two ordinary cases fall outside it, and both
+    return a confident `inert here` nobody established.
+
+    **A changelog entry naming a dependency.** `rumdl` 0.2.60 ships
+    `deps: update h2 to 0.4.16` under **Fixed**, with no `Security` heading —
+    RUSTSEC-2026-0258. The crate is Rust inside a Python wheel, so `pip-audit`
+    is clean under both `-s pypi` and `-s osv`, correctly, and the repo's config
+    has never heard of `h2`. Reading the wheel's PEP 770 SBOM answers it:
+    CycloneDX 1.5, 178 components, no `h2` — while `tokio` is there, so the
+    document is the real shipped set. `Cargo.lock` says the opposite, because it
+    carries `[dev-dependencies]` and `jsonschema` is one.
+
+    **A rule the repo disables.** `rumdl` 0.2.59 fixed a destructive `MD013`
+    autofix in a repo running `--fix` on every Markdown commit. `disable =
+    ["MD013"]` is a claim about a file; `rumdl check README.md` clean against
+    `--no-config` finding 32 is a claim about the tool.
+    """
+
+    def test_phase_2_says_the_grep_cannot_answer_a_vendored_dependency(self):
+        self.assertRegex(
+            self.material(2).lower(),
+            r"grep[^.]{0,400}(cannot|only when)",
+            "Phase 2 called the scope test `one grep`, which is false for an "
+            "advisory against a dependency vendored out of another ecosystem — "
+            "the case where every Python-side scanner is correctly clean",
+        )
+
+    def test_the_shipped_set_is_read_from_the_wheel_not_the_vendored_lockfile(self):
+        phase2 = self.material(2)
+        self.assertIn(
+            "sboms/",
+            phase2,
+            "the shipped set is in the wheel's own SBOM; nothing else in reach "
+            "distinguishes a vendored crate that is compiled in from one that is not",
+        )
+        self.assertIn(
+            "dev-dependencies",
+            phase2,
+            "a reader who reaches for Cargo.lock instead finds the crate and calls "
+            "it exposure — it records dev-dependencies, which are not in the binary",
+        )
+
+    def test_a_wheel_with_no_sbom_is_underivable_rather_than_clean(self):
+        self.assertRegex(
+            self.material(2).lower(),
+            r"no sbom[^.]{0,200}underivable|underivable[^.]{0,200}sbom",
+            "PEP 770 coverage is partial, so a missing SBOM says nothing about a "
+            "missing crate. Collapsing it into `clean` builds the unverified "
+            "verifier this plugin exists to argue against",
+        )
+
+    def test_a_disabled_rule_is_proven_by_running_the_tool_both_ways(self):
+        phase2 = self.material(2)
+        self.assertIn(
+            "--no-config",
+            phase2,
+            "an `inert here` resting on a config line is an assertion about the "
+            "file while the verdict is about the tool — the same gap Phase 6 "
+            "closed for a red check by attributing it",
+        )


### PR DESCRIPTION
Closes #77, #78, #79, #80, #81.

The `uv.lock` path had never been replayed in a fresh context — `fpga-board-sim`
#363 is a `setup-uv` bump and every replay round since 0.24.0 rode on it. The
first run against a lockfile bump handed back five things, and one of them was a
line that could never have worked.

## What changed

| Issue | Fix |
|---|---|
| #77 | `references/*.md` named scripts with `${CLAUDE_PLUGIN_ROOT}`, which is substituted into **`SKILL.md`'s text only**. `discover.py --shell` now emits `SCRIPTS=` from its own `__file__`; exactly one line still bootstraps, and a guard holds it there |
| #78 | Phase 5 gains a fourth qualifier — *which groups* — and reconciliation against the set Phase 1 derived. **Not** `--group dev`: measured, that flag is a no-op where it was proposed |
| #79 | `--no-project` qualified rather than universal, plus the measurement that it is not isolation at all when a `.venv` is present |
| #80 | New `references/uv-lock.md` § Phase 2: read a vendored crate's exposure out of the wheel's PEP 770 SBOM, never out of `Cargo.lock` |
| #81 | An `inert here` resting on a config line is proven by running the tool both ways |

## The replay

`fpga-board-sim` #365 (mypy 2.3.0→2.3.1, ruff 0.16.3→0.16.4, rumdl 0.2.55→0.2.58),
fresh context via `claude -p --plugin-dir`, execution authorised deliberately
because Phases 4 and 5 both changed. **It ran out of budget at Phase 7, so there
is no verdict** — but it reached and followed every changed surface:

- `S="${SCRIPTS:?…}/audit.py"` resolved; the Phase 1 block ran **as written**
- the SBOM recipe ran: `h2 -> no`, `tokio -> YES` on `rumdl` 0.2.58
- `rumdl check README.md` clean vs `--no-config` finding 32, reproduced
- `uv run --group dev --with mypy==… mypy .` — no `--no-project` — both runs
  `Success: no issues found in 157 source files`
- `uv pip list | grep -iE '^(mypy|ruff|rumdl)='` → all three at the proposed versions

**And it found a defect in the Phase 4 prose written an hour earlier.** Dropping
`--no-project` makes the comparison a capture of `uv run`, and the first
invocation provisions the environment while the second does not — eight lines of
diff on two identical mypy results. A read-only gate has no tree diff to fall
back on, so that capture *is* the measurement. Folded in rather than filed.

## Tests

Fifteen guards, four classes, each mutation-checked with the mutation asserted to
have landed before the result was read. **Two did not discriminate as first
written** — one matched `grouped`, one was satisfied by prose predating the fix —
and both were rewritten. `reachable()` had to learn `$SCRIPTS` in the same
commit: converting Phase 6's `C=` line emptied `reachable(6)` and four guards
went to matching nothing. They failed loudly, which is the only reason that is a
footnote.

293 tests, ruff, mypy, all green.