### PR TITLE
fix: stop --no-execute running the PR's build code, and make a hand-back cite its evidence (0.34.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,109 @@ patch.
 
 ## [Unreleased]
 
+## [0.34.0] — 2026-09-01
+
+Closes [#93](https://github.com/Machai-Kydoimos/dependabot-audit/issues/93) and
+[#96](https://github.com/Machai-Kydoimos/dependabot-audit/issues/96), both raised
+from a Phase 8 hand-back of a `uv.lock` audit of PR #384. They are the same shape
+from two directions: a claim this procedure makes **about itself** that its own
+commands falsified, and nothing anywhere to catch it.
+
+**Minor, not patch.** Phase 3 changes what it audits and what it runs to do it,
+and Phase 8 gains a class the hand-back did not have.
+
+### Fixed
+
+- **Phase 3 audits the lockfile, and no longer executes the PR** (#93). The only
+  recipe was `uv run --with pip-audit pip-audit --skip-editable`, and `uv run`
+  syncs the project first — installing it editable and building any sdist in the
+  resolution. Measured on uv 0.12.8 against a project whose `setup.py` writes a
+  file when it runs: the file appears, and `pip-audit`'s own output names the
+  project as `distribution marked as editable`.
+
+  `--no-execute` runs Phases 0–3 and 6–7 and says *"every one of those is a
+  network read"*. So the mode that exists for **a PR you have no reason to trust
+  yet** ran that PR's build code — with no `MAY_EXECUTE` gate and no banner, both
+  of which Phases 4 and 5 carry.
+
+  The phase now exports and audits the lockfile: `uv export --frozen` into
+  `$SCRATCH`, then `uvx pip-audit -r … --no-deps --disable-pip`. No resolution, no
+  `pip`, no environment. **Verified in both directions**, because an auditor that
+  cannot report dirty is worse than none: a clean export exits 0, and
+  `jinja2==2.11.3` through the same command exits 1 with four advisories.
+
+  Two further gaps closed with it. The recipe never said **which tree** — run in
+  the user's checkout it audits the currently installed set and reports clean
+  about a dependency set that is not the one under audit, the same silent-failure
+  shape as the interpreter trap already documented beside it. And it audited **one
+  resolution**; the export emits every fork with its marker, which is the scope
+  `uv sync --locked` asserts and the install does not.
+
+- **Phase 2's config differential stopped syncing the project too** (#93). Found
+  by the new guard rather than by reading — `uv run <tool> check` is the same
+  defect in the same `--no-execute` set, and it had been there since 0.32.0. It
+  now reads `uv run --no-project --with <tool>==<locked>`, the spelling Phase 4
+  already used. Measured on uv 0.12.8: plain `uv run` produces the build trace and
+  a `.venv`; `--no-project` produces neither.
+
+- **The `--no-execute` claim now says what it depends on.** *"Every one of those
+  is a network read"* is a property of each phase's commands, not of its number,
+  and a phase in that set which gains a command has to be checked against it. The
+  paragraph says so, and the suite now enforces it.
+
+### Added
+
+- **A hand-back row carries its evidence, or it is `unproven`** (#96). Phase 8's
+  deviation list classified as **plugin defect**, **prose gap** or **correct**,
+  with no requirement to say how the class was reached — so a row's classification
+  carried the authority of a measurement while resting on an inference. It is the
+  only output in this plugin that classifies without citing; Phase 7's report has
+  a verdict table and a confidence rule that is *"derived, not felt"*.
+
+  A `plugin defect` row now names the command that failed and the exit status it
+  returned. Where the run went straight to a workaround and never issued the form
+  the procedure specifies, the class is the new **`unproven`** — the deviation is
+  still real and still handed back, but its cause was inferred and the row says so.
+
+- **"Did this happen?" before "is this mechanism right?"** The cheapest check is
+  searching the session's own history for the command the row says failed. Where
+  it was never issued, that settles the row in seconds, before any measurement.
+
+- **An `unproven` row is a question, not a ticket.** The reader-facing half, and
+  the one that actually broke: the same claim — that Phase 7's `git worktree
+  remove` fails because Phase 5's `uv sync` leaves a `.venv/` — arrived on
+  2026-08-30 and again on 2026-09-01 from two different audits, each with a stated
+  mechanism, neither having run the plain command. Measured on git 2.55.0 and uv
+  0.12.8 in a worktree of a repo with **no `.gitignore` at all**: `remove` exits 0.
+  It gates on `git status --porcelain`, which omits *ignored* files, and uv writes
+  a `.gitignore` containing `*` inside `.venv/`. The second row labelled itself
+  unproven and became an issue anyway.
+
+### Tests
+
+- **`TestNoExecutePhaseBuildsTheAuditedProject`** holds every phase in the
+  `--no-execute` set to running nothing that builds or installs the audited
+  project, reading `reachable()` so it follows a phase into its ecosystem
+  reference and into any script the phase is mechanised into later. It found the
+  Phase 2 instance above on its first run, which is the argument for it.
+
+- **The anti-vacuity check is pinned to literals, not to the document.** A pattern
+  that matches nothing satisfies a negative guard in silence, so the discrimination
+  is asserted against the two commands that shipped and the three that replaced
+  them. A live check that the pattern still fires on Phase 5 sits beside it.
+
+- **The guard scans code, not comments.** Its first version fired on a comment in
+  `uv-lock.md` § Phase 2 warning against the very command it forbids — the failure
+  `reachable()`'s own docstring names, reproduced by the guard written to use it.
+  Whole-line comments are dropped before matching, and the explanation moved out of
+  the fence into the prose where it reads better anyway.
+
+- **Mutation checking caught a dead guard before it shipped.** The
+  "did this happen?" assertion was written as an alternation and stayed green with
+  half its rule deleted. It now binds both halves — the question and the place to
+  look — and each half fails the guard on its own.
+
+
 ## [0.33.0] — 2026-08-30
 
 Closes [#90](https://github.com/Machai-Kydoimos/dependabot-audit/issues/90) and

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -61,6 +61,14 @@ procedure's value, and it is the right default for a PR you have no reason to
 trust yet. Use it when the user asks, and when Phase 0 classifies the PR as one
 the bots did not open. Say in the report which phases did not run.
 
+**That claim is a property of each phase's commands, not of its number**, and it
+has already been false once: until 0.34.0 the `uv.lock` recipe for Phase 3 was
+`uv run --with pip-audit …`, which syncs the project — installing it editable and
+building any sdist in the resolution — so the mode that exists for a PR you do not
+trust ran that PR's build code. A phase in this set that gains a command has to be
+checked against this sentence, which is what `tests/test_skill_prose.py` now does
+mechanically.
+
 ## Arguments
 
 `/dependabot-audit <PR> [--no-execute] [--comment]`, and the same words said in
@@ -698,6 +706,8 @@ that and asserting it.
 ## Phase 3 — Known vulnerabilities
 
 *Requires: the Phase 1 output for this ecosystem.*
+*Runs under `--no-execute`, so nothing here may execute the PR's code — and for
+`uv.lock` that is a property of the auditor's flags, not of the phase.*
 
 **The question: what does the world already know is wrong with this?** Expect it
 to agree with Phase 2 only sometimes — that divergence is the point, not a
@@ -705,7 +715,7 @@ contradiction. The method differs by ecosystem; the question does not.
 
 | Ecosystem | Method |
 |---|---|
-| `uv.lock` | `references/uv-lock.md` § Phase 3 — the OSV batch is **already done** by the Phase 1 script, so read that result rather than re-querying; what remains is the ecosystem's own auditor, and `pip-audit` audits the wrong interpreter if invoked casually |
+| `uv.lock` | `references/uv-lock.md` § Phase 3 — the OSV batch is **already done** by the Phase 1 script, so read that result rather than re-querying; what remains is the ecosystem's own auditor — and the obvious invocation of it **executes the PR's code**, in a phase `--no-execute` runs |
 | GitHub Actions | `references/actions.md` § Phase 3 — GHSA carries an `actions` ecosystem, and the obvious port of the `uv.lock` query reports **clean on a known-compromised action** |
 
 That second row is why this phase has a guard in the test suite. *"Not
@@ -1251,12 +1261,35 @@ So, separately from what the audit found about the PR, hand back:
   gap it filled;
 - **every plugin file read directly rather than invoked as written.**
 
-Classify each as **plugin defect**, **prose gap**, or **correct**. All three are
-real answers and `correct` is the common one: no procedure enumerates every repo
+Classify each as **plugin defect**, **prose gap**, **unproven**, or **correct**.
+All four are real answers and `correct` is the common one: no procedure enumerates every repo
 it will meet, and improvising is usually the right call. The goal is not to
 suppress the improvisation but to stop it being invisible — a workaround that
 *works* is precisely the one nobody reports, which is how the shadowing shipped
 in 0.2.1 and survived to 0.23.0.
+
+**A `plugin defect` row carries its evidence, or it is not that row.** Name the
+command that failed and the exit status it returned. Where the run went straight
+to a workaround and never issued the form this file specifies, the class is
+**`unproven`**: the deviation is real and still worth handing back, but its
+*cause* was inferred, and a row that does not say so is read as measured.
+
+That distinction has cost two rounds. On 2026-08-30 and again on 2026-09-01, two
+different audits handed back the same claim — that Phase 7's `git worktree
+remove` fails because Phase 5's `uv sync` leaves a `.venv/` — each with a stated
+mechanism, neither having run the plain command. Measured on git 2.55.0 and uv
+0.12.8, in a worktree of a repo with **no `.gitignore` at all**: `remove` exits
+**0**. It gates on `git status --porcelain`, which omits *ignored* files, and uv
+writes a `.gitignore` containing `*` inside `.venv/`. The mechanism was never
+there, and both rows read as though it had been observed.
+
+**The cheapest check is "did this happen?", not "is this mechanism right?"** —
+search this session's own history for the command the row says failed. Where it
+was never issued, that settles the row in seconds, before any measurement.
+
+**And an `unproven` row is a question, not a ticket.** Verify it before filing.
+Both rounds above became issues on the strength of a mechanism that reads as
+observation; the second had labelled *itself* unproven and was filed anyway.
 
 Read it off what you actually ran. Reconstructing the list from the phase
 headings returns a clean sheet every time, because the headings are what you

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -265,20 +265,31 @@ row is.
 Then the claim rests on a config line, and a config line is an assertion about a
 *file* while the verdict is about the *tool*. Run it both ways:
 
+**`--no-project` is load-bearing**, not tidiness: a plain `uv run` syncs the
+audited project first, installing it editable and building any sdist in the
+resolution. Phase 2 runs under `--no-execute`, so the tool comes from PyPI at the
+locked version instead.
+
 ```bash
-uv run <tool> check <one representative file>              # as this repo runs it
-uv run <tool> check --no-config <the same file>            # with the config out
+uv run --no-project --with <tool>==<locked> <tool> check <a representative file>
+uv run --no-project --with <tool>==<locked> <tool> check --no-config <the same file>
 ```
+
+Measured on uv 0.12.8 against a project whose `setup.py` writes a file when it
+runs: plain `uv run` produces that file and a `.venv`; `uv run --no-project`
+produces neither. Pin `<locked>` to the version the lockfile carries today — that
+is what makes it the same tool the repo runs, and the differential meaningless if
+it is not.
 
 Measured on `rumdl` 0.2.59's destructive `MD013` fix — *"stop reflow from joining
 a setext heading into its underline"* — in a repo running `rumdl check --fix` on
 every Markdown commit, where the claim was `disable = ["MD013", "MD036"]`:
 
 ```
-$ uv run rumdl check README.md
+$ uv run --no-project --with rumdl==0.2.59 rumdl check README.md
 Success: No issues found in 1 file (6ms)
 
-$ uv run rumdl check --no-config README.md
+$ uv run --no-project --with rumdl==0.2.59 rumdl check --no-config README.md
 Issues: Found 32 issues in 1 file (14ms)
 ```
 
@@ -295,22 +306,62 @@ ecosystem's own auditor. **The OSV half is already done** — the Phase 1 script
 it — so read that result instead of issuing a second query. What remains is the
 auditor.
 
-**Auditor trap.** `pip-audit` audits the environment of the interpreter it runs
-under. Activating a virtualenv does **not** redirect a `pip-audit` installed
-elsewhere — it will happily audit the system Python and report on distro
-packages. Symptom: package names in the output the project never depended on. Run
-it inside the project environment:
+**Audit the lockfile, not an environment**, and write the export *outside* the
+worktree — it is not the PR's file, and an untracked file in `$SCRATCH/pr-<N>` is
+residue Phase 7 then has to account for.
 
 ```bash
-uv run --with pip-audit pip-audit --skip-editable
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+cd "$SCRATCH/pr-<N>"                          # the PR's tree — the set under audit
+uv export --frozen --format requirements.txt --no-emit-project \
+  -o "$SCRATCH/pr-<N>-requirements.txt"       # --all-packages for a workspace
+uvx pip-audit -r "$SCRATCH/pr-<N>-requirements.txt" --no-deps --disable-pip
 ```
 
-`--skip-editable` is required when the project installs itself editable, and
-`--strict` re-escalates that skip into a fatal error — do not combine them.
-Default service is PyPI's advisory DB; `-s osv` selects OSV.
+**Three of those flags are this phase's contract, not tidiness.** `--no-deps` and
+`--disable-pip` together mean no resolution and no `pip` at all, so nothing is
+installed and no build backend runs; `--frozen` reads the lockfile rather than
+updating it. Measured on uv 0.12.8: the audited tree's `setup.py` does not run and
+no `.venv` appears. **Phase 3 runs under `--no-execute`**, where this procedure has
+promised the PR's code will not run — so the flags are what make that promise
+true. Default service is PyPI's advisory DB; `-s osv` selects OSV.
 
-`pip-audit --locked` does not necessarily parse `uv.lock`; auditing the synced
-environment is the reliable path.
+**Verified in both directions**, because an auditor that cannot report dirty is
+worse than none: a clean export exits 0 with *"No known vulnerabilities found"*,
+and `jinja2==2.11.3` through the same command exits **1** with four advisories and
+their fix versions.
+
+**The export covers every fork; a synced environment covers one.** `uv export`
+emits a pinned line per fork, each carrying its marker:
+
+```
+rpds-py==0.27.1   ; python_full_version <  '3.10'
+rpds-py==2026.6.3 ; python_full_version >= '3.11'
+```
+
+So the audit sees the 3.9 fork's older release even though this interpreter will
+never install it — the scope `uv sync --locked` asserts and the install does not,
+which is the whole reason this phase reads the lockfile. **Do not flatten the
+markers.** Both pins in one file with the markers stripped is `ResolutionImpossible`,
+and de-duplicating to one pin per name silently drops the forks it removed.
+
+**The auditor trap, for the case where you audit an environment anyway.**
+`pip-audit` audits the environment of the interpreter it runs under. Activating a
+virtualenv does **not** redirect a `pip-audit` installed elsewhere — it will
+happily audit the system Python and report on distro packages. Symptom: package
+names in the output the project never depended on. Running it inside the project
+environment fixes that, and `uv run --with pip-audit pip-audit --skip-editable` is
+the form — **but `uv run` syncs the project first**, installing it editable and
+building any sdist in the resolution. That executes the PR's code, so it belongs
+behind `MAY_EXECUTE` with Phases 4 and 5, not here. `--skip-editable` suppresses
+the *reporting* of the editable install, not the install; `--strict` re-escalates
+that skip into a fatal error — do not combine them.
+
+`pip-audit --locked` does not necessarily parse `uv.lock`, which is why the export
+is the path rather than pointing `pip-audit` at the lockfile directly.
 
 ## Phase 4 — Behavior change
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -3269,3 +3269,167 @@ class TestPhase2CanReachAChangelogAtAll(SkillHarness):
             r"[Ss]ay which rung produced the row|which rung answered",
             "Phase 2 must report which rung produced the row, as Phase 5 reports which install ran",
         )
+
+
+class TestNoExecutePhaseBuildsTheAuditedProject(SkillHarness):
+    """`--no-execute` says Phases 0-3 and 6-7 are network reads. Two of them were not.
+
+    Until 0.34.0 `references/uv-lock.md` § Phase 3 gave one command —
+    `uv run --with pip-audit pip-audit --skip-editable` — and § Phase 2's config
+    differential gave `uv run <tool> check`. `uv run` syncs the project before it
+    runs anything, so both installed the audited tree editable and built any sdist
+    in its resolution. Measured on uv 0.12.8 against a project whose `setup.py`
+    writes a file when executed: plain `uv run` produces that file and a `.venv`;
+    `uv run --no-project` produces neither, and `uv export` never materialises an
+    environment at all.
+
+    So the mode that exists for a PR you have no reason to trust ran that PR's
+    build code — with no `MAY_EXECUTE` gate and no banner, both of which Phases 4
+    and 5 carry.
+
+    What this detects is narrower than "executes something": it is *builds or
+    installs the audited project*. Phase 4 runs the repo's own gates and is
+    supposed to, under `MAY_EXECUTE`; it stays clean here because it already
+    spells every invocation `uv run --no-project`. The pattern is also the set of
+    commands this plugin actually uses, not a proof that no other command builds
+    a project — a phase in this set that gains a new tool has to be added to it,
+    which is what the `--no-execute` paragraph now tells the reader.
+    """
+
+    NO_EXECUTE = (0, 1, 2, 3, 6, 7)
+
+    # `uv run --no-project` supplies the tool from PyPI and never touches the
+    # audited project, which is why Phase 2's differential and Phase 4's
+    # gate_diff invocations are spelled that way. Bare `uv run` is the defect.
+    EXECUTES = re.compile(
+        r"\buv run\b(?!\s+--no-project\b)|\buv sync\b|\bpip install\b|\bpre-commit run\b"
+    )
+
+    @staticmethod
+    def _uncommented(shell: str) -> str:
+        """Drop whole-line `#` comments before matching.
+
+        `reachable` strips comments out of *scripts* for exactly this reason, and
+        bash fences need the same treatment: the first version of this guard fired
+        on a comment in `uv-lock.md` § Phase 2 that warns against the very command
+        it forbids — the failure the harness docstring above already names.
+
+        Whole-line only. A trailing `#` can sit inside a quoted string (`--jq
+        '"#\\(.number)"'`), and cutting there would corrupt the line rather than
+        clean it. A trailing comment that names a build command is possible and
+        would be missed; a whole-line explanation is what actually happens.
+        """
+        return "\n".join(line for line in shell.splitlines() if not line.lstrip().startswith("#"))
+
+    def test_no_no_execute_phase_builds_the_audited_project(self):
+        for number in self.NO_EXECUTE:
+            code = self._uncommented(self.reachable(number))
+            hits = sorted(set(self.EXECUTES.findall(code)))
+            self.assertEqual(
+                hits,
+                [],
+                f"Phase {number} runs under --no-execute, which promises a network "
+                f"read; {hits} builds and installs the audited tree",
+            )
+
+    def test_the_pattern_still_discriminates(self):
+        """Anti-vacuity, pinned to literals rather than to the document.
+
+        A pattern that matches nothing satisfies the guard above in silence. The
+        strings below are the two forms that actually shipped and the three the
+        fix replaced them with, so a refactor that stops matching fails here
+        rather than going green on a Phase 3 that had regained `uv run`.
+        """
+        for bad in (
+            "uv run --with pip-audit pip-audit --skip-editable",
+            "uv run <tool> check --no-config <the same file>",
+            "uv sync --locked --no-build --no-install-project",
+        ):
+            self.assertRegex(bad, self.EXECUTES, f"{bad!r} builds the project and must match")
+        for ok in (
+            "uv run --no-project --with ruff==<locked> ruff format .",
+            "uv export --frozen --format requirements.txt --no-emit-project",
+            'uvx pip-audit -r "$SCRATCH/pr-<N>-requirements.txt" --no-deps --disable-pip',
+        ):
+            self.assertNotRegex(ok, self.EXECUTES, f"{ok!r} does not touch the project")
+
+    def test_the_pattern_still_finds_a_real_violation_in_the_document(self):
+        """Phase 5 installs frozen and says so; if it stops matching, so has the pattern."""
+        self.assertRegex(
+            self._uncommented(self.reachable(5)),
+            self.EXECUTES,
+            "Phase 5 is documented as the phase that installs the PR; a pattern that "
+            "no longer matches it cannot be trusted over Phases 0-3",
+        )
+
+    def test_phase_3_names_the_tree_it_reads(self):
+        """An unstated tree audits the pre-bump environment and reports clean."""
+        self.assertIn(
+            "$SCRATCH/pr-<N>",
+            self.material(3),
+            "Phase 3 must name the tree it audits; run in the user's checkout it "
+            "reports on the currently installed set, which is not the one under audit",
+        )
+
+
+class TestTheDeviationHandBackCarriesItsEvidence(SkillHarness):
+    """A `plugin defect` row that never ran the command still reads as measured.
+
+    The same claim arrived on 2026-08-30 and again on 2026-09-01, from two
+    different audits: that Phase 7's `git worktree remove` fails because Phase 5's
+    `uv sync` leaves a `.venv/`. Both stated a mechanism and neither ran the plain
+    command. Both were wrong — `remove` gates on `git status --porcelain`, which
+    omits *ignored* files, and uv writes a `.gitignore` containing `*` inside
+    `.venv/`, so the plain form exits 0. The second row labelled *itself* unproven
+    and was filed as a probable defect anyway.
+
+    Consistency only, per this file's header: that Phase 8 carries the rule is
+    checkable here. Whether a run follows it is behavioural, and belongs to the
+    replay gate — which is where both instances above were actually caught.
+    """
+
+    def phase8(self) -> str:
+        return dict(self.phases)[8]
+
+    def test_unproven_is_one_of_the_classes(self):
+        """Three classes leave an inferred cause nowhere to go but `plugin defect`."""
+        body = self.phase8()
+        for cls in ("plugin defect", "prose gap", "unproven", "correct"):
+            self.assertIn(cls, body, f"the deviation classes must include {cls!r}")
+
+    def test_a_plugin_defect_row_names_its_command_and_exit_status(self):
+        self.assertRegex(
+            self.phase8(),
+            r"exit status",
+            "a `plugin defect` row must name the command that failed and the exit "
+            "status it returned, or it is asserting a cause it inferred",
+        )
+
+    def test_the_first_check_is_whether_it_happened(self):
+        r"""Both halves, because an alternation is satisfied by either.
+
+        The first draft of this guard was `did this happen\?|search this
+        session's own history` and stayed green with the question deleted — the
+        rule is the question *and* where to look for the answer, and a guard that
+        accepts half of it does not hold the rule.
+        """
+        body = self.phase8()
+        self.assertIn(
+            "did this happen?",
+            body,
+            "the cheapest verification is whether the command was ever issued, not "
+            "whether the mechanism is right",
+        )
+        self.assertIn(
+            "search this session's own history",
+            body,
+            "the question needs the place to look, or it is advice rather than a check",
+        )
+
+    def test_an_unproven_row_is_verified_before_it_is_filed(self):
+        self.assertRegex(
+            self.phase8(),
+            r"question, not a ticket",
+            "an unproven row that reaches the issue tracker unverified is how the "
+            "same wrong cause was filed twice",
+        )


### PR DESCRIPTION
Closes #93. Closes #96.

Both are the same shape from two directions: a claim this procedure makes **about
itself** that its own commands falsified, with nothing anywhere to catch it.

## #93 — `--no-execute` ran the PR's build code

`SKILL.md` says the mode runs Phases 0–3 and 6–7 and that *"every one of those is
a network read"*, and calls it the right default for **a PR you have no reason to
trust yet**. Phase 3's only `uv.lock` recipe was `uv run --with pip-audit pip-audit
--skip-editable`, and `uv run` syncs the project before running anything —
installing it editable and building any sdist in the resolution. Measured on uv
0.12.8 against a project whose `setup.py` writes a file when it runs:

```
$ uv run --with pip-audit pip-audit --skip-editable
victimproj  distribution marked as editable
$ cat PROOF-build-code-ran.txt
the audited tree's build backend executed
```

No `MAY_EXECUTE` gate, no banner — both of which Phases 4 and 5 carry.

The phase now exports the lockfile and audits that: `uv export --frozen` into
`$SCRATCH`, then `uvx pip-audit -r … --no-deps --disable-pip`. No resolution, no
`pip`, no environment. **Verified in both directions**, because an auditor that
cannot report dirty is worse than none — a clean export exits 0, and
`jinja2==2.11.3` through the same command exits 1 with four advisories.

Two further gaps closed with it: the recipe never said **which tree** (in the
user's checkout it audits the pre-bump set and reports clean about the wrong
thing), and it audited **one resolution** where the export carries every fork with
its marker.

**The new guard then found a second instance nobody had read for.** Phase 2's
config differential, shipped in 0.32.0, ran `uv run <tool> check` — same defect,
same `--no-execute` set. It now uses `uv run --no-project --with <tool>==<locked>`,
the spelling Phase 4 already used. Measured: plain `uv run` writes the build trace
and a `.venv`; `--no-project` writes neither.

## #96 — a hand-back row classified without citing

Phase 8's deviation list classified rows **plugin defect** / **prose gap** /
**correct** with no requirement to say how the class was reached, so a row's class
carried the authority of a measurement while resting on an inference. It is the
only output here that classifies without citing; Phase 7's report has a verdict
table and a confidence rule that is *"derived, not felt"*.

A `plugin defect` row now names the command that failed and the exit status it
returned; where the run went straight to a workaround and never issued the
specified form, the class is the new **`unproven`**. The first check is *"did this
happen?"*, searched in the session's own history. And an `unproven` row is a
question, not a ticket.

The cost of not having it: the same claim — Phase 7's `git worktree remove` fails
because Phase 5's `uv sync` leaves a `.venv/` — arrived 2026-08-30 and again
2026-09-01 from two different audits, each with a mechanism, neither having run
the plain command. Measured on git 2.55.0 in a worktree of a repo with **no
`.gitignore` at all**: `remove` exits 0. It gates on `git status --porcelain`,
which omits *ignored* files, and uv writes a `.gitignore` containing `*` inside
`.venv/`. The second row labelled *itself* unproven and became an issue anyway.

## Tests

`TestNoExecutePhaseBuildsTheAuditedProject` reads `reachable()`, so it follows a
phase into its ecosystem reference and into any script the phase is mechanised
into later. Its anti-vacuity check is pinned to **literals rather than to the
document**, because a pattern that matches nothing satisfies a negative guard in
silence.

It scans code and not comments — its first version fired on a comment in
`uv-lock.md` § Phase 2 warning against the very command it forbids, which is the
failure `reachable()`'s own docstring names, reproduced by the guard written to
use it.

Every new guard is mutation-checked by deleting the sentence rather than editing
the guard, eight cases. **One came back dead**: the *"did this happen?"* assertion
was an alternation and stayed green with half its rule removed. It now binds both
halves, and each fails on its own.

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim #384`

The PR the finding came from, headless in a fresh context via `--plugin-dir`, and
checked against the transcript rather than the report's account of itself. The
installed cache tops out at 0.33.0 and `--disable-pip` exists only in the working
tree, so its presence below is what proves `--plugin-dir` won.

```
Bash calls the run executed: 26

=== 1. commands that would build/install the audited project ===
  NONE

=== 2. did Phase 3 use the export path? ===
  uv export       calls [21]
  pip-audit       calls [22]
  --disable-pip   calls [22]
  --no-deps       calls [22]
```

Phase 3, as the run actually issued it:

```
  $ uv export --frozen --format requirements.txt --no-emit-project -o "$SCRATCH/pr-384-requirements.txt"
  --- export exit: 0 ---
  827 /tmp/dbaudit-Machai-Kydoimos-fpga-board-sim-384/pr-384-requirements.txt
  === .venv created in the worktree? ===
  no

  $ uvx pip-audit -r "$SCRATCH/pr-384-requirements.txt" --no-deps --disable-pip
  No known vulnerabilities found
  --- pip-audit exit: 0 ---
```

**The run checked the safety claim rather than trusting it.** Unprompted, it ran
`ls -a "$SCRATCH/pr-384" | grep '^\.venv$'` and handed it back as a `correct`
deviation: *"Checking the reference's own safety claim rather than trusting it. It
held — no `.venv`."*

**#96 worked behaviourally**, which is the half the session that wrote the clause
cannot test. The hand-back closes:

> **Verify before filing** — the mechanism above is measured (the commit list and
> release bodies are quoted from this run's own output), but whether the ladder
> should change is a design call for the maintainer.

One caveat stated plainly: no row needed the `unproven` class, so that path is
still unexercised.

Cleanup verified independently rather than from the report — no worktrees
registered, no `pr-384` branch, and `$SCRATCH` holding only `phase0.env`, the two
lockfiles and the new requirements export.

The replay also independently rediscovered #94 from a different range
(`v0.2.60...v0.2.62`) and found a destructive-fix instance this session had not —
`rumdl fmt lib.rs` writing `# [derive(Debug)]` to disk. Recorded on that issue,
not fixed here.
