### PR TITLE
fix: take every Phase 4 gate through gate_diff.py, not beside it (0.31.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,10 @@
-# Local gates, and the only enforcing ones. Branch protection and rulesets are
-# both unavailable on this repo's plan (private repo, free org), so a CI check
-# can never be made required — CI here is advisory, and these hooks are what can
-# actually stop a bad commit. Install with: pre-commit install
+# Local gates, run before the commit exists. They are no longer the *only*
+# enforcing ones: the repo went public on 2026-08-15 and a ruleset on `main` now
+# requires six contexts, so CI is enforcing rather than advisory — a red check
+# blocks the merge. #37 recorded that switch; the ruleset itself is a repo setting.
+# These hooks still earn their place by failing in seconds on your machine
+# instead of minutes in Actions, and by running `--fix` where CI only checks.
+# Install with: pre-commit install
 #
 # The pinned `rev:`s are the single source of truth for tool versions: CI runs
 # `pre-commit run --all-files` rather than its own `pip install ruff mypy`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,89 @@ patch.
 
 ## [Unreleased]
 
+## [0.31.0] — 2026-08-30
+
+Closes [#85](https://github.com/Machai-Kydoimos/dependabot-audit/issues/85), which
+the round-10 replay of `fpga-board-sim` #365 found while validating 0.30.1 — and
+which shows why that validation is a separate gate from the test suite.
+
+**0.30.1 shipped green, mutation-checked, and inert.** Its neutralisation is a
+`--run` fragment, and the replay never built a `--run` to put it in: Phase 4 took
+ruff and rumdl through `gate_diff.py` and compared **mypy** — the
+project-importing gate the whole `--no-project` exception exists for — with a
+bare `cd` into the worktree and two `uv run` calls. The residue fix reached
+nothing, and three older guarantees went with it: `require_clean_worktree`, the
+`reset --hard` between runs, and the tree snapshot the phase exists to take. The
+run then reported *"no improvisation affecting the evidence — every phase ran
+through the plugin's own scripts (`gate_diff.py`) as written"*, which is the
+Phase 8 line a reader trusts to decide whether to re-check.
+
+Two candidate causes, and the fix closes both rather than settling which:
+
+- **the example was a fragment.** Every other block in Phase 4 is a whole
+  `python3 "$G" --tree …` invocation; the project-importing one was a lone
+  `--run` line, reading as advice about a flag rather than a call to make.
+- **the prose arguably licensed it.** *"A read-only gate has no tree diff to fall
+  back on, so this capture is the measurement"* is a defensible warrant for
+  capturing the output by hand.
+
+**Minor, not patch.** Phase 4 now takes a tree measurement for a class of gate it
+was only comparing by output, and its report says so — a change to what the phase
+verifies.
+
+### Fixed
+
+- **The project-importing example is a whole invocation**, preamble and all,
+  matching every other block in the phase. So is the residue example from 0.30.1,
+  which had the same fragment shape and the same consequence.
+
+- **A new rule, "through the script, not beside it — including the gates with no
+  write mode."** It names the #365 bypass, what it costs, and the sharp half: for
+  a read-only gate, a tree delta is not a lesser signal but the **only** thing it
+  can contain — a gate that writes nothing, measured as having written something,
+  has measured its own cache. That makes 0.30.1's neutralisation matter most
+  exactly where it looked least relevant.
+
+- **The warm-up line no longer reads as a licence.** "Warming beforehand is a
+  `--run` you discard, not a licence to drive the tool by hand."
+
+- **`.pre-commit-config.yaml`'s header stopped arguing a policy that reversed.**
+  It claimed branch protection and rulesets were unavailable "on this repo's plan
+  (private repo, free org)", so CI "can never be made required" and the hooks
+  "are what can actually stop a bad commit". The repo went public 2026-08-15 and a
+  ruleset on `main` requires six contexts, so a red check blocks the merge. The
+  stale text argued the opposite. The version-pinning paragraph below it was
+  correct and is untouched.
+
+### Tests
+
+Two guards in `tests/test_skill_prose.py`, **structural rather than textual on
+purpose**: every Phase 4 block that pins a version under test must contain an
+actual invocation, and the neutralisation must sit inside one. A guard asserting
+the phase *says* to use the script would have passed against the text that did
+not elicit it — 298 tests did exactly that, which is the whole lesson of #85.
+Both mutation-checked by restoring each example to its fragment form.
+
+### Replay
+
+`fpga-board-sim` #365, headless against the working tree, **before** this PR
+rather than after — 40 turns, 8m12s, $4.16.
+
+`gate_diff.py` calls went 3 → 5, and mypy is now one of them:
+
+```
+--run warm-locked "PYTHONDONTWRITEBYTECODE=1 uv run --group dev --with mypy==2.3.0 mypy ."
+--run locked      "PYTHONDONTWRITEBYTECODE=1 uv run --group dev --with mypy==2.3.0 mypy ."
+--run proposed    "PYTHONDONTWRITEBYTECODE=1 uv run --group dev --with mypy==2.3.1 mypy ."
+```
+
+The discarded warm-up run is the new warm-up line being followed. The report's
+disclosure is now accurate — it names its one real improvisation instead of
+claiming none — and the run's own hand-back reads: *"That guidance worked — I
+took mypy through the script with a discarded warm-up run, and the uv-provisioning
+artifact it warns about did not appear."* Verdict unchanged and correct: merge
+as-is, then follow up.
+
 ## [0.30.1] — 2026-08-30
 
 [#83](https://github.com/Machai-Kydoimos/dependabot-audit/issues/83), handed back
@@ -3553,7 +3636,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.1...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.31.0...HEAD
+[0.31.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.1...v0.31.0
 [0.30.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.28.0...v0.29.0

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -300,7 +300,17 @@ the version under test, measured on uv 0.12.5 against a project locking
 `iniconfig 2.1.0`, where `uv run --with iniconfig==2.0.0` resolves to 2.0.0:
 
 ```bash
-  --run proposed "uv run --group <group> --with mypy==<proposed> mypy ."
+# Fresh call: nothing survives one, so re-derive and re-source exactly as above.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
+G="${SCRIPTS:?not in the handoff — re-run Phase 0}/gate_diff.py"
+
+python3 "$G" --tree "$SCRATCH/base-<N>" \
+  --run locked   "PYTHONDONTWRITEBYTECODE=1 uv run --group <group> --with mypy==<locked> mypy ." \
+  --run proposed "PYTHONDONTWRITEBYTECODE=1 uv run --group <group> --with mypy==<proposed> mypy ."
 ```
 
 **A gate that imports the project also writes into the tree it is measured in,
@@ -328,6 +338,15 @@ repo's `.gitignore` — the runs have to be treated alike for the comparison to
 mean anything:
 
 ```bash
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
+G="${SCRIPTS:?not in the handoff — re-run Phase 0}/gate_diff.py"
+
+python3 "$G" --tree "$SCRATCH/base-<N>" \
+  --run locked   "PYTHONDONTWRITEBYTECODE=1 COVERAGE_FILE=../cov-locked   uv run --group <group> --with pytest==<locked>   pytest -q --cov=<pkg>" \
   --run proposed "PYTHONDONTWRITEBYTECODE=1 COVERAGE_FILE=../cov-proposed uv run --group <group> --with pytest==<proposed> pytest -q --cov=<pkg>"
 ```
 
@@ -335,6 +354,16 @@ mean anything:
 relative `../` lands the data file beside the worktree instead of inside it, and
 needs no handoff to resolve. Both false findings above go to *no difference*
 under it, measured.
+
+**Through the script, not beside it — including the gates with no write mode.**
+A type checker or a test suite writes nothing, so the temptation is to run it
+twice by hand and diff the output, which is what a replay of #365 did: it took
+ruff and rumdl through `gate_diff.py` and compared mypy with a bare `cd` into the
+worktree and two `uv run` calls. That loses `require_clean_worktree`, loses the
+`reset --hard` between runs — so run two inherits run one — and loses the tree
+snapshot entirely. And the residue above is not a lesser concern for a read-only
+gate but the **only** thing its tree delta can contain: a gate that writes
+nothing, measured as having written something, has measured its own cache.
 
 **Compare the tool's output, not `uv run`'s.** The first invocation provisions
 the environment and says so — `Creating virtual environment`, `Installed 35
@@ -344,7 +373,10 @@ run alone. Measured on this phase's own replay, where two mypy runs both
 reported `Success: no issues found in 157 source files` and the diff came back
 eight lines long, all of them uv's. Warm the cache with a throwaway run, or strip
 what uv wrote before comparing; a read-only gate has no tree diff to fall back
-on, so this capture *is* the measurement.
+on, so this capture *is* the measurement. Which is a reason to run it **inside**
+`gate_diff.py`, not outside: the script already captures each run's output and
+compares them, and warming beforehand is a `--run` you discard, not a licence to
+drive the tool by hand.
 
 Repos that have been bitten by this say so in their own configuration. The one
 this section came from pins its mypy hook local rather than to `mirrors-mypy`,

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1084,6 +1084,65 @@ class TestPhase4DoesNotReadItsOwnResidueAsAFinding(SkillHarness):
         )
 
 
+class TestPhase4CallsTheScriptForEveryGate(SkillHarness):
+    """A `--run` fragment does not elicit the call it is a fragment of.
+
+    Measured, not reasoned: the round-10 replay of `fpga-board-sim` #365 took
+    ruff and rumdl through `gate_diff.py` and compared **mypy** -- the
+    project-importing gate the `--no-project` exception exists for -- with a bare
+    `cd` into the worktree and two `uv run` calls. Every other code block in
+    Phase 4 is a whole `python3 "$G" --tree ...` invocation; that one was a lone
+    `--run` line, and it read as advice about a flag rather than a call to make.
+
+    The bypass costs more than the flag. It loses `require_clean_worktree`, loses
+    the `reset --hard` between runs -- so run two inherits run one -- and loses
+    the tree snapshot the phase exists to take. It also silently voided 0.30.1,
+    whose neutralisation is a `--run` fragment and so reaches nothing when no
+    `--run` is built: that fix shipped green, mutation-checked, and inert.
+
+    So the guard is structural rather than textual. A prose assertion that the
+    phase *says* to use the script would have passed against the text that did
+    not elicit it -- 298 tests did. This asks that every block teaching a gate
+    invocation actually contains one.
+    """
+
+    def _phase4_blocks(self) -> list[tuple[str, str]]:
+        found: list[tuple[str, str]] = []
+        for path in (SKILL, PLUGIN / "references/uv-lock.md"):
+            for number, body in phases(path.read_text(encoding="utf-8")):
+                if number == 4:
+                    found.extend((path.name, code) for code in bash_blocks(body))
+        return found
+
+    def _blocks_containing(self, token: str) -> list[tuple[str, str]]:
+        hits = [(name, code) for name, code in self._phase4_blocks() if token in code]
+        self.assertTrue(hits, f"Phase 4 no longer carries a block containing {token!r}")
+        return hits
+
+    def test_every_gate_example_is_a_whole_invocation(self):
+        """A block that pins a version under test must also make the call."""
+        for token in ("--with mypy", "--with pytest", "--with ruff"):
+            for name, code in self._blocks_containing(token):
+                self.assertIn(
+                    "gate_diff.py",
+                    code,
+                    f"{name}: the {token} example is a fragment. #85 measured that a bare "
+                    "--run line is compared by hand instead, losing the clean-tree guard, "
+                    "the reset between runs, and the tree snapshot",
+                )
+                self.assertIn("--tree", code, f"{name}: {token} example names no tree")
+
+    def test_the_residue_neutralisation_reaches_a_call(self):
+        """0.30.1's fix was inert precisely because it sat in a fragment."""
+        for name, code in self._blocks_containing("PYTHONDONTWRITEBYTECODE"):
+            self.assertIn(
+                "gate_diff.py",
+                code,
+                f"{name}: the neutralisation only takes effect on a --run the script is "
+                "handed; in a fragment it is text",
+            )
+
+
 class TestEverythingTheProseNamesExists(SkillHarness):
     """A renamed script breaks every phase that invokes it, silently."""
 


### PR DESCRIPTION
Closes #85.

Found by the round-10 replay of `fpga-board-sim` #365 while validating 0.30.1 —
and it is 0.30.1 that it invalidates.

**0.30.1 shipped green and was inert.** 298 tests, five mutation-checked guards,
CI clean, a published release. Its neutralisation is a `--run` fragment and the
replay never built a `--run` to carry it: Phase 4 took ruff and rumdl through
`gate_diff.py`, and compared **mypy** — the project-importing gate the whole
`--no-project` exception exists for — with a bare `cd` and two `uv run` calls.

The bypass costs more than the fix it voided: `require_clean_worktree` never ran,
`restore()`'s `reset --hard` never ran between runs, and `snapshot_changes` never
ran — no tree measurement at all, which is the weaker comparison the script
exists to replace. The run then reported *"no improvisation affecting the
evidence"*. Only the transcript showed otherwise.

## The fix

Both the mypy and the pytest/residue examples become **whole invocations** with
the canonical handoff preamble. A new rule — *"through the script, not beside it
— including the gates with no write mode"* — gives the sharp reason: for a
read-only gate a tree delta is not a lesser signal but the **only** thing it can
contain, so a gate that writes nothing and is measured as having written
something has measured its own cache. And the warm-up line no longer reads as a
licence: *"warming beforehand is a `--run` you discard, not a licence to drive
the tool by hand."*

Also here, unrelated surface, agreed as a follow-up rather than folded into
0.30.1: `.pre-commit-config.yaml`'s header claimed rulesets were unavailable and
CI "can never be made required". The repo went public 2026-08-15 and a ruleset on
`main` requires six contexts, so a red check blocks the merge — the paragraph
argued the reverse.

**Minor rather than patch:** Phase 4 now takes a tree measurement for a class of
gate it was only comparing by output.

## Tests

Two guards, **structural rather than textual on purpose**: every Phase 4 block
pinning a version under test must contain an actual invocation, and the
neutralisation must sit inside one. A guard asserting the phase *says* to use the
script would have passed against the text that did not elicit it — 298 tests did
exactly that. Both mutation-checked by restoring each example to its fragment
form.

300 tests, `pre-commit run --all-files` clean.

## Replay — run before this PR, not after

`fpga-board-sim` #365, headless against the working tree. 40 turns, 8m12s, $4.16.

`gate_diff.py` calls went **3 → 5**, and mypy is now one of them:

```
--run warm-locked "PYTHONDONTWRITEBYTECODE=1 uv run --group dev --with mypy==2.3.0 mypy ."
--run locked      "PYTHONDONTWRITEBYTECODE=1 uv run --group dev --with mypy==2.3.0 mypy ."
--run proposed    "PYTHONDONTWRITEBYTECODE=1 uv run --group dev --with mypy==2.3.1 mypy ."
```

The discarded `warm-locked` run is the new warm-up line being followed. The
report's disclosure is now accurate — it names its one real improvisation rather
than claiming none — and its own hand-back reads:

> That guidance worked — I took mypy through the script with a discarded warm-up
> run, and the uv-provisioning artifact it warns about did not appear.

Verdict unchanged and correct: *merge as-is, then follow up*.

Two new deviation rows from that run are **not** addressed here — they are
pre-existing and unrelated to #85: no documented salvage for a refused
`--no-build`, and `audit.py`'s fork list covering only changed packages while
Phase 5's disclosure duty covers the whole install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)