### PR TITLE
fix: prune stale worktrees before Phase 0 fetches, and give Phase 2 a way to reach a changelog (0.33.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/.github/workflows/live.yml
+++ b/.github/workflows/live.yml
@@ -33,3 +33,10 @@ jobs:
       - run: python -m unittest discover -s integration -v
         env:
           RUN_NETWORK_TESTS: "1"
+          # `test_live_changelog_sources` shells out to `gh api`, and `gh` refuses
+          # to run unauthenticated. Without a token its helper raises SkipTest, so
+          # the whole file would skip in silence — a guard that never fires while
+          # looking like coverage, which is worse than not having it. Read-only:
+          # the job's `permissions:` is `contents: read`, and every repository it
+          # queries is public.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,83 @@ patch.
 
 ## [Unreleased]
 
+## [0.33.0] — 2026-08-30
+
+Closes [#90](https://github.com/Machai-Kydoimos/dependabot-audit/issues/90) and
+[#91](https://github.com/Machai-Kydoimos/dependabot-audit/issues/91), handed back
+by the round-12 and round-13 replays of `fpga-board-sim` #365. Both are the same
+shape: a phase names a step it never says how to take, so the run improvises one
+— and an improvisation that comes up empty is indistinguishable from a real
+absence.
+
+**Minor, not patch.** Phase 0 gains a command in its state-changing block, and
+Phase 2 gains a documented method where it had none. Both change what the phase
+does and what its row can assert.
+
+### Fixed
+
+- **Phase 0 prunes stale worktree registrations before it fetches** (#90).
+  `$SCRATCH` lives under `$TMPDIR`, so a reboot or a tmp sweep between two audits
+  of the same PR deletes the worktrees and leaves their registrations behind. Git
+  then refuses **the fetch** — one command before either `worktree add` — with
+  `refusing to fetch into branch 'refs/heads/pr-<N>' checked out at '<a path that
+  no longer exists>'`. The stale-worktree paragraph that exists for exactly this
+  is keyed to `git worktree add` refusing, so Phase 0 died two commands before
+  reaching its own remedy. Measured on git 2.55.0: stale registration → fetch
+  exits 128; `prune` first → fetch and both adds exit 0; `prune` on clean state
+  is a no-op.
+
+  **The hand-back was wrong about both remedies**, and the issue records the
+  measurement rather than the row: `git worktree remove` does *not* fail on a
+  missing path (exit 0, and git's own message for the `add` case names it), and
+  `git branch -D` was never needed once the registration was gone. `prune` is
+  preferred for taking no path argument and clearing `pr-<N>` and `base-<N>`
+  together.
+
+### Added
+
+- **Phase 2 has a way to reach a changelog** (#91). *"Read the changelog for
+  every version in the gap"* had no method anywhere in the plugin — not how to
+  find the project's repository, not how to name the release tag, not what to do
+  when there is no release. `references/uv-lock.md` § Phase 2 now carries the
+  repo lookup and a three-rung ladder: release notes, then a changelog section
+  for that exact version, then the tag-to-tag commit range. **Say which rung
+  produced the row**, for the same reason Phase 5 says which install ran.
+
+- **The tag is matched against the release list, never constructed.** Measured
+  2026-08-30 across one bump's three tools: `ruff` releases as `0.16.4` (and
+  `gh release view v0.16.4` is *release not found*, while its **older** tags do
+  carry `v`), `rumdl` as `v0.2.58`, and `python/mypy` publishes **zero** releases
+  while tagging `v2.3.1`. A guessed prefix returns "release not found", which
+  reads exactly like "this version has no notes" — so the audit reports an
+  absence of evidence as evidence of absence for a version whose notes are
+  sitting there.
+
+  mypy is the worked example because it needs all three rungs: no releases, a
+  `CHANGELOG.md` written per *minor* release so there is no `2.3.1` section, and
+  then six commits in the range. It is also in the `dev` group of most repos this
+  plugin audits, so the row that used to go quiet went quiet often.
+
+### Tests
+
+- **The repo's own pipe guard caught the first version of the ladder.**
+  `gh api … | grep | head` reports `head`'s status, so a failed lookup yields an
+  empty tag at exit 0 — the exact failure the new prose warns about, reintroduced
+  by the code teaching it. The block now captures the release list, checks the
+  status, and filters the variable.
+
+- **`integration/test_live_changelog_sources.py`** holds the two claims about
+  other people's repositories that the prose rests on: that mypy still publishes
+  no releases, and that ruff and rumdl still disagree about the `v` prefix. They
+  belong in the network suite precisely because they can change under us — if
+  mypy starts cutting releases, the example should be revisited rather than left
+  quietly asserting something that stopped being true.
+
+- **A guard anchored to the whole of `material(2)` passed trivially** and was
+  narrowed. `actions.md` § Phase 2 carries its own `compare` call, so a check for
+  the commit-range rung was satisfied by a different reference's prose — the
+  round-8 trap, recurring. Six mutants confirm the guards, including that one.
+
 ## [0.32.0] — 2026-08-30
 
 Closes [#87](https://github.com/Machai-Kydoimos/dependabot-audit/issues/87) and
@@ -3734,7 +3811,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.1...v0.31.0
 [0.30.1]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.0...v0.30.1

--- a/integration/test_live_changelog_sources.py
+++ b/integration/test_live_changelog_sources.py
@@ -1,0 +1,88 @@
+"""The premise behind Phase 2's changelog ladder: not every project releases.
+
+`references/uv-lock.md` § Phase 2 tells the auditor to fall back from release
+notes to a changelog section to a tag-to-tag commit range, and justifies the
+ladder with two facts about the outside world:
+
+1. a widely-depended-on project can publish **no GitHub releases at all**, and
+2. release tags disagree about the `v` prefix, so constructing one silently
+   returns "release not found" — which reads exactly like "no notes for this
+   version".
+
+Both are claims about other people's repositories and both can change without
+notice. That is precisely why they belong here rather than in the hermetic
+suite: if `python/mypy` starts cutting releases, the prose should be revisited,
+not quietly left asserting something that stopped being true.
+
+    RUN_NETWORK_TESTS=1 python3 -m unittest discover -s integration -v
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import unittest
+from typing import Any
+
+live = unittest.skipUnless(
+    os.environ.get("RUN_NETWORK_TESTS"),
+    "set RUN_NETWORK_TESTS=1; this queries api.github.com",
+)
+
+
+def gh_json(path: str, jq: str) -> Any:
+    """One `gh api` call, unpiped, with its exit status actually checked.
+
+    CONTRIBUTING's standing trap: `gh api ... | jq` reports jq's status, so an
+    auth failure or a rate limit arrives as an empty result at exit 0 — which
+    here would look like "this project publishes no releases", the very fact
+    under test.
+    """
+    done = subprocess.run(
+        ["gh", "api", path, "--jq", jq],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if done.returncode != 0:
+        raise unittest.SkipTest(f"gh api {path} failed ({done.returncode}): {done.stderr.strip()}")
+    return json.loads(done.stdout or "null")
+
+
+@live
+class TestNotEveryProjectPublishesReleases(unittest.TestCase):
+    def test_mypy_still_publishes_no_github_releases(self):
+        """The worked example in the reference. If this starts failing, mypy has
+        begun releasing and the ladder's rung-3 example needs a new subject."""
+        count = gh_json("repos/python/mypy/releases", "length")
+        self.assertEqual(
+            count,
+            0,
+            "python/mypy now publishes releases — Phase 2's 'zero releases, patch "
+            "documented only in commits' example is stale",
+        )
+
+    def test_mypy_still_tags_what_it_does_not_release(self):
+        """The ladder only works because the tags exist to compare between."""
+        tags = gh_json("repos/python/mypy/tags", "[.[].name]")
+        self.assertIn("v2.3.1", tags, "the tag the reference compares from is gone")
+
+    def test_the_commit_range_still_answers_for_a_patch_release(self):
+        n = gh_json("repos/python/mypy/compare/v2.3.0...v2.3.1", ".commits | length")
+        self.assertIsInstance(n, int)
+        self.assertGreater(n, 0, "rung 3 returned nothing for a release known to have content")
+
+
+@live
+class TestReleaseTagsDisagreeAboutThePrefix(unittest.TestCase):
+    """Why the reference matches the tag instead of building it."""
+
+    def test_ruff_releases_without_a_v_prefix(self):
+        tags = gh_json("repos/astral-sh/ruff/releases?per_page=100", "[.[].tag_name]")
+        self.assertIn("0.16.4", tags)
+        self.assertNotIn("v0.16.4", tags, "ruff has started prefixing; the example needs updating")
+
+    def test_rumdl_releases_with_one(self):
+        tags = gh_json("repos/rvben/rumdl/releases?per_page=100", "[.[].tag_name]")
+        self.assertIn("v0.2.58", tags)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,6 @@ exclude = ["integration/fixtures"]
 # override then disappears with no warning, not even under
 # --warn-unused-configs (tested: errors went 25 -> 175). Adding a test file
 # means adding it here; forgetting is loud, which is the safer direction.
-module = ["test_audit", "test_ci_state", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry"]
+module = ["test_audit", "test_ci_state", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry", "test_live_changelog_sources"]
 disallow_untyped_defs = false
 disallow_untyped_calls = false

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -155,10 +155,26 @@ Then the part that changes state, which is yours:
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
+git worktree prune          # a previous run's registrations, if $SCRATCH is gone
 git fetch origin "pull/<N>/head:pr-<N>" "$DEFAULT"
 git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
 ```
+
+**`prune` first, and it is not defensive clutter.** `$SCRATCH` lives under
+`$TMPDIR`, so a reboot or a tmp sweep between two audits of the same PR deletes
+the worktrees and leaves their registrations behind. Git then refuses **the
+fetch** — one command before any `worktree add` — with a message naming a
+directory that is not there:
+
+```
+fatal: refusing to fetch into branch 'refs/heads/pr-<N>' checked out at '<a path that no longer exists>'
+```
+
+That is this, not a permissions or ref problem, and the stale-worktree paragraph
+below does not reach it: that paragraph is keyed to `git worktree add` refusing,
+and Phase 0 never gets that far. `prune` is a no-op when state is clean, needs no
+path argument, and clears `pr-<N>` and `base-<N>` together.
 
 **An actions bump consumes neither worktree — do not create them for one.**
 `references/actions.md` reads the diff with `git show "pr-<N>:…"` throughout,

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -133,6 +133,66 @@ The mechanical half — the registry's true latest, with publish timestamps — 
 **already done** by the Phase 1 script. What is left is the question `SKILL.md`
 sends here: this repo runs the tool, so is it in the change's scope?
 
+### Reaching the changelog at all
+
+`SKILL.md` says to read the changelog for every version in the gap. For a PyPI
+package that is three steps, and each has a way of failing quietly.
+
+**The repo is in PyPI's metadata, not guessable from the package name.** The
+Simple API the Phase 1 script uses carries artifacts and nothing else, so this is
+the one place to reach for the JSON API:
+
+```bash
+PKG=<name>; VER=<version>
+REPO=$(python3 - "$PKG" <<'PY'
+import json, sys, urllib.request
+d = json.load(urllib.request.urlopen(f"https://pypi.org/pypi/{sys.argv[1]}/json", timeout=30))
+for url in (d["info"].get("project_urls") or {}).values():
+    if url and "github.com/" in url:
+        print("/".join(url.split("github.com/")[1].strip("/").split("/")[:2])); break
+PY
+)
+
+# Do NOT construct the tag. Match it — and capture the list before filtering it,
+# so a failed lookup is a failed lookup and not an empty answer.
+TAGS=$(gh api "repos/$REPO/releases" --paginate --jq '.[].tag_name') \
+  || { echo "release list unavailable for $REPO — a lookup failure, not an absent release" >&2; exit 2; }
+TAG=$(printf '%s\n' "$TAGS" | grep -Fx -e "$VER" -e "v$VER" | head -1)
+```
+
+**Constructing the tag is the quiet failure.** Projects disagree about the `v`
+prefix and change their minds mid-life. Measured 2026-08-30, on the three tools
+in one bump:
+
+| Project | Release tag for the audited version | Note |
+|---|---|---|
+| `ruff` | `0.16.4` | `gh release view v0.16.4` → *release not found*; its **older** tags do carry `v` |
+| `rumdl` | `v0.2.58` | |
+| `mypy` | — | tags `v2.3.1`, publishes **no releases at all** |
+
+A guessed tag returns "release not found", which reads exactly like "this version
+has no notes" — so the audit reports an absence of evidence as evidence of
+absence, for a version whose notes are right there.
+
+**Then the ladder, in order. Say which rung produced the row:**
+
+| Rung | Command | When it runs out |
+|---|---|---|
+| 1. release notes | `gh release view "$TAG" --repo "$REPO"` | the project publishes none — check `gh api repos/$REPO/releases --jq length`, and `0` means *never*, not *not yet* |
+| 2. the repo's changelog | fetch `CHANGELOG.md` and find the section for **this exact version** | the project writes entries per *minor* release, so a patch has no section |
+| 3. the commit range | `gh api repos/$REPO/compare/<tag-before>...<tag> --jq '.commits[].commit.message'` | the tags themselves are missing, which is worth reporting |
+
+Measured on `mypy` 2.3.0 → 2.3.1, which needs all three rungs: zero releases, a
+`CHANGELOG.md` whose headings run `Next Release`, `Mypy 2.3`, `Mypy 2.2` with no
+`2.3.1` between them, and then six commits in the range — a crash fix on
+overload unpacking and three `mypyc` fixes, which is the content the phase came
+for.
+
+**"No changelog" is not a finding; "rung 3, six commits" is.** Report which rung
+answered, the same way Phase 5 reports which install ran. A patch release from a
+project that tags without releasing is ordinary — mypy is in the `dev` group of
+most repos this plugin audits — so a row that goes quiet here goes quiet often.
+
 ### When the changelog entry names a dependency
 
 A compiled Python package vendors another ecosystem's dependency graph into its

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -3152,3 +3152,120 @@ class TestExposureIsEstablishedRatherThanAssumed(SkillHarness):
             "file while the verdict is about the tool — the same gap Phase 6 "
             "closed for a red check by attributing it",
         )
+
+
+class TestPhase0ClearsAStaleWorktreeRegistration(SkillHarness):
+    """`$SCRATCH` lives under `$TMPDIR`, so it disappears between audits.
+
+    The worktrees go; their registrations in `.git/worktrees` do not. Git then
+    refuses the **fetch** — `refusing to fetch into branch 'refs/heads/pr-<N>'
+    checked out at '<a path that no longer exists>'` — and Phase 0 dies one
+    command before either `worktree add`.
+
+    That matters because the stale-worktree paragraph further down is keyed to
+    `git worktree add` refusing, so the phase's own remedy is unreachable from
+    the failure that actually fires. Measured on git 2.55.0: with the
+    registration stale the fetch exits 128; `git worktree prune` first makes the
+    fetch, and both adds, exit 0, and `prune` on clean state is a no-op.
+
+    Ordering is the whole content of the fix, so the guard checks position and
+    not merely presence — `prune` after the fetch would be green on a
+    substring test and useless in the run.
+    """
+
+    def _phase0(self) -> str:
+        return self.shell[0]
+
+    def test_phase_0_prunes_before_it_fetches(self):
+        shell = self._phase0()
+        self.assertIn("git worktree prune", shell, "Phase 0 must clear stale registrations")
+        prune = shell.index("git worktree prune")
+        fetch = shell.index('git fetch origin "pull/')
+        self.assertLess(
+            prune,
+            fetch,
+            "prune must run BEFORE the fetch: the fetch is what a stale registration "
+            "refuses, and pruning afterwards never runs",
+        )
+
+    def test_the_failure_it_answers_is_named(self):
+        """A message naming a directory that is not there reads like a
+        permissions or ref problem, and the reader has no reason to connect it
+        to worktrees at all."""
+        body = dict(self.phases)[0]
+        self.assertIn(
+            "refusing to fetch into branch",
+            body,
+            "Phase 0 must quote the error, or the remedy is unfindable from the symptom",
+        )
+
+
+class TestPhase2CanReachAChangelogAtAll(SkillHarness):
+    """ "Read the changelog for every version in the gap" had no method.
+
+    Nothing in the plugin said how to find the project's repo, how to name the
+    release tag, or what to do when there is no release — so every run
+    improvised, and a run that improvises "no changelog found" reports an
+    absence of evidence as evidence of absence.
+
+    Measured 2026-08-30 on the three tools in `fpga-board-sim` #365: `ruff`'s
+    release tag is `0.16.4` (and `v0.16.4` is *release not found*), `rumdl`'s is
+    `v0.2.58`, and `python/mypy` publishes **zero** releases while tagging
+    `v2.3.1` — with a `CHANGELOG.md` that has no `2.3.1` section, because it
+    writes entries per minor release. Only the commit range answers that one.
+    """
+
+    def _ladder(self) -> str:
+        for _, section in self._handoffs(2):
+            for block in bash_blocks(section):
+                if "project_urls" in block:
+                    return block
+        self.fail("Phase 2 documents no way to find the project's repository")
+
+    def test_the_tag_is_matched_against_the_release_list_not_constructed(self):
+        """Guessing the prefix returns "release not found", which reads exactly
+        like "this version has no notes"."""
+        block = self._ladder()
+        self.assertIn("tag_name", block, "the tag comes from the release list")
+        self.assertRegex(
+            block,
+            r"grep -Fx.*-e \"\$VER\".*-e \"v\$VER\"",
+            "both spellings must be matched against what the project actually "
+            "published, rather than one of them assumed",
+        )
+
+    def test_a_failed_lookup_is_not_read_as_an_absent_release(self):
+        """The same distinction Phase 0 draws for every derived output, at the
+        point where the two look identical: an empty tag."""
+        block = self._ladder()
+        self.assertIn(
+            "a lookup failure, not an absent release",
+            block,
+            "a failed `gh api` must exit, not fall through to 'no release for this version'",
+        )
+
+    def _uv_lock_phase2(self) -> str:
+        """Just `uv-lock.md`'s Phase 2, never the whole of `material(2)`.
+
+        `actions.md` § Phase 2 carries its own `compare` call for the tag-line
+        question, so a guard reading every reference at once is satisfied by
+        that one and says nothing about this ladder — the trap round 8 named:
+        anchor a prose guard to the subsection it is about.
+        """
+        for name, section in self._handoffs(2):
+            if name == "uv-lock.md":
+                return section
+        self.fail("Phase 2 no longer hands off to uv-lock.md")
+
+    def test_all_three_rungs_are_named(self):
+        section = self._uv_lock_phase2()
+        for rung in ("gh release view", "CHANGELOG.md", "/compare/"):
+            self.assertIn(rung, section, f"the ladder is missing {rung}")
+
+    def test_the_row_says_which_rung_answered(self):
+        """ "No changelog" is not a finding; "rung 3, six commits" is."""
+        self.assertRegex(
+            self._uv_lock_phase2(),
+            r"[Ss]ay which rung produced the row|which rung answered",
+            "Phase 2 must report which rung produced the row, as Phase 5 reports which install ran",
+        )


### PR DESCRIPTION
Closes #90 and #91, handed back by the round-12 and round-13 replays of
`fpga-board-sim` #365.

Both are the same shape, which is why they ship together: **a phase names a step
it never says how to take.** The run improvises one, and an improvisation that
comes up empty is indistinguishable from a real absence — a fetch that fails for
an unexplained reason, a changelog reported as missing when it is sitting there.

## #90 — Phase 0 died two commands before its own remedy

`$SCRATCH` lives under `$TMPDIR`, so a reboot or a tmp sweep between two audits
of the same PR deletes the worktrees and leaves their registrations in
`.git/worktrees`. Git then refuses **the fetch**:

```
fatal: refusing to fetch into branch 'refs/heads/pr-<N>' checked out at '<a path that no longer exists>'
```

The stale-worktree paragraph written for exactly this situation is keyed to `git
worktree add` refusing — and Phase 0 runs the fetch two commands earlier, so the
remedy is unreachable from the failure that fires. `git worktree prune` now runs
first: a no-op when state is clean, no path argument, and it clears `pr-<N>` and
`base-<N>` together.

**The hand-back was wrong about both remedies**, and #90 records the measurement
rather than the row:

```
A: untracked .venv/ dir       -> exit=0
B: git worktree remove on a missing path -> exit=0     <- the row said this fails
C: re-fetch after remove      -> exit=0                <- the row said branch -D was needed
```

`git worktree remove` succeeds on a missing path — git's own message for the
`add` case even names it as a remedy — and once the registration is gone the
fetch succeeds, so `branch -D` is never reached for.

## #91 — "read the changelog" had no method

Not how to find the project's repository, not how to name the release tag, not
what to do when there is no release. `references/uv-lock.md` § Phase 2 now
carries the repo lookup and a three-rung ladder — release notes, changelog
section, tag-to-tag commit range — and asks **which rung produced the row**, for
the same reason Phase 5 asks which install ran.

**The tag is matched against the release list, never constructed.** Measured
across one bump's three tools:

| Project | Release tag | Note |
|---|---|---|
| `ruff` | `0.16.4` | `gh release view v0.16.4` → *release not found*; its **older** tags do carry `v` |
| `rumdl` | `v0.2.58` | |
| `mypy` | — | tags `v2.3.1`, publishes **zero** releases |

A guessed prefix returns "release not found", which reads exactly like "this
version has no notes" — the audit then reports an absence of evidence as evidence
of absence for a version whose notes are right there.

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim #365`

**With a stale worktree registration planted deliberately**, so the run met #90's
failure rather than a simulation of it:

```
$ git worktree list | tail -1
/tmp/dbaudit-.../pr-365   51b5aa6 [pr-365] prunable
```

Phase 0 pruned, then fetched and built both worktrees clean:

```
git worktree prune
git fetch origin "pull/365/head:pr-365" "$DEFAULT"
 * branch            main       -> FETCH_HEAD
Preparing worktree (checking out 'pr-365')
Preparing worktree (detached HEAD dec7f01)
```

Phase 2 used the ladder as written — repo lookup, captured-then-filtered tag
match, all three rungs on mypy:

```
mypy  -> python/mypy    releases=0
ruff  -> astral-sh/ruff releases=30
ruff 0.16.4 -> tag='0.16.4'          rumdl 0.2.58 -> tag='v0.2.58'

=== rung 1: releases ===
python/mypy releases = 0  (0 = never publishes releases)
=== rung 2: CHANGELOG.md headings ===
3:## Next Release
9:## Mypy 2.3
132:## Mypy 2.2
=== rung 3: commit range v2.3.0...v2.3.1 ===
Fix crash when unpacking return value from overload (#21830)
```

and the report's Security row reads:

> mypy 2.3.1 reached at **rung 3** (0 GitHub releases, no `2.3.1` CHANGELOG
> section) — 6 commits: an overload-unpacking crash fix + three mypyc fixes.

Eight phases, no errors, `merge as-is`.

## Three things caught during the work, all folded in

**The repo's own pipe guard rejected the first ladder.** `gh api … | grep | head`
reports `head`'s status, so a failed lookup yields an empty tag at exit 0 — the
exact failure the new prose warns about, reintroduced by the block teaching it.
It now captures the release list, checks the status, then filters the variable.

**A guard anchored to all of `material(2)` passed trivially.** `actions.md` §
Phase 2 carries its own `compare` call, so a check for the commit-range rung was
satisfied by a different reference's prose — the round-8 trap, recurring.
Narrowed to `uv-lock.md` § Phase 2, and the mutant now fails.

**`live.yml` set no `GH_TOKEN`.** The new integration file shells out to `gh`,
which refuses to run on a runner with no stored credentials, so its helper would
have raised `SkipTest` and the whole file would have skipped in silence — a guard
that never fires while looking like coverage. The job's `permissions:` is already
`contents: read` and every repository it queries is public.

## Tests

316 on Python 3.11–3.14, plus ruff 0.16.2 and mypy 1.18.2. Six mutants confirm
the new guards, including the reordered `prune` and the trivially-passing one.

`integration/test_live_changelog_sources.py` holds the two claims about other
people's repositories that the prose rests on — that mypy still publishes no
releases, and that ruff and rumdl still disagree about the `v` prefix. They
belong in the network suite precisely because they can change under us: if mypy
starts cutting releases, the worked example should be revisited rather than left
quietly asserting something that stopped being true.
