### PR TITLE
fix: take Phase 5's fork list lockfile-wide, and salvage a refused --no-build (0.32.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,104 @@ patch.
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-08-30
+
+Closes [#87](https://github.com/Machai-Kydoimos/dependabot-audit/issues/87) and
+[#88](https://github.com/Machai-Kydoimos/dependabot-audit/issues/88), the two
+deviations the round-11 replay of `fpga-board-sim` #365 handed back. Both are
+Phase 5, and both are the same failure in different clothing: the phase asks for
+a disclosure the run cannot actually make, so the auditor improvises one — and
+the improvisation is not the same twice.
+
+**Minor, not patch.** The fork list now covers the whole lockfile instead of the
+changed set, and Phase 5 gained a documented salvage where it previously
+recorded an accepted loss. Both change what the phase verifies and what its row
+asserts.
+
+### Fixed
+
+- **`audit.py`'s fork list covers the lockfile, not the bump** (#88). It was
+  built from `report["currency"]`, which only ever holds the changed set, so a
+  package that is forked and *unchanged* produced no fork list at all — while
+  `pins`, four lines above it, was already lockfile-wide and said so in its own
+  comment. On #365 that left the auditor deriving the list by hand and the report
+  asserting *"`rpds-py 0.30.0` … was verified by Phase 1 but not installed"*,
+  false in its first half: `rpds-py` was never in the audited set.
+
+- **The widened list keeps the two claims apart**, which is the half that makes
+  widening safe rather than worse. Forks print under one of two headings —
+  `artifacts verified against the registry above` for packages this run audited,
+  `NOT audited by this run` for the rest. Artifact provenance really is
+  changed-only; conflating it with pin structure is how #88 started.
+
+- **Three sentences in `references/uv-lock.md` that were wrong about their own
+  script.** The scope table promised *"**every** fork's artifacts"*, the
+  qualifier row claimed *"Phase 1 checked all of them"*, and the worked example
+  modelled *"the 3.11 fork of `rpds-py` was verified but not installed"* — the
+  exact wrong sentence a real report then reproduced.
+
+- **An unparseable version in an unaudited fork no longer aborts the run.**
+  `_version_key` refuses what it cannot order, and for a package under audit that
+  refusal is the contract. The fork list is wider than the audited set now, so
+  the same raise would let one odd version in a package nobody asked about kill a
+  complete audit. Disclosure is not judgment: `_ordered_pins` falls back to
+  lockfile order.
+
+### Added
+
+- **A documented salvage for a refused `--no-build`** (#87). The refusal names
+  the package it rejected; when that is a *dependency* rather than the project,
+  the loss can be narrowed instead of accepted. The lockfile already identifies
+  the offenders — a package with no `wheels` array is one uv must build — so
+  excluding every package that *has* one leaves the offenders as the only source
+  builds, and yields a falsifiable row: *"4 of 6 third-party packages resolved to
+  wheels; `actionlint-py` was the only sdist built"*.
+
+  This existed as a gap because the same refusal on the same PR produced two
+  different rows in two consecutive replays: round 10 fell back to a plain
+  `uv sync --locked` and dropped the wheels claim, round 11 improvised the
+  enumeration for 36 of 38 packages. Phase 5's own text says *"'Frozen install
+  passed' is not the same claim in the two cases"*, so a non-deterministic row
+  here is a defect rather than a preference.
+
+  Two boundaries ship with it, both measured on uv 0.12.7: the narrowing **proves
+  less than a true `--no-build`**, because the conceded package's build code did
+  run; and uv **fails fast, naming one package per run**, so the lockfile read is
+  a predictor and the sync remains the proof.
+
+- **The recipe counts packages, not lockfile blocks** — a correction the replay
+  made to the first version of it, which had shipped in this same branch. Run
+  against #365 it printed *"held 37 of 38 third-party packages to wheels"*, and
+  the lockfile has 39 blocks, 38 remote, but **37 remote packages**: `rpds-py` is
+  forked across two. The block-wise count inflated both halves of the row and
+  passed the duplicate to `--no-build-package` twice. Corrected, the same lockfile
+  yields *"36 of 37"*, with no duplicate. A forked package is now held to a wheel
+  only if **every** one of its forks has one, since uv must build the fork that
+  does not. Getting this wrong is the sharpest possible version of the phase's own
+  failure mode: a row whose entire value is that a reader can check the numbers.
+
+- **The local-versus-remote distinction the recipe turns on.** Filtering on
+  `registry` looks equivalent and is not — measured, uv also emits `url` and
+  `git` (remote, and a `url` wheel *does* carry a `wheels` array) alongside
+  `editable`, `virtual` and `directory` (local). Registry-only filtering lets a
+  `url` or `git` dependency escape both the exclusion and the denominator, so a
+  package built from source goes unnamed in a row claiming to name them all.
+  This was caught by the guard below, on the first version of the recipe.
+
+### Tests
+
+- **The salvage guard runs the documented snippet**, against a fixture carrying
+  every `source` kind uv was observed to emit, rather than matching it for
+  substrings. Inverting the condition to `not p.get("wheels")` — the mistake that
+  makes the recipe a no-op — leaves every substring in place, so a
+  pattern-matching guard cannot tell the recipe from the one that does nothing.
+  Four mutants confirm it: the inversion, the dropped local filter, the
+  registry-only filter, and a `LOCAL` set missing `directory`.
+
+- **The cross-artifact quotation guard reads its quote out of the prose** instead
+  of holding a third copy of the literal. It was passing by agreeing with itself;
+  derived, a reworded script fails until the reference is brought along.
+
 ## [0.31.0] — 2026-08-30
 
 Closes [#85](https://github.com/Machai-Kydoimos/dependabot-audit/issues/85), which
@@ -3636,7 +3734,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.32.0...HEAD
+[0.32.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.1...v0.31.0
 [0.30.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.0...v0.30.1
 [0.30.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.29.0...v0.30.0

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -570,8 +570,10 @@ is that a reader can check them.
 Two things about it are worth knowing, and both belong in the report:
 
 - **It proves less than a true `--no-build`.** The conceded package's build code
-  did run. The claim is "everything except these named packages came from a
-  wheel", not "no third-party build code ran".
+  did run, and a PEP 517 build is arbitrary code — it can fetch from the network,
+  which is the whole reason `--no-build` is worth wanting. The claim is
+  "everything except these named packages came from a wheel", not "no third-party
+  build code ran". Name the concessions in the row so the reader can weigh them.
 - **The lockfile read is a predictor; the sync is the proof.** A package can carry
   wheels for other platforms and none for this one, and it will be refused despite
   having a `wheels` array. uv **fails fast — one package per run** (measured: with

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -499,6 +499,86 @@ install proves slightly less than it would otherwise. That is a trade worth maki
 by default and worth reversing deliberately — **say in the report which one you
 ran.** "Frozen install passed" is not the same claim in the two cases.
 
+#### When the refusal names a dependency, narrow it — do not drop the claim
+
+The error above names the package it refused. If that package is the **project**,
+`--no-install-project` is the answer and it is already in the command. If it is a
+**dependency**, the loss is not all-or-nothing, and the two wrong moves are
+dropping to a plain `uv sync --locked` (which proves nothing about wheels) and
+hand-rolling the exclusion list differently each time. Both have happened on the
+same PR.
+
+There is no inverse flag, but the lockfile already names the offenders: a package
+with **no `wheels` array** is one uv must build. Exclude every package that *does*
+have one, and the offenders are the only source builds left.
+
+The one distinction that matters is **local versus remote**, not registry versus
+everything. Measured on uv 0.12.7, a lockfile entry's `source` is one of:
+
+| `source` key | What it is | Exclude it? |
+|---|---|---|
+| `registry`, `url`, `git` | a package fetched from elsewhere | **yes, if it has `wheels`** — that is the claim being made |
+| `editable`, `virtual`, `directory` | the project itself, or a path dependency | **never** — these are built from source by design, and excluding one fails the sync for the reason `--no-install-project` exists |
+
+Filtering on `registry` alone looks equivalent and is not: a `url` or `git`
+dependency then escapes the exclusion *and* the denominator, so a package built
+from source goes unnamed in a row claiming to name them all.
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
+cd "$SCRATCH/pr-<N>"
+mapfile -t ROWS < <(python3 - uv.lock <<'PY'
+import sys, tomllib
+LOCAL = {"editable", "virtual", "directory"}   # the project and its path deps
+remote: dict[str, bool] = {}
+for p in tomllib.load(open(sys.argv[1], "rb"))["package"]:
+    if LOCAL & set(p.get("source", {})):
+        continue
+    # Count PACKAGES, not lockfile blocks: a forked package has one block per
+    # fork, and counting blocks inflates both halves of the row. It can be held
+    # to a wheel only if EVERY one of its forks has one, hence the `and`.
+    # No `wheels` key -> uv must build it, so it is one of the concessions.
+    remote[p["name"]] = remote.get(p["name"], True) and bool(p.get("wheels"))
+print(len(remote))                     # first line: the denominator
+for name, wheeled in remote.items():
+    if wheeled:
+        print(name)
+PY
+)
+TOTAL="${ROWS[0]}"; WHEELED=("${ROWS[@]:1}")
+
+ARGS=(); for p in "${WHEELED[@]}"; do ARGS+=(--no-build-package "$p"); done
+uv sync --locked "${ARGS[@]}"
+echo "held ${#WHEELED[@]} of $TOTAL third-party packages to wheels"
+```
+
+Measured on uv 0.12.7, replaying `fpga-board-sim` #365: this installs the project
+editable and every wheeled dependency from a wheel, and yields *"36 of 37
+third-party packages resolved to wheels; `actionlint-py` was the only sdist
+built"* — falsifiable, and strictly stronger than the plain sync.
+
+**Say "packages" only if you counted packages.** That lockfile has 39 blocks, 38
+of them remote, but only 37 remote *packages* — `rpds-py` is forked across two
+blocks. A block-wise count reports "37 of 38" and passes the duplicate to
+`--no-build-package` twice; the numbers are then wrong in a row whose entire value
+is that a reader can check them.
+
+Two things about it are worth knowing, and both belong in the report:
+
+- **It proves less than a true `--no-build`.** The conceded package's build code
+  did run. The claim is "everything except these named packages came from a
+  wheel", not "no third-party build code ran".
+- **The lockfile read is a predictor; the sync is the proof.** A package can carry
+  wheels for other platforms and none for this one, and it will be refused despite
+  having a `wheels` array. uv **fails fast — one package per run** (measured: with
+  two sdist-only dependencies the error names one), so if the sync still fails,
+  add the newly-named package to the conceded set and re-run. It converges, and
+  the conceded set is the answer.
+
 Then run the repo's own gates from Phase 0, and its full test suite.
 
 ### `--locked` checks the whole lockfile; the install materialises one resolution
@@ -507,9 +587,12 @@ Those are different claims and the row must not merge them:
 
 | Step | Scope |
 |---|---|
-| `audit.py` provenance | **every** fork's artifacts, against the registry |
+| `audit.py` provenance | every fork's artifacts **of the packages this PR changed** — the lockfile's other forks are not checked at all |
 | `uv sync --locked` | asserts the whole lockfile is consistent with the manifest |
 | the install that follows | **one** resolution — the interpreter and platform present |
+
+Three different scopes, and the first is the narrow one. It is easy to read the
+provenance row as lockfile-wide because its neighbours are.
 
 So a green row here on 3.14 says nothing about whether the 3.11 fork's artifacts
 still fetch or its older release still installs. **Ask the environment which one
@@ -521,10 +604,19 @@ uv run python -V                  # inside the synced environment
 uv pip list --format=freeze       # the versions actually materialised
 ```
 
-The Phase 1 script prints the fork list — `forked packages: every pin verified,
-one of them installed` — so the names and versions to reconcile against are
-already in the output. Name the interpreter and the fork in the reproduction
-row; do not report the install as though it covered every pin.
+The Phase 1 script prints the fork list — `forked packages: uv pins these at more
+than one version` — covering the **whole lockfile**, so the names and versions to
+reconcile against are already in the output and there is nothing to derive by
+hand. It arrives in two groups, and the split is the point:
+
+| Group in `audit.py`'s output | What Phase 5 may say about it |
+|---|---|
+| `artifacts verified against the registry above` | this run checked every pin's artifacts; the install exercised one. Name which |
+| `NOT audited by this run` | the pin **count and versions only**. Phase 1 checked nothing here — the package is outside the changed set |
+
+Name the interpreter and the fork in the reproduction row; do not report the
+install as though it covered every pin, and **never write "verified" against a
+name from the second group** — that asserts a check the run did not make.
 
 **When the bumped package is itself forked, a second sync is the thorough
 version** and it is a deliberate escalation, not the default:
@@ -547,13 +639,19 @@ as true of every one:
 |---|---|
 | **which install** | the script-suppressing flags are the documented default and they weaken the proof: a package that genuinely needs its install script is not exercised. Re-running without them is a legitimate choice — say which produced the row |
 | **which interpreter** | the install materialised one fork of a forked lockfile. `uv run python -V`, not the auditor's `python3` |
-| **which forks were only verified** | Phase 1 checked all of them and Phase 5 installed one. Name the others rather than letting the install stand for them |
+| **which forks were only verified, and which were not checked at all** | of the forks Phase 1 audited it checked every pin and Phase 5 installed one; the lockfile's other forks got neither. Name both sets rather than letting the install stand for them |
 | **which groups** | the sync installs the default groups, and a bump outside them is absent with nothing to show for it. Reconcile against the set Phase 1 named, above |
 
 None of the four is a failure to disclose. "Frozen install passed under
-`--no-build --no-install-project` on CPython 3.14, `dev` group included; the 3.11
-fork of `rpds-py` was verified but not installed" is a stronger row than "frozen
-install passed", because it is one a reader can falsify.
+`--no-build --no-install-project` on CPython 3.14, `dev` group included; `rpds-py`
+is forked and unchanged, so its 3.11 pin was neither audited nor installed" is a
+stronger row than "frozen install passed", because it is one a reader can falsify.
+
+Note which half of that sentence the fork clause makes: **unaudited and not
+installed**, not "verified but not installed". The verified-but-not-installed row
+is the right one only for a fork of a package the PR actually changed — and on a
+real audit of #365 the wrong version of this sentence was written about `rpds-py`,
+which the run had never looked at.
 
 Gate on exit codes. `cmd | tail && next` gates on `tail`, so a failing suite sails
 through; use `set -o pipefail` or separate calls.

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -693,6 +693,22 @@ def _is_prerelease(version: str) -> bool:
     return parsed["pre"] is not None or parsed["dev"] is not None
 
 
+def _ordered_pins(versions: Sequence[str]) -> list[str]:
+    """Every pin of one package, newest last, falling back to lockfile order.
+
+    `_version_key` refuses a version it cannot parse, and for an *audited*
+    package refusing is the contract — its currency is what the audit is for.
+    This list is wider than the audited set, so the same refusal here would let
+    one unparseable version in a package nobody asked about abort the whole run.
+    Disclosure is not judgment: the names and versions are still worth printing
+    unsorted, and lockfile order is a defined order rather than an arbitrary one.
+    """
+    try:
+        return sorted(versions, key=_version_key)
+    except ValueError:
+        return list(versions)
+
+
 def fork_context(entry: dict[str, Any], pins: dict[str, list[str]]) -> tuple[list[str], bool]:
     """Every version this package is pinned at, and whether this entry is the highest.
 
@@ -931,22 +947,36 @@ def render(report: dict[str, Any]) -> None:
         print("      earliest first; compare these against $CREATED_AT, the PR's own\n")
 
     # A forked package is checked in full and installed in part, and nothing in
-    # the output said so. Phase 1 verifies every fork's artifacts against the
-    # registry; a frozen install materialises one resolution. A green Phase 5
-    # then reads as though it covered all of them, which is a claim the run
-    # never made. Mechanised here rather than left to the prose, because a
-    # disclosure the report is merely asked to remember is one it can omit.
-    forked = {c["name"]: c["pinned"] for c in report["currency"] if c["pins"] > 1}
-    if forked:
-        print("=== forked packages: every pin verified, one of them installed")
-        for name, versions in forked.items():
-            print(f"      {name:24s} {len(versions)} pins: {', '.join(versions)}")
+    # the output said so. Phase 1 verifies the artifacts of every fork it audits;
+    # a frozen install materialises one resolution. A green Phase 5 then reads as
+    # though it covered all of them, which is a claim the run never made.
+    # Mechanised here rather than left to the prose, because a disclosure the
+    # report is merely asked to remember is one it can omit.
+    #
+    # Printed in two groups rather than one annotated list. The failure this
+    # replaces was a report calling an unaudited fork "verified by Phase 1", and
+    # a heading that says which check ran is harder to misread past than a
+    # column the eye can skip.
+    forks = report.get("forks", [])
+    if forks:
+        print("=== forked packages: uv pins these at more than one version")
+        verified = [f for f in forks if f["audited"]]
+        unverified = [f for f in forks if not f["audited"]]
+        if verified:
+            print("      artifacts verified against the registry above, one pin installed:")
+            for f in verified:
+                print(f"        {f['name']:24s} {f['pins']} pins: {', '.join(f['pinned'])}")
+        if unverified:
+            print("      NOT audited by this run — lockfile structure only, no artifact")
+            print("      of these was checked, because they are outside the changed set:")
+            for f in unverified:
+                print(f"        {f['name']:24s} {f['pins']} pins: {', '.join(f['pinned'])}")
         print("      uv splits a package across blocks under different resolution-markers.")
-        print("      The provenance rows above cover all of them; a frozen install")
-        print("      materialises only the resolution matching the interpreter and")
-        print("      platform present — which need not be the highest pin. Name the one")
-        print("      Phase 5 exercised (`uv run python -V` inside the synced environment)")
-        print("      rather than reporting the install as though it covered every fork.\n")
+        print("      A frozen install materialises only the resolution matching the")
+        print("      interpreter and platform present — which need not be the highest")
+        print("      pin. Name the one Phase 5 exercised (`uv run python -V` inside the")
+        print("      synced environment) rather than reporting the install as though it")
+        print("      covered every fork, and do not report an unaudited pin as verified.\n")
 
     for att in report.get("attestations", []):
         if not att["artifacts"]:
@@ -1107,8 +1137,33 @@ def main() -> int:
     # Fork structure comes from the whole lockfile, not just the selected set: a
     # bump can move one fork of a package while its sibling stays where it is.
     pins: dict[str, list[str]] = {}
+    spelling: dict[str, str] = {}
     for pkg in packages:
-        pins.setdefault(_normalize(pkg["name"]), []).append(pkg["version"])
+        key = _normalize(pkg["name"])
+        pins.setdefault(key, []).append(pkg["version"])
+        spelling.setdefault(key, pkg["name"])
+
+    # Every fork in the lockfile, not only the audited ones. Phase 5's disclosure
+    # duty covers the whole install, so a fork outside the changed set is exactly
+    # as capable of making a green install read as though it covered every pin —
+    # and it used to be invisible here, which left the auditor deriving the list
+    # by hand and reporting an unaudited package as "verified by Phase 1".
+    #
+    # `audited` carries the half that is easy to conflate and expensive to get
+    # wrong: this run compared artifacts against the registry only for packages
+    # in the changed set. For the rest this is lockfile structure and nothing
+    # more, and the two must not be printed as one list.
+    audited = {_normalize(p["name"]) for p in targets}
+    report["forks"] = [
+        {
+            "name": spelling[key],
+            "pinned": _ordered_pins(versions),
+            "pins": len(versions),
+            "audited": key in audited,
+        }
+        for key, versions in pins.items()
+        if len(versions) > 1
+    ]
 
     # What each selected package held in the base lockfile, so an attestation can
     # be compared against the release it replaces.

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1248,9 +1248,14 @@ class TestForkDisclosure(_MainHarness):
     `uv sync --locked` asserts the whole lockfile is consistent with the
     manifest, across every fork. The install then materialises only the
     resolution for the interpreter that happens to be present. Phase 1 verifies
-    every fork's artifacts against the registry, so a green Phase 5 on 3.14 says
-    nothing about whether the 3.11 fork's artifacts install — and nothing in the
-    output distinguished the two.
+    every fork's artifacts **of the packages it audits**, so a green Phase 5 on
+    3.14 says nothing about whether the 3.11 fork's artifacts install — and
+    nothing in the output distinguished the two.
+
+    That qualifier is load-bearing and was absent here until 0.32.0: the audited
+    set is the changed set, so "every fork" is true of this class's fixture and
+    false of a lockfile with a fork nobody bumped. `TestForksOutsideTheChangedSet`
+    covers that case.
 
     Mechanised here rather than left to `SKILL.md`, per the rule in
     CONTRIBUTING: prose is the weakest of the three levers, and a disclosure the

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1305,7 +1305,8 @@ wheels = [
         _, out, _ = self._run(
             [write_lock(self, self.FORKED), "--changed", "rpds-py"], meta=self._forked_meta()
         )
-        self.assertIn("one of them installed", out)
+        self.assertIn("one pin installed", out)
+        self.assertIn("artifacts verified against the registry", out)
         self.assertIn("uv run python -V", out, "the interpreter is the thing to record")
 
     def test_an_unforked_lockfile_says_nothing_about_forks(self):
@@ -1327,6 +1328,166 @@ wheels = [
         currency = json.loads(out)["currency"]
         self.assertEqual([c["pinned"] for c in currency], [["0.30.0", "2026.6.3"]] * 2)
         self.assertEqual({c["pins"] for c in currency}, {2})
+
+
+class TestForksOutsideTheChangedSet(_MainHarness):
+    """The fork list covers the lockfile, not the bump.
+
+    Phase 5's disclosure duty is lockfile-wide — the install materialises one
+    resolution of *every* fork present, not only the ones a PR moved — but the
+    list was built from `report["currency"]`, which only ever holds the changed
+    set. A package forked and unchanged produced no fork list at all.
+
+    Measured on `fpga-board-sim` #365 (a mypy + ruff + rumdl bump, with
+    `rpds-py` forked and untouched): `audit.py` printed nothing, the auditor
+    derived the list by hand, and the report asserted "`rpds-py 0.30.0` was
+    verified by Phase 1 but not installed" — false in its first half, because
+    `rpds-py` was never in the audited set. Widening the list without keeping
+    the audited/unaudited split would make that sentence *easier* to write, so
+    the split is held here as tightly as the widening.
+    """
+
+    UNCHANGED_FORK = f"""
+[[package]]
+name = "rumdl"
+version = "0.2.53"
+source = {{ registry = "https://pypi.org/simple" }}
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/rumdl-0.2.53-py3-none-any.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = {{ registry = "https://pypi.org/simple" }}
+resolution-markers = ["python_full_version < '3.11'"]
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/p-0.30.0.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = {{ registry = "https://pypi.org/simple" }}
+resolution-markers = ["python_full_version >= '3.11'"]
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/p-2026.6.3.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+
+[[package]]
+name = "fpga-simulator"
+version = "0.20.0"
+source = {{ editable = "." }}
+"""
+
+    def _rumdl_meta(self):
+        return pypi_meta("0.2.53", [pypi_file("rumdl-0.2.53-py3-none-any.whl")])
+
+    def _run_unchanged_fork(self, *extra):
+        return self._run(
+            [write_lock(self, self.UNCHANGED_FORK), "--changed", "rumdl", *extra],
+            meta=self._rumdl_meta(),
+        )
+
+    def test_a_fork_outside_the_changed_set_is_still_named(self):
+        """The regression itself: bump rumdl, and rpds-py's fork went unmentioned."""
+        code, out, _ = self._run_unchanged_fork()
+        self.assertEqual(code, 0)
+        self.assertIn("forked packages", out, "a fork the bump did not touch is still installed")
+        self.assertIn("rpds-py", out)
+        self.assertIn("0.30.0, 2026.6.3", out, "both pins, in version order")
+
+    def test_an_unaudited_fork_is_not_printed_as_verified(self):
+        """The half that makes the widening safe rather than worse."""
+        _, out, _ = self._run_unchanged_fork()
+        self.assertIn("NOT audited by this run", out)
+        head, _, tail = out.partition("NOT audited by this run")
+        self.assertIn("rpds-py", tail, "the unchanged fork belongs under the unaudited heading")
+        self.assertNotIn(
+            "rpds-py",
+            head.split("=== forked packages")[-1],
+            "an unaudited fork must not appear under the verified heading",
+        )
+
+    # A second forked package, untouched by the bump, so both groups print at
+    # once. With a single fork the two headings are mutually exclusive and the
+    # rows cannot be attributed to the wrong one — which is the whole risk.
+    TWO_FORKS = (
+        UNCHANGED_FORK
+        + f"""
+[[package]]
+name = "zope-interface"
+version = "5.0"
+source = {{ registry = "https://pypi.org/simple" }}
+resolution-markers = ["python_full_version < '3.11'"]
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/z-5.0.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+
+[[package]]
+name = "zope-interface"
+version = "6.0"
+source = {{ registry = "https://pypi.org/simple" }}
+resolution-markers = ["python_full_version >= '3.11'"]
+wheels = [
+    {{ url = "https://files.pythonhosted.org/packages/xx/z-6.0.whl", hash = "sha256:{"a" * 64}", size = 100 }},
+]
+"""
+    )
+
+    def test_a_changed_fork_and_an_unchanged_one_are_reported_apart(self):
+        """Both groups at once — the case where conflating them is invisible.
+
+        `rpds-py` is forked and bumped, `zope-interface` is forked and untouched.
+        A single flat list would put them side by side under one heading, which
+        is how an unaudited pin gets written up as verified.
+        """
+        _, out, _ = self._run(
+            [write_lock(self, self.TWO_FORKS), "--changed", "rpds-py"],
+            meta=pypi_meta(
+                "2026.6.3",
+                [],
+                releases={
+                    "0.30.0": [pypi_file("p-0.30.0.whl")],
+                    "2026.6.3": [pypi_file("p-2026.6.3.whl")],
+                },
+            ),
+        )
+        verified, sep, unaudited = out.partition("NOT audited by this run")
+        self.assertTrue(sep, "the unaudited heading must appear when a fork went unchecked")
+        verified = verified.split("=== forked packages")[-1]
+        self.assertIn("artifacts verified against the registry", verified)
+        self.assertIn("rpds-py", verified, "the bumped fork had its artifacts checked")
+        self.assertNotIn("zope-interface", verified, "an unaudited fork must not sit under it")
+        self.assertIn("zope-interface", unaudited)
+        self.assertIn("5.0, 6.0", unaudited, "its pins are still worth disclosing")
+
+    def test_the_forks_reach_json_with_the_audited_flag(self):
+        """A caller reading JSON needs the split too, or it re-derives it wrongly."""
+        _, out, _ = self._run_unchanged_fork("--json")
+        forks = json.loads(out)["forks"]
+        self.assertEqual(
+            forks,
+            [{"name": "rpds-py", "pinned": ["0.30.0", "2026.6.3"], "pins": 2, "audited": False}],
+        )
+
+    def test_an_unorderable_version_in_an_unaudited_fork_does_not_abort_the_run(self):
+        """Refusing is the contract for a package under audit, not for every
+        package in the lockfile.
+
+        `_version_key` raises on a version it cannot parse, and the audited path
+        routes that through `fail()` deliberately — currency it cannot judge is
+        a finding. The fork list is wider than the audited set now, so the same
+        raise would let one unparseable version in a package nobody asked about
+        kill an otherwise-complete audit. Disclosure is not judgment.
+        """
+        lock = self.UNCHANGED_FORK.replace('version = "2026.6.3"', 'version = "not-a-version"')
+        code, out, err = self._run(
+            [write_lock(self, lock), "--changed", "rumdl"], meta=self._rumdl_meta()
+        )
+        self.assertEqual(code, 0, f"the audit of rumdl still stands: {err}")
+        self.assertIn("rpds-py", out)
+        self.assertIn("not-a-version", out, "printed unsorted rather than dropped")
 
 
 class TestOsvBatching(_MainHarness):

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -40,6 +40,9 @@ from __future__ import annotations
 import ast
 import pathlib
 import re
+import subprocess
+import sys
+import tempfile
 import unittest
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
@@ -858,13 +861,220 @@ class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
         A cross-artifact check, in the same family as "every path the prose names
         must exist": reword the script and the quotation goes stale, sending the
         reader to look for a line that is no longer there.
+
+        The quotation is *read out of the prose* rather than written here as a
+        third copy. Hardcoding it meant the literal lived in two places and this
+        test passed by agreeing with itself; derived, a reworded script fails
+        until the reference is brought along, which is the coupling it exists for.
         """
-        quoted = "forked packages: every pin verified, one of them installed"
-        self.assertIn(quoted.split(":")[0], self.material(5))
+        # Fenced blocks first: ``` pairs off against the inline spans and drags
+        # the scan out of alignment, which reads as "the prose stopped quoting
+        # it". The quotation has to be in prose anyway — a heading named inside
+        # a bash block is not the reader being told where to look.
+        phase5 = re.sub(r"```.*?```", "", self.material(5), flags=re.DOTALL)
+        # Whitespace-collapsed on both sides: the quotation wraps across a line
+        # in the Markdown, and a guard that a reflow can break is one that gets
+        # deleted rather than fixed.
+        quoted = [
+            " ".join(q.split())
+            for q in re.findall(r"`([^`]+)`", phase5)
+            if q.lstrip().startswith("forked packages")
+        ]
+        self.assertEqual(
+            len(quoted), 1, "Phase 5 should quote audit.py's fork heading exactly once"
+        )
+        script = " ".join((PLUGIN / "scripts/audit.py").read_text(encoding="utf-8").split())
         self.assertIn(
-            quoted,
-            (PLUGIN / "scripts/audit.py").read_text(encoding="utf-8"),
-            "SKILL.md quotes a line audit.py no longer prints",
+            quoted[0],
+            script,
+            "Phase 5 quotes a line audit.py no longer prints",
+        )
+
+    def test_the_prose_names_both_groups_the_script_prints(self):
+        """The fork list is lockfile-wide and split; the prose must carry both.
+
+        Widening the list without the split is what produced the defect it fixes:
+        an unaudited fork printed beside audited ones, and a report that called
+        it "verified by Phase 1". The heading a reader has to *not* misread is
+        the unaudited one, so that is the one held here.
+        """
+        script = (PLUGIN / "scripts/audit.py").read_text(encoding="utf-8")
+        self.assertIn("NOT audited by this run", script)
+        self.assertIn(
+            "NOT audited by this run",
+            self.material(5),
+            "Phase 5 must name the group heading whose rows it forbids calling verified",
+        )
+
+    def test_an_unaudited_fork_is_not_described_as_verified(self):
+        """The reference modelled the exact wrong sentence.
+
+        `audit.py` only ever audits the changed set, so "the 3.11 fork of
+        `rpds-py` was verified but not installed" — about a package no bump
+        touched — asserts a check that never ran. It was the example row, and a
+        real #365 report reproduced it almost verbatim.
+        """
+        phase5 = self.material(5)
+        self.assertNotIn(
+            "fork of `rpds-py` was verified",
+            phase5,
+            "the example sentence claims Phase 1 verified an unchanged package",
+        )
+        self.assertIn(
+            "neither audited nor installed",
+            phase5,
+            "the worked example must model the unaudited-fork wording, not the verified one",
+        )
+
+
+class TestPhase5SalvagesARefusedNoBuild(SkillHarness):
+    """A refused `--no-build` has one documented answer, not two improvised ones.
+
+    `uv sync --locked --no-build --no-install-project` fails when a *dependency*
+    ships only an sdist, and the reference described that as an accepted loss.
+    Two consecutive replays of `fpga-board-sim` #365 then handled the same
+    refusal differently: round 10 fell back to a plain `uv sync --locked` and
+    dropped the wheels claim entirely, round 11 improvised `--no-build-package`
+    for 36 of 38 packages. Both are defensible readings, which is the defect —
+    Phase 5's own text says "'Frozen install passed' is not the same claim in
+    the two cases", so this row must not be non-deterministic across runs.
+
+    Held structurally, per the 0.31.0 lesson: a guard that only asks whether the
+    phase *mentions* `--no-build-package` passes against a sentence that never
+    elicits the call. The block has to build the exclusion and run the sync.
+    """
+
+    def _salvage_block(self) -> str:
+        for _, section in self._handoffs(5):
+            for block in bash_blocks(section):
+                if "--no-build-package" in block:
+                    return block
+        self.fail("Phase 5 documents no block that runs the narrowed --no-build")
+
+    def test_the_salvage_is_a_whole_invocation_not_a_flag_to_mention(self):
+        block = self._salvage_block()
+        self.assertIn("uv sync --locked", block, "the salvage has to reach an actual sync")
+        self.assertIn(
+            "uv.lock",
+            block,
+            "the exclusion list is derived from the lockfile; a hand-written list is "
+            "the improvisation this replaces",
+        )
+
+    def test_the_salvage_excludes_the_wheeled_packages_not_the_offender(self):
+        """The inverse is the easy mistake and it is a no-op.
+
+        `--no-build-package <offender>` refuses the build that was already
+        failing. The recipe has to name every package that *has* a wheel, so the
+        offenders are the only source builds left.
+
+        The documented snippet is **run**, against a lockfile with a known
+        sdist-only package, rather than matched for substrings. Inverting the
+        condition to `not p.get("wheels")` leaves every substring in place — a
+        pattern-matching guard cannot tell this recipe from the one that does
+        nothing, which is the distinction the whole issue is about.
+        """
+        match = re.search(r"<<'PY'\n(.*?)\nPY\n", self._salvage_block(), re.DOTALL)
+        if match is None:
+            self.fail("the salvage derives its list with an embedded PY heredoc")
+        snippet = match.group(1)
+
+        # Every `source` kind uv 0.12.7 was observed to emit, so the local/remote
+        # split is falsifiable here rather than asserted: `url` carries wheels and
+        # must be excluded, `directory` and `editable` must not be.
+        lock = """
+[[package]]
+name = "wheeled-one"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [{ url = "https://x/w1-1.0-py3-none-any.whl", hash = "sha256:aa", size = 1 }]
+
+[[package]]
+name = "sdist-only"
+version = "2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://x/s-2.0.tar.gz", hash = "sha256:bb", size = 1 }
+
+[[package]]
+name = "url-wheeled"
+version = "3.0"
+source = { url = "https://x/u-3.0-py3-none-any.whl" }
+wheels = [{ url = "https://x/u-3.0-py3-none-any.whl", hash = "sha256:cc", size = 1 }]
+
+[[package]]
+name = "git-built"
+version = "4.0"
+source = { git = "https://example.invalid/g" }
+
+[[package]]
+name = "path-dep"
+version = "5.0"
+source = { directory = "vendor/path-dep" }
+wheels = [{ url = "https://x/p-5.0-py3-none-any.whl", hash = "sha256:dd", size = 1 }]
+
+[[package]]
+name = "half-forked"
+version = "6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = ["python_full_version >= '3.11'"]
+wheels = [{ url = "https://x/h-6.0-py3-none-any.whl", hash = "sha256:ee", size = 1 }]
+
+[[package]]
+name = "half-forked"
+version = "0.9"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = ["python_full_version < '3.11'"]
+sdist = { url = "https://x/h-0.9.tar.gz", hash = "sha256:ff", size = 1 }
+
+[[package]]
+name = "the-project"
+version = "0.1.0"
+source = { editable = "." }
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "uv.lock"
+            path.write_text(lock, encoding="utf-8")
+            done = subprocess.run(
+                [sys.executable, "-", str(path)],
+                input=snippet,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(done.returncode, 0, done.stderr)
+        total, *wheeled = done.stdout.split()
+        self.assertEqual(
+            wheeled,
+            ["wheeled-one", "url-wheeled"],
+            "the exclusion list is every REMOTE package that has wheels. `sdist-only` "
+            "and `git-built` are the concessions; `half-forked` has a fork with no "
+            "wheel so uv must build it; `path-dep` and `the-project` are local and "
+            "must never be excluded, whatever they carry",
+        )
+        self.assertEqual(
+            total,
+            "5",
+            "the denominator counts PACKAGES, not lockfile blocks: five remote "
+            "packages across six blocks, because `half-forked` is forked. Counting "
+            "blocks inflates the row and passes the duplicate to "
+            "--no-build-package twice",
+        )
+
+    def test_the_boundary_is_stated_with_the_recipe(self):
+        """The narrowing proves less than a true `--no-build`, and a row that
+        does not say so overstates in the direction this phase exists to stop."""
+        material = self.material(5)
+        self.assertIn(
+            "fails fast",
+            material,
+            "uv names one refused package per run, so the reader needs to know it may "
+            "have to re-run rather than concluding the set is complete",
+        )
+        self.assertRegex(
+            material,
+            r"[Pp]roves less than a true `--no-build`",
+            "the conceded package's build code did run; the report must not read as "
+            "'no third-party build code ran'",
         )
 
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -822,10 +822,14 @@ class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
 
     `uv sync --locked` asserts the whole lockfile is consistent with the
     manifest, across every `resolution-markers` fork, and Phase 1 verifies every
-    fork's artifacts against the registry. The install then covers only the
-    resolution matching the interpreter present — so a green row on 3.14 says
-    nothing about whether the 3.11 fork's artifacts fetch or install, and nothing
-    in the report distinguished the two.
+    fork's artifacts **of the packages it audits** — which is the changed set,
+    not the lockfile. The install then covers only the resolution matching the
+    interpreter present — so a green row on 3.14 says nothing about whether the
+    3.11 fork's artifacts fetch or install, and nothing in the report
+    distinguished the two.
+
+    The unqualified version of that sentence stood here until 0.32.0 and was the
+    same claim the reference made; #88 is what it cost.
 
     Phase 5 already insists the row name *which install* ran. The same rule was
     not applied to the interpreter, where it matters more.


### PR DESCRIPTION
Closes #87 and #88 — the two deviations round 11 handed back on `fpga-board-sim`
#365. Both are Phase 5 asking for a disclosure the run cannot actually make, so
the auditor improvises one, and the improvisation is not the same twice.

## #88 — the fork list covered the bump, not the lockfile

`audit.py` built the list from `report["currency"]`, which only ever holds the
changed set, so a package forked and **unchanged** produced no fork list at all.
`pins`, four lines above it, was already lockfile-wide and said so in its own
comment.

On #365 that left the auditor deriving the list by hand with inline `tomllib`
and the report asserting *"`rpds-py 0.30.0` … was verified by Phase 1 but not
installed"* — false in its first half. The reference modelled that exact sentence
in its own worked example, and three of its statements were wrong about their own
script (*"**every** fork's artifacts"*, *"Phase 1 checked all of them"*, and the
example).

Widening alone would have made the wrong sentence **easier** to write, so the
list prints in two groups. Artifact provenance really is changed-only; conflating
it with pin structure is how #88 started.

## #87 — a refused `--no-build` had no documented salvage

Round 10 fell back to a plain `uv sync --locked` and dropped the wheels claim;
round 11 hand-rolled `--no-build-package` with the offender and project names
hardcoded. Phase 5's own text says *"'Frozen install passed' is not the same
claim in the two cases"*, so a row that is non-deterministic across runs is a
defect rather than a preference.

The lockfile already names the offenders — no `wheels` array means uv must build
it — so excluding every package that *has* one leaves the concessions as the only
source builds.

**The first version of that filter was wrong**, and the new guard caught it:
`registry`-only looks equivalent to local-vs-remote and is not. Measured on uv
0.12.7, a `url` or `git` dependency escapes both the exclusion and the
denominator, and a `url` wheel does carry a `wheels` array.

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim #365`

Twice, headless via `--plugin-dir`, because the first round found a defect in the
fix and the second confirms the correction.

**Round 12 — both fixes reached the run.** Phase 1 printed what round 11 printed
nothing for:

```
=== forked packages: uv pins these at more than one version
      NOT audited by this run — lockfile structure only, no artifact
      of these was checked, because they are outside the changed set:
        rpds-py                  2 pins: 0.30.0, 2026.6.3
```

and the report's Phase 5 row then read:

```
`rpds-py` is forked (0.30.0 / 2026.6.3); the install materialised 2026.6.3, and
Phase 1 audited neither pin — it is outside the changed set, so it is unaudited
and not installed, not "verified but not installed".
```

The salvage was lifted verbatim from the reference and ran — but printed:

```
held 37 of 38 third-party packages to wheels
sdist-built (the concession):
actionlint-py
```

That lockfile has 39 blocks, 38 of them remote, and **37 remote packages** —
`rpds-py` is forked across two. The recipe counted blocks, inflating both halves
of a row whose entire value is that a reader can check the numbers, and passed
the duplicate to `--no-build-package` twice.

**Folded into this change rather than deferred.** A forked package is held to a
wheel only if *every* one of its forks has one, since uv must build the fork that
does not.

**Round 13 — the corrected recipe, same PR:**

```
held 36 of 37 third-party packages to wheels
sdist-built (the concessions):
    actionlint-py
EXIT=0
```

### Measured and deliberately not fixed

Round 12 also handed back a claim that Phase 7's `git worktree remove` *"will
fail on **every** `uv.lock` audit that reaches Phase 5"*, because `uv sync`
leaves a `.venv/`. It does not:

```
A: untracked .venv/ dir       -> exit=0
B: untracked root file        -> exit=128  | fatal: ... use --force to delete it
C: clean                      -> exit=0
D: real uv .venv (many files) -> exit=0
```

git 2.55.0 does not descend into a wholly-untracked directory — the same
mechanism as #83 — and the replay went straight to `--force`, so it never ran the
plain form it reports as failing. Left alone.

## Tests

310, green on Python 3.11–3.14, plus ruff 0.16.2 and mypy 1.18.2.

The salvage guard **runs the documented snippet** against a fixture carrying every
`source` kind uv was observed to emit, rather than matching it for substrings —
inverting the condition to `not p.get("wheels")` leaves every substring in place,
so a pattern-matching guard cannot tell the recipe from the one that does nothing.
Fifteen mutants confirm the new guards, including the registry-only filter and the
block-wise count.

The cross-artifact quotation guard now reads its quote out of the prose instead of
holding a third copy of the literal; it had been passing by agreeing with itself.
