### PR TITLE
fix: stop Phase 4 reading a gate's own residue as a finding (0.30.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,73 @@ patch.
 
 ## [Unreleased]
 
+## [0.30.1] — 2026-08-30
+
+[#83](https://github.com/Machai-Kydoimos/dependabot-audit/issues/83), handed back
+by the `fpga-board-sim` #365 replay against the released 0.30.0 and classified a
+prose gap. The hand-back was right that 0.30.0 opened a hole, and wrong about
+where it is. Measuring moved the fix.
+
+0.30.0 tells Phase 4 to drop `--no-project` for a gate that imports the project.
+Such a gate writes its own bookkeeping into the tree `gate_diff.py` is measuring,
+and the issue read the cache directories as the hazard — to be closed by checking
+they are gitignored. Measured with `gate_diff.py` itself, that is the one shape
+that never was:
+
+| What the gate leaves behind | Reaches `snapshot_changes` |
+|---|---|
+| `.mypy_cache/`, `.ruff_cache/`, `.pytest_cache/` | **never** — each tool writes a `.gitignore` of `*` into its own cache; measured on mypy 1.18.2, ruff 0.14.2 and pytest 8.4.2 against a repo with no `.gitignore` at all |
+| another untracked directory, `__pycache__/` above all | **not by default** — `git status --porcelain` collapses it to `dir/`, and `_content_key` returns `None` for anything that is not a file, so the entry is dropped before it can be compared |
+| a file at a non-ignored path — `.coverage`, `coverage.xml`, `junit.xml` | **always** |
+
+So the proposed fix would have sent auditors to gitignore directories that were
+already invisible, while the shape that does fire went unnamed. Both false
+findings reproduced end to end, and neither run touched a line of the repo's code:
+
+- a real `coverage 7.6.1 -> 7.13.0` bump, `.coverage` untracked and unignored, in
+  the **default** git configuration, reports `~ .coverage  both act, different
+  result — the fix itself changed`. That is the destructive-fix vocabulary — the
+  finding this phase exists for — spent on coverage's own data file.
+- with `status.showUntrackedFiles=all` in the repo under test, which un-collapses
+  the directory row, a real `pytest 8.4.2 -> 9.1.1` bump reports a `+`/`-` pair on
+  `tests/__pycache__/test_ok.cpython-313-pytest-9.1.1.pyc` — *widened scope* and
+  *narrowed scope* — because pytest stamps its own version into the name of every
+  file it rewrites.
+
+**Patch rather than minor.** Phase 4 verifies what it always did, on the tree it
+always did. What changes is that the measurement stops carrying the tool's own
+bookkeeping into the answer, which is this file's definition of a patch: a fix
+that only makes an existing claim true.
+
+### Fixed
+
+- **`references/uv-lock.md` Phase 4 names the residue that actually reaches the
+  comparison**, as a table rather than a caution. The useful half is which rows to
+  stop worrying about — a reference that says "check your caches are ignored"
+  spends the auditor's attention on the two rows that were never visible.
+
+- **The neutralisation goes in the command, not in the repo's `.gitignore`.**
+  `PYTHONDONTWRITEBYTECODE=1 COVERAGE_FILE=../cov-<label>`, prepended identically
+  to every `--run`: the runs have to be treated alike for the comparison to mean
+  anything, and only the command reaches both. `gate_diff.py` runs each command
+  with the tree as its working directory, so the relative `../` lands the data
+  file beside the worktree and needs no handoff to resolve. That spelling is the
+  suite's doing — the first draft wrote `$SCRATCH/cov-proposed` and the guard
+  against a block reading the handoff without sourcing it failed on it — the
+  guard 0.28.0 added, doing the job it was added for.
+
+### Tests
+
+Three guards in `tests/test_gate_diff.py` pin the mechanics the prose describes: a
+collapsed directory is dropped, a file at the root is compared, and
+`status.showUntrackedFiles=all` is the repo setting that turns the first into the
+second. Two in `tests/test_skill_prose.py` hold Phase 4 to naming both the
+neutralisation and the residue.
+
+All five mutation-checked. Returning `_content_key`'s `None` to a sentinel fails
+the directory guard and nothing else; deleting either token from the reference
+fails one prose guard each.
+
 ## [0.30.0] — 2026-08-24
 
 The `uv.lock` path had never been replayed in a fresh context. `fpga-board-sim`
@@ -3486,7 +3553,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.1...HEAD
+[0.30.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.27.0...v0.28.0

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -303,6 +303,39 @@ the version under test, measured on uv 0.12.5 against a project locking
   --run proposed "uv run --group <group> --with mypy==<proposed> mypy ."
 ```
 
+**A gate that imports the project also writes into the tree it is measured in,
+and one shape of that residue is reported as a finding.** Not the shape it looks
+like — checking that `.mypy_cache/` is gitignored is busywork. Measured with
+`gate_diff.py` itself, mypy 1.18.2 / ruff 0.14.2 / pytest 8.4.2:
+
+| What the gate leaves behind | Reaches `snapshot_changes` |
+|---|---|
+| `.mypy_cache/`, `.ruff_cache/`, `.pytest_cache/` | **never** — each tool writes a `.gitignore` of `*` into its own cache, so git omits it whatever the repo ignores |
+| another untracked directory, `__pycache__/` above all | **not by default** — `git status --porcelain` collapses it to `dir/`, and a directory has no content to hash, so the entry is dropped. **Yes** where the repo sets `status.showUntrackedFiles=all`, which un-collapses it |
+| a file at a non-ignored path — `.coverage`, `coverage.xml`, `junit.xml` | **always** |
+
+The two live rows invent a difference out of the tool's own bookkeeping and
+report it in the vocabulary of a real finding. A `coverage 7.6.1 -> 7.13.0` bump
+with `.coverage` unignored gives `~ .coverage  both act, different result — the
+fix itself changed`; under `showUntrackedFiles=all`, `pytest 8.4.2 -> 9.1.1`
+gives a `+`/`-` pair on
+`tests/__pycache__/test_ok.cpython-313-pytest-9.1.1.pyc` — *widened scope* and
+*narrowed scope* — because pytest stamps its own version into every file it
+rewrites. Neither touches a line of the repo's code.
+
+Neutralise it in the command, identically on every run, rather than trusting the
+repo's `.gitignore` — the runs have to be treated alike for the comparison to
+mean anything:
+
+```bash
+  --run proposed "PYTHONDONTWRITEBYTECODE=1 COVERAGE_FILE=../cov-proposed uv run --group <group> --with pytest==<proposed> pytest -q --cov=<pkg>"
+```
+
+`gate_diff.py` runs each command with the tree as its working directory, so the
+relative `../` lands the data file beside the worktree instead of inside it, and
+needs no handoff to resolve. Both false findings above go to *no difference*
+under it, measured.
+
 **Compare the tool's output, not `uv run`'s.** The first invocation provisions
 the environment and says so — `Creating virtual environment`, `Installed 35
 packages`, the hardlink warning — and the second, warm, says none of it. Captured

--- a/tests/test_gate_diff.py
+++ b/tests/test_gate_diff.py
@@ -290,5 +290,78 @@ class TestTheSnapshotReadsEveryPorcelainField(GateDiffHarness):
         self.assertIn("fresh.txt", changed)
 
 
+class TestGateResidueThatIsNotAFinding(GateDiffHarness):
+    """A project-importing gate writes its own bookkeeping into the measured tree.
+
+    Phase 4 drops `--no-project` for a type checker or a test suite, which is
+    what makes this live: those gates leave caches and data files behind. The
+    intuition is that any of it manufactures a difference, and the measurement
+    says only one shape of it does.
+
+    A directory does not, because two mechanisms have to line up and only ever
+    one does: `git status --porcelain` collapses a wholly untracked directory to
+    `dir/`, and `_content_key` returns None for anything that is not a file, so
+    the entry is dropped before it can be compared. A file does, always -- a
+    real `coverage 7.6.1 -> 7.13.0` bump reports `~ .coverage`, *both act,
+    different result*, which reads as the destructive-fix case and is nothing
+    but coverage's own data file.
+
+    These pin the table in `references/uv-lock.md` Phase 4. Both halves matter:
+    without the first, the reference tells auditors to go and gitignore caches
+    that were never visible; without the second, the residue that does invent a
+    finding looks equally harmless.
+    """
+
+    def test_an_untracked_directory_the_gate_leaves_behind_is_not_a_change(self):
+        """Differing contents, and still no difference: the collapse hides it."""
+        tree = git_repo(self)
+        code, out, _ = self._run(
+            tree,
+            [
+                ("locked", "mkdir -p .cache/v && printf one > .cache/v/meta.json"),
+                ("proposed", "mkdir -p .cache/v && printf two > .cache/v/meta.json"),
+            ],
+        )
+        self.assertEqual(code, 0, "a collapsed directory has no content to compare")
+        self.assertIn("no run changed any file", out)
+
+    def test_a_file_the_gate_leaves_behind_is_a_change(self):
+        """The `.coverage` shape: a file at the root reaches the comparison."""
+        tree = git_repo(self)
+        code, out, _ = self._run(
+            tree,
+            [("locked", "printf one > .coverage"), ("proposed", "printf two > .coverage")],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn(".coverage", out)
+        self.assertIn("different result", out)
+
+    def test_expanding_untracked_files_surfaces_the_directory_residue(self):
+        """`status.showUntrackedFiles=all` un-collapses it, and then it does fire.
+
+        Measured on a real `pytest 8.4.2 -> 9.1.1` bump: pytest writes its own
+        version into the name of every file it rewrites, so the two runs leave
+        `...-pytest-8.4.2.pyc` and `...-pytest-9.1.1.pyc` and the comparison
+        reports a `+`/`-` pair -- *widened scope* and *narrowed scope* -- for a
+        gate that touched no code at all.
+        """
+        tree = git_repo(self)
+        subprocess.run(
+            ["git", "-C", str(tree), "config", "status.showUntrackedFiles", "all"],
+            check=True,
+            capture_output=True,
+        )
+        code, out, _ = self._run(
+            tree,
+            [
+                ("locked", "mkdir -p .cache && printf x > .cache/a-1.0.pyc"),
+                ("proposed", "mkdir -p .cache && printf x > .cache/a-2.0.pyc"),
+            ],
+        )
+        self.assertEqual(code, 1, "the repo config is what decides this, not the gate")
+        self.assertIn("acted on by proposed only", out)
+        self.assertIn("acted on by locked only", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1036,6 +1036,54 @@ class TestPhase4MeasuresTheRightTree(SkillHarness):
         self.assertIn("$SCRATCH/base-<N>", self.shell[0])
 
 
+class TestPhase4DoesNotReadItsOwnResidueAsAFinding(SkillHarness):
+    """The gate writes into the tree Phase 4 is measuring it in.
+
+    0.30.0 dropped `--no-project` for a gate that imports the project, which is
+    what makes this live: a type checker or a test suite leaves caches and data
+    files behind, and the phase compares the tree before and after.
+
+    The intuition is that the cache directories are the hazard, and measurement
+    says they are the one shape that never was. `.mypy_cache/`, `.ruff_cache/`
+    and `.pytest_cache/` each carry a `.gitignore` of `*` the tool writes
+    itself; any other untracked directory is collapsed to `dir/` by
+    `git status --porcelain` and then dropped, because a directory has no
+    content to hash. What does reach the comparison is a *file* -- and a real
+    `coverage 7.6.1 -> 7.13.0` bump reports `~ .coverage`, *both act, different
+    result*, which is the destructive-fix vocabulary spent on coverage's own
+    data file.
+
+    So the guard is that the reference gives a neutralisation in the command
+    rather than a `.gitignore` audit: the two runs have to be treated alike for
+    the comparison to mean anything, and only the command reaches both.
+    `tests/test_gate_diff.py` pins the mechanics this prose describes.
+    """
+
+    def test_the_neutralisation_is_something_the_run_carries(self):
+        material = self.material(4)
+        for token in ("PYTHONDONTWRITEBYTECODE", "COVERAGE_FILE"):
+            self.assertIn(
+                token,
+                material,
+                f"{token} is how a run stops writing residue into the measured "
+                "tree; a check on the repo's .gitignore reaches neither run",
+            )
+
+    def test_the_residue_that_actually_reaches_the_comparison_is_named(self):
+        material = self.material(4)
+        self.assertIn(
+            ".coverage",
+            material,
+            "the file-shaped residue is the row that fires by default",
+        )
+        self.assertIn(
+            "status.showUntrackedFiles",
+            material,
+            "and the repo config that un-collapses the directory row is the "
+            "only thing that makes the rest of it visible",
+        )
+
+
 class TestEverythingTheProseNamesExists(SkillHarness):
     """A renamed script breaks every phase that invokes it, silently."""
 


### PR DESCRIPTION
Closes #83.

The hand-back was right that 0.30.0 opened a hole and wrong about where it is.
Measuring moved the fix.

0.30.0 tells Phase 4 to drop `--no-project` for a gate that imports the project,
which is what makes this live: a type checker or a test suite leaves caches and
data files in the tree `gate_diff.py` is measuring. #83 read the cache
directories as the hazard, to be closed by checking they are gitignored.
Measured with `gate_diff.py` itself, that is the one shape that never was:

| What the gate leaves behind | Reaches `snapshot_changes` |
|---|---|
| `.mypy_cache/`, `.ruff_cache/`, `.pytest_cache/` | **never** — each tool writes a `.gitignore` of `*` into its own cache; measured on mypy 1.18.2, ruff 0.14.2, pytest 8.4.2 against a repo with no `.gitignore` at all |
| another untracked directory, `__pycache__/` above all | **not by default** — porcelain collapses it to `dir/`, and `_content_key` returns `None` for anything that is not a file |
| a file at a non-ignored path — `.coverage`, `coverage.xml`, `junit.xml` | **always** |

So the sentence #83 asked for would have sent auditors to gitignore directories
that were already invisible, while the shape that does fire went unnamed. Two
false findings, both reproduced end to end, neither touching a line of the
repo's code:

- a real `coverage 7.6.1 -> 7.13.0` bump, `.coverage` untracked and unignored,
  in the **default** git configuration, reports `~ .coverage  both act,
  different result — the fix itself changed` — the destructive-fix vocabulary
  spent on coverage's own data file;
- with `status.showUntrackedFiles=all`, a real `pytest 8.4.2 -> 9.1.1` bump
  reports a `+`/`-` pair on
  `tests/__pycache__/test_ok.cpython-313-pytest-9.1.1.pyc`, read out as *widened
  scope* and *narrowed scope*, because pytest stamps its own version into the
  name of every file it rewrites.

The reference now carries those three rows as a table — the useful half is which
rows to stop worrying about — and puts the neutralisation in the command rather
than in the repo's `.gitignore`:

```
PYTHONDONTWRITEBYTECODE=1 COVERAGE_FILE=../cov-<label>
```

prepended identically to every `--run`. Both runs have to be treated alike for
the comparison to mean anything, and only the command reaches both. Measured
clean on both false findings above.

The `../` is the suite's doing: the first draft wrote `$SCRATCH/cov-proposed`
and `TestEveryConsumerReloadsTheHandoff` failed it, the guard 0.28.0 added doing
the job it was added for.

**Patch rather than minor.** Phase 4 verifies what it always did, on the tree it
always did; the measurement just stops carrying the tool's own bookkeeping into
the answer.

### Tests

Three guards in `tests/test_gate_diff.py` pin the mechanics the prose describes;
two in `tests/test_skill_prose.py` hold Phase 4 to naming both the neutralisation
and the residue. All five mutation-checked — restoring `_content_key`'s `None` to
a sentinel fails the directory guard and nothing else, and deleting either token
from the reference fails one prose guard each.

298 unit tests, 6 integration tests with `RUN_NETWORK_TESTS=1`, and
`pre-commit run --all-files` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)