### PR TITLE
feat: mechanise Phase 7's cleanup, and give Phase 5's residue somewhere to go (0.35.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,97 @@ patch.
 
 ## [Unreleased]
 
+## [0.35.0] — 2026-09-01
+
+Closes [#97](https://github.com/Machai-Kydoimos/dependabot-audit/issues/97) and
+[#95](https://github.com/Machai-Kydoimos/dependabot-audit/issues/95). Phase 7's
+tidy-up becomes a script, because the three commands it replaces said nothing
+about what does or does not dirty a worktree — and two separate audits therefore
+reasoned it out and reached the same wrong answer.
+
+**Minor, not patch.** Phase 7 changes what it does and gains a row it can report;
+Phase 5 gains a stated expectation it did not have.
+
+### Added
+
+- **`scripts/cleanup.py`** (#97) removes exactly what Phase 0 created — `pr-<N>`,
+  `base-<N>`, `tip-<N>` and the `pr-<N>` branch — discovering which are actually
+  present, so a rewritten base needs no extra line and an actions bump, which
+  creates no worktree at all, needs none removed. The prose used to ask the reader
+  to adjust the command list for both cases, which is the kind of instruction that
+  gets skipped.
+
+  **Why a script for three commands.** Prose is the weakest of the three levers,
+  and this trap kept recurring through it: on 2026-08-30 and again on 2026-09-01,
+  two different audits handed back the claim that Phase 5's `uv sync` leaves a
+  `.venv/` which makes `git worktree remove` refuse. It does not — `remove` gates
+  on `git status --porcelain`, which omits *ignored* files, and uv, pytest, ruff
+  and mypy each write a `.gitignore` containing `*` inside their own directory.
+  Measured on git 2.55.0 and uv 0.12.8 in a worktree of a repo with **no
+  `.gitignore` at all**, the plain form exits 0. A run that types the command
+  re-derives that question every time; a run that calls the script never asks it.
+
+- **The residue is written out before the tree goes.** `$SCRATCH/residue-<tree>.diff`
+  carries the porcelain output and `git diff HEAD`; untracked paths are listed and
+  not dumped. `$SCRATCH` outlives the worktrees, so the evidence outlives the tree
+  that held it — which is what makes the removal safe. Forcing without writing
+  would discard something the audit produced and had not yet reported, the loss
+  `gate_diff.py`'s `restore()` declines `-x` to avoid.
+
+  Per-tree rather than one file: `pr-<N>` dirty is Phase 5's gates, `base-<N>`
+  dirty means `gate_diff.py`'s restore did not hold, and those are different
+  findings that must not land in one buffer under one heading.
+
+- **Exit `1` means residue was found and the worktree was still removed** — a
+  finding for the report, not a cleanup failure. `0` is clean and `2` is
+  could-not-run, the same contract `gate_diff.py` uses. Phase 7 says to read the
+  code and not to chain on it: `cleanup.py … && next` swallows the finding, the
+  same shape as Phase 5's `cmd | tail && next` trap one phase over.
+
+### Fixed
+
+- **Phase 5's residue has somewhere to go** (#95). Phase 4 mutates `base-<N>` and
+  `gate_diff.py` restores it after every run; Phase 5 mutates `pr-<N>` and nothing
+  restored it, so a fix-mode gate — `rumdl check --fix`, `ruff format`, a
+  `pre-commit` run that stages what it fixes — left tracked files modified or
+  staged and Phase 7 exited 128 on them. Phase 5 now says the dirt is **expected
+  and is a result**, and that tidying it destroys the finding: *"the repo's own
+  gates rewrote N tracked files at the proposed version"* is Phase 4's question
+  reached from the other direction.
+
+- **Phase 0's reuse remedy no longer refuses on the state it was written for.**
+  *"If either check fails, `git worktree remove` it and re-add"* followed a check
+  that fails precisely when the tree is dirty — which is what a plain `remove`
+  refuses on. It now calls `cleanup.py`, so a previous run's residue is saved
+  rather than discarded unread.
+
+### Tests
+
+- **`tests/test_cleanup.py`**, 14 cases on real git worktrees: clean removal, a
+  missing path (exit 0, per #90's measurement), the actions-bump shape, a
+  rewritten base's `tip-<N>`, a self-ignoring `.venv`, un-ignored `__pycache__`,
+  a modified tracked file, a staged one, a dirty `base-<N>` getting its own file,
+  and the three exit codes including a crash reporting 2 rather than 1.
+
+- **One case asks `uv` rather than restating it.** CONTRIBUTING's rule is that a
+  fixture built from the rule can only ever agree with it, and the rule here is a
+  claim about what uv writes — so `test_a_real_uv_venv_does_not_count_either`
+  builds a real venv and skips where `uv` is absent. The hand-built equivalent
+  stays, because it is what CI on four interpreters actually runs.
+
+- **A guard retired itself, exactly as predicted, and the suite caught it.**
+  `reachable()`'s docstring warns that a guard scanning only a phase's own bash
+  goes green the moment its mechanism moves into a script. Mechanising Phase 7 did
+  that to `TestCleanupRunsOnEveryPath`, on the same commit — the pattern now
+  matches `cleanup.py` too, and the artifact list is read through `reachable()`,
+  where `_code_only` strips docstrings so the script's own prose about `WORKTREES`
+  cannot satisfy the assertion that the tuple must.
+
+- **Quote-agnostic argv matching.** `_code_only` normalises source through
+  `ast.unparse`, so a double-quoted argv in a script arrives single-quoted and a
+  literal match fails silently. Noted in the guard that hit it.
+
+
 ## [0.34.0] — 2026-09-01
 
 Closes [#93](https://github.com/Machai-Kydoimos/dependabot-audit/issues/93) and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,6 +335,15 @@ after nine commits of growth.
 - **Tool versions live in `.pre-commit-config.yaml` and nowhere else.** CI invokes
   the hooks rather than installing its own ruff and mypy, so there is no second pin
   to drift.
+- **`git add` a new file before you gate it, or the gate is lying.**
+  `pre-commit run --all-files` runs its hooks over `git ls-files`, so an untracked
+  file is invisible to every hook that takes filenames — ruff among them. mypy is
+  the exception and that is what makes this hard to spot: its `files = [...]` in
+  `pyproject.toml` walks the tree itself, so a new module gets type-checked while
+  going completely unlinted. Measured on an untracked probe with a deliberate
+  `SIM117` shape: `pre-commit run ruff-check --all-files` reports **Passed** while
+  it is untracked and **3 errors** the moment it is staged. Cost one red CI round
+  in 0.35.0, on a run whose local output had read green.
 
 ## Commits and releases
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,6 @@ exclude = ["integration/fixtures"]
 # override then disappears with no warning, not even under
 # --warn-unused-configs (tested: errors went 25 -> 175). Adding a test file
 # means adding it here; forgetting is loud, which is the safer direction.
-module = ["test_audit", "test_ci_state", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry", "test_live_changelog_sources"]
+module = ["test_audit", "test_ci_state", "test_cleanup", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry", "test_live_changelog_sources"]
 disallow_untyped_defs = false
 disallow_untyped_calls = false

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -242,7 +242,12 @@ test "$(git -C "$SCRATCH/pr-<N>" rev-parse HEAD)" = "$HEAD_SHA"
 git -C "$SCRATCH/pr-<N>" status --porcelain                       # must be empty
 ```
 
-If either check fails, `git worktree remove` it and re-add.
+If either check fails, remove it and re-add — with
+`python3 "$SCRIPTS/cleanup.py" --scratch "$SCRATCH" --pr <N>` rather than a bare
+`git worktree remove`. The second check fails precisely when the tree is dirty,
+and a plain `remove` refuses on exactly that, so the remedy would fail on the
+state it was written for — and a previous run's Phase 5 residue would be
+discarded unread rather than saved.
 
 **Phase 0 outputs.** Every later phase consumes these and nothing else:
 
@@ -808,6 +813,15 @@ The worktrees and the `pr-<N>` branch are cleaned up in Phase 7, not here — an
 audit that stops at Phase 1's gate never reaches this phase and still has to
 tidy up after itself.
 
+**Expect the gates to leave this tree dirty, and do not tidy it yourself.** Where
+the repo's gates are fix-mode — `ruff format`, `rumdl check --fix`, a `pre-commit`
+run that stages what it fixes — they rewrite tracked files here, and that is a
+*result*: the repo's own gates changed this tree at the proposed version, which is
+Phase 4's question reached from the other direction. Nothing restores `pr-<N>` the
+way `gate_diff.py` restores `base-<N>`, and that is deliberate. Phase 7 saves the
+diff and reports it; a `git checkout .` here destroys the finding before anyone
+sees it.
+
 ## Phase 6 — CI verification
 
 *Requires from Phase 0: `$HEAD_SHA`, `$BASE_SHA`, `$OWNER`, `$NAME`.*
@@ -1207,18 +1221,45 @@ audit reaches, including the one that ends at the gate.
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
-git worktree remove "$SCRATCH/pr-<N>"
-git worktree remove "$SCRATCH/base-<N>"
-git branch -D "pr-<N>"
+python3 "${SCRIPTS:?not in the handoff — re-run Phase 0}/cleanup.py" \
+  --scratch "$SCRATCH" --pr <N>
+echo "cleanup exit: $?"
 ```
 
-Remove exactly what Phase 0 created, and nothing else. Add `$SCRATCH/tip-<N>` if
-Phase 0 found the base rewritten; drop both worktree lines on an actions bump,
-where Phase 0 creates neither and only the branch is left to remove.
+**Read the exit code; do not chain on it.** `0` is clean, `2` is could-not-run, and
+**`1` means residue was found and the worktree was still removed** — a finding for
+the report, not a cleanup failure. `cleanup.py … && echo done` treats that finding
+as an error and hides it, the same shape as Phase 5's `cmd | tail && next`.
 
-Keeping them is reasonable when a follow-up run is likely — say so in the report,
-with the commands above, so the user knows what is there. Silently keeping them
-is what this step exists to prevent.
+The script removes exactly what Phase 0 created and nothing else, discovering which
+of `pr-<N>`, `base-<N>` and `tip-<N>` are actually there — so a rewritten base needs
+no extra line and an actions bump, which creates no worktree at all, needs none
+removed.
+
+**Why a script, when it was three commands.** Because the three commands said
+nothing about what does or does not dirty a worktree, and two separate audits
+therefore reasoned it out and reached the same wrong answer: that Phase 5's
+`uv sync` leaves a `.venv/` which makes `remove` refuse. It does not — `remove`
+gates on `git status --porcelain`, which omits *ignored* files, and uv, pytest,
+ruff and mypy each write a `.gitignore` containing `*` inside their own directory.
+A run that types the command re-derives that question every time; a run that calls
+the script never asks it.
+
+**The refusal that is real is a Phase 5 finding.** Phase 5 runs the repo's own
+gates in `$SCRATCH/pr-<N>`, and where those are fix-mode — `pre-commit` stages its
+own edits — tracked files end up modified or staged. Phase 4 mutates `base-<N>` and
+`gate_diff.py` restores it after every run; nothing restores `pr-<N>`. So the
+script writes the residue to `$SCRATCH/residue-<tree>.diff` **before** removing:
+`$SCRATCH` outlives the worktrees, so the evidence outlives the tree that held it.
+Forcing without writing would discard something the audit produced and had not yet
+reported, which is the loss `gate_diff.py`'s `restore()` declines `-x` to avoid.
+
+*"The repo's own gates rewrote N tracked files at the proposed version"* is the
+strongest row Phase 5 can produce. Put it in the report, with the path.
+
+Keeping the worktrees is reasonable when a follow-up run is likely — say so in the
+report, with the command above, so the user knows what is there. Silently keeping
+them is what this step exists to prevent.
 
 ## Phase 8 — Learning loop (the only thing worth persisting)
 

--- a/skills/dependabot-audit/scripts/cleanup.py
+++ b/skills/dependabot-audit/scripts/cleanup.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Phase 7's tidy-up: remove what Phase 0 created, and report what dirtied it.
+
+Phase 0 registers two worktrees and a `pr-<N>` branch in the **user's** repo, and
+they accumulate one set per PR audited. Phase 7 is the only phase every audit
+reaches -- `--no-execute` skips Phase 5, and Phase 1's gate stops before it, which
+is the path where the audit was most right to stop and the one that used to litter
+every time.
+
+Until 0.35.0 this was three commands in the prose:
+
+    git worktree remove "$SCRATCH/pr-<N>"
+    git worktree remove "$SCRATCH/base-<N>"
+    git branch -D "pr-<N>"
+
+and the prose said nothing about what does or does not dirty a worktree. Two
+different audits (2026-08-30 and 2026-09-01) therefore reasoned it out and reached
+the same wrong answer -- that `uv sync`'s `.venv/` makes the plain `remove` refuse.
+It does not: `remove` gates on `git status --porcelain`, which omits *ignored*
+files, and uv, pytest, ruff and mypy each write a `.gitignore` containing `*`
+inside their own directory. Measured on git 2.55.0 and uv 0.12.8 in a worktree of a
+repo with no `.gitignore` at all, the plain form exits 0.
+
+The refusal that *is* real was missed by both: Phase 5 runs the repo's own gates in
+`$SCRATCH/pr-<N>`, and where those are fix-mode -- `pre-commit` stages its own
+edits, as `gate_diff.py`'s `restore()` already records -- tracked files end up
+modified or staged, and `remove` exits 128. Phase 4 mutates `base-<N>` and
+`gate_diff.py` restores it after every run; nothing restored `pr-<N>`.
+
+**So the residue is written out before the tree goes.** `--force` alone would
+discard evidence the audit produced and has not yet reported, which is the failure
+`restore()` reasons about when it declines `-x`. Writing first is what makes the
+removal safe: `$SCRATCH` outlives the worktrees, so the diff outlives the tree that
+held it. A gate that rewrote tracked files at the proposed version is the strongest
+row Phase 5 can produce, and it was being thrown away either way -- forced away, or
+left behind with the litter.
+
+Not archival: `$SCRATCH` lives under `$TMPDIR` and a reboot takes it. The file is
+for the report being written now.
+
+Usage:
+    cleanup.py --scratch DIR --pr N [--repo DIR]
+
+Exit status: 0 = removed, nothing to report. 1 = removed, and residue was found
+(a Phase 5 finding, not a cleanup failure). 2 = could not run.
+Requires Python 3.11+. No network.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import NoReturn
+
+# Exactly what Phase 0 creates, and nothing else. `tip-<N>` exists only when
+# Phase 0 found the base rewritten; an actions bump creates no worktree at all
+# and leaves only the branch. Discovering which are present beats being told:
+# the caller cannot get it wrong, and the actions case needs no flag.
+WORKTREES = ("pr-{n}", "base-{n}", "tip-{n}")
+
+
+def fail(what: str) -> NoReturn:
+    """Exit 2 -- could not run. Never 1, which means residue was found."""
+    print(f"error: {what}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run git and hand back the result. Callers decide what a failure means.
+
+    Unlike `gate_diff.py`'s `_git`, this one does not raise on a non-zero exit:
+    half the calls here are expected to fail sometimes. `worktree remove` on a
+    path that is already gone exits 0 (measured for #90), but `branch -D` on a
+    branch that was never created exits 1, and that is a no-op rather than an
+    error -- an actions bump reaches Phase 7 with no branch of its own.
+    """
+    return subprocess.run(  # noqa: S603
+        ["git", "-C", str(cwd), *args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+
+def porcelain(tree: Path) -> str:
+    """What git considers dirty here: modified, staged, or untracked-and-not-ignored.
+
+    The same command `git worktree remove` itself gates on, which is why this is
+    the right question to ask before removing. Ignored files -- a `.venv`, a tool
+    cache -- are absent from it, and are also absent from what `remove` refuses on.
+    """
+    return _git(tree, "status", "--porcelain").stdout.strip()
+
+
+def write_residue(tree: Path, scratch: Path, status: str) -> Path:
+    """Save what dirtied the tree, outside the tree, before it is removed.
+
+    Per-tree rather than one file: `pr-<N>` dirty is Phase 5's gates, `base-<N>`
+    dirty means `gate_diff.py`'s restore did not hold, and those are different
+    findings that must not land in one buffer under one heading.
+
+    Tracked changes get their diff, because *what* the gate rewrote is the finding.
+    Untracked paths are listed and not dumped -- a stray build artefact is signal
+    that it happened, not content worth carrying.
+    """
+    out = scratch / f"residue-{tree.name}.diff"
+    diff = _git(tree, "diff", "HEAD").stdout
+    body = [
+        f"# residue in {tree}",
+        "# Written by Phase 7 before removing the worktree. Not archival:",
+        "# $SCRATCH lives under $TMPDIR and a reboot takes it.",
+        "",
+        "=== git status --porcelain ===",
+        status,
+        "",
+        "=== git diff HEAD (tracked changes) ===",
+        diff.rstrip() or "(none -- the residue is untracked files only)",
+        "",
+    ]
+    out.write_text("\n".join(body), encoding="utf-8")
+    return out
+
+
+def counts(status: str) -> tuple[int, int]:
+    """(tracked changes, untracked paths) from porcelain's two-column codes.
+
+    `??` is untracked; everything else is a tracked path the gate touched. The
+    split matters to the report: a gate that rewrote tracked files is a behaviour
+    finding, while untracked residue is usually just a cache the repo does not
+    ignore.
+    """
+    lines = [ln for ln in status.splitlines() if ln.strip()]
+    untracked = sum(1 for ln in lines if ln.startswith("??"))
+    return len(lines) - untracked, untracked
+
+
+def remove_worktree(repo: Path, tree: Path, scratch: Path) -> tuple[bool, Path | None]:
+    """Remove one worktree, saving its residue first. (removed, residue path)."""
+    if not tree.exists():
+        # Still worth calling: the registration can outlive the directory, and
+        # `remove` on a missing path clears it and exits 0.
+        _git(repo, "worktree", "remove", str(tree))
+        return True, None
+
+    status = porcelain(tree)
+    residue = write_residue(tree, scratch, status) if status else None
+
+    result = _git(repo, "worktree", "remove", str(tree))
+    if result.returncode != 0:
+        # The only expected failure is the dirty tree whose residue is now saved,
+        # so forcing here loses nothing that is not already written down. Anything
+        # else -- a locked worktree, a permission error -- still fails loudly below.
+        result = _git(repo, "worktree", "remove", "--force", str(tree))
+    return result.returncode == 0, residue
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scratch", required=True, help="$SCRATCH from the Phase 0 handoff")
+    parser.add_argument("--pr", required=True, help="the PR number under audit")
+    parser.add_argument("--repo", default=".", help="the user's repo (default: cwd)")
+    args = parser.parse_args()
+
+    repo = Path(args.repo).resolve()
+    scratch = Path(args.scratch)
+    if not (repo / ".git").exists():
+        fail(f"{repo} is not a git repository; refusing to run")
+    if not scratch.is_dir():
+        fail(f"{scratch} does not exist -- re-derive $SCRATCH, or Phase 0 never ran")
+
+    # A previous run's registration can point at a path a tmp sweep deleted, and
+    # a stale one makes `remove` on a live path report about the wrong thing.
+    _git(repo, "worktree", "prune")
+
+    removed: list[str] = []
+    residues: list[tuple[str, Path, tuple[int, int]]] = []
+    stuck: list[str] = []
+
+    for pattern in WORKTREES:
+        tree = scratch / pattern.format(n=args.pr)
+        existed = tree.exists()
+        status = porcelain(tree) if existed else ""
+        ok, residue = remove_worktree(repo, tree, scratch)
+        if not ok:
+            stuck.append(str(tree))
+            continue
+        if existed:
+            removed.append(tree.name)
+        if residue:
+            residues.append((tree.name, residue, counts(status)))
+
+    branch = f"pr-{args.pr}"
+    if _git(repo, "branch", "-D", branch).returncode == 0:
+        removed.append(f"branch {branch}")
+
+    print(f"removed: {', '.join(removed) if removed else 'nothing -- already clean'}")
+    if stuck:
+        fail("could not remove " + ", ".join(stuck) + "; they are still registered")
+
+    if not residues:
+        print("no residue: every worktree was clean when it was removed.")
+        return 0
+
+    print()
+    for name, path, (tracked, untracked) in residues:
+        print(f"RESIDUE in {name}: {tracked} tracked file(s) changed, {untracked} untracked")
+        print(f"  saved to {path}")
+    print()
+    print("This is a Phase 5 finding, not a cleanup failure. A gate that rewrote")
+    print("tracked files at the proposed version is what Phase 4 exists to catch,")
+    print("reached from the other direction -- report it, with the file above.")
+    return 1
+
+
+def cli() -> NoReturn:
+    """Entry point. Anything unforeseen becomes exit 2, never exit 1.
+
+    Exit 1 here means residue was found -- a finding for the report. An unhandled
+    exception exits 1 too, so without this a crash would be read as a gate having
+    rewritten the tree. Set `DEPENDABOT_AUDIT_DEBUG` to re-raise.
+    """
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if os.environ.get("DEPENDABOT_AUDIT_DEBUG"):
+            raise
+        fail(
+            f"unexpected {type(exc).__name__}: {exc}\n"
+            "       This is a bug, not a finding. Set DEPENDABOT_AUDIT_DEBUG=1 "
+            "for the traceback."
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,260 @@
+"""Regression tests for cleanup.py.
+
+No network. Every case is a real git worktree in a throwaway repo, because what
+is under test is git's own behaviour — which of `remove`'s refusals are real, and
+which one two separate audits inferred and got wrong.
+
+    python3 -m unittest discover -s tests -v
+
+The case that matters most is `test_residue_is_written_before_the_tree_goes`:
+without it, forcing the removal discards the evidence the audit produced and has
+not yet reported, which is the failure `gate_diff.py`'s `restore()` reasons about
+when it declines `-x`.
+
+One case deliberately uses a **real** `uv` venv rather than a hand-written
+`.gitignore`, and skips where `uv` is absent. CONTRIBUTING's rule is that a
+fixture built from the rule can only ever agree with it, and the rule here is a
+claim about what uv writes — so at least one test has to ask uv rather than
+restate it. The hand-built equivalent stays too: it is what CI on four
+interpreters actually runs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
+)
+
+from cleanup import cli, main
+
+PR = "7"
+
+
+def git(directory: pathlib.Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(directory), *args], capture_output=True, text=True, check=False
+    )
+
+
+class CleanupHarness(unittest.TestCase):
+    """A repo with `pr-7` and `base-7` worktrees under a scratch directory."""
+
+    def setUp(self):
+        root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        self.repo = root / "repo"
+        self.scratch = root / "scratch"
+        self.scratch.mkdir(parents=True)
+        self.repo.mkdir()
+        (self.repo / "tracked.txt").write_text("original\n", encoding="utf-8")
+        for args in (
+            ["init", "-q", "-b", "main"],
+            ["add", "-A"],
+            ["-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "base"],
+        ):
+            git(self.repo, *args)
+
+    def add_worktrees(self, *names: str) -> None:
+        for name in names:
+            path = self.scratch / f"{name}-{PR}"
+            if name == "pr":
+                git(self.repo, "worktree", "add", "-q", str(path), "-b", f"pr-{PR}")
+            else:
+                git(self.repo, "worktree", "add", "-q", "--detach", str(path), "HEAD")
+
+    def run_cleanup(self) -> tuple[int, str]:
+        argv = ["cleanup.py", "--scratch", str(self.scratch), "--pr", PR, "--repo", str(self.repo)]
+        out = io.StringIO()
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            code = main()
+        return code, out.getvalue()
+
+    def worktrees(self) -> str:
+        return git(self.repo, "worktree", "list").stdout
+
+    def residue(self, name: str) -> pathlib.Path:
+        return self.scratch / f"residue-{name}-{PR}.diff"
+
+
+class TestACleanWorktreeJustGoes(CleanupHarness):
+    def test_both_worktrees_and_the_branch_are_removed(self):
+        self.add_worktrees("pr", "base")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 0, out)
+        self.assertNotIn(f"pr-{PR}", self.worktrees())
+        self.assertNotIn(f"base-{PR}", self.worktrees())
+        self.assertEqual(git(self.repo, "branch", "--list", f"pr-{PR}").stdout.strip(), "")
+        self.assertIn("no residue", out)
+
+    def test_a_missing_path_is_not_an_error(self):
+        """Measured for #90: `remove` on a path that is gone exits 0."""
+        self.add_worktrees("pr", "base")
+        shutil.rmtree(self.scratch / f"pr-{PR}")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 0, out)
+        self.assertNotIn(f"pr-{PR}", self.worktrees())
+
+    def test_an_actions_bump_has_only_a_branch_to_remove(self):
+        """Phase 0 creates no worktree for an actions bump; the branch still exists."""
+        git(self.repo, "branch", f"pr-{PR}")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 0, out)
+        self.assertIn(f"branch pr-{PR}", out)
+        self.assertEqual(git(self.repo, "branch", "--list", f"pr-{PR}").stdout.strip(), "")
+
+    def test_a_rewritten_base_leaves_a_tip_worktree_to_remove(self):
+        self.add_worktrees("pr", "base", "tip")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 0, out)
+        self.assertIn(f"tip-{PR}", out)
+        self.assertNotIn(f"tip-{PR}", self.worktrees())
+
+
+class TestIgnoredResidueIsNotResidue(CleanupHarness):
+    """The claim two separate hand-backs got wrong, in both its forms."""
+
+    def test_a_self_ignoring_venv_does_not_count(self):
+        self.add_worktrees("pr", "base")
+        venv = self.scratch / f"pr-{PR}" / ".venv"
+        venv.mkdir()
+        (venv / ".gitignore").write_text("*\n", encoding="utf-8")
+        (venv / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 0, out)
+        self.assertIn("no residue", out)
+        self.assertFalse(self.residue("pr").exists())
+
+    @unittest.skipUnless(shutil.which("uv"), "uv not installed")
+    def test_a_real_uv_venv_does_not_count_either(self):
+        """Ask uv what it writes rather than restating it.
+
+        The hand-built case above encodes this repo's *claim* about uv. If uv
+        stopped writing a self-ignoring `.venv`, that test would keep passing and
+        the plugin's prose would be wrong with a green suite behind it.
+        """
+        self.add_worktrees("pr")
+        tree = self.scratch / f"pr-{PR}"
+        made = subprocess.run(
+            ["uv", "venv", "--quiet"], cwd=tree, capture_output=True, text=True, check=False
+        )
+        if made.returncode != 0:  # pragma: no cover - uv present but unusable
+            self.skipTest(f"uv venv failed: {made.stderr.strip()}")
+        self.assertTrue((tree / ".venv" / ".gitignore").exists(), "uv no longer self-ignores")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 0, out)
+        self.assertIn("no residue", out)
+
+    def test_an_untracked_file_with_no_ignore_rule_does_count(self):
+        """`__pycache__` is the one piece of test residue that writes no self-ignore."""
+        self.add_worktrees("pr")
+        cache = self.scratch / f"pr-{PR}" / "tests" / "__pycache__"
+        cache.mkdir(parents=True)
+        (cache / "t.pyc").write_bytes(b"\x00")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 1, out)
+        self.assertIn("0 tracked file(s) changed, 1 untracked", out)
+
+
+class TestResidueIsReportedAndSaved(CleanupHarness):
+    """Phase 5 runs the repo's own gates in `pr-<N>` and nothing restores it."""
+
+    def dirty_tracked(self) -> pathlib.Path:
+        tree = self.scratch / f"pr-{PR}"
+        (tree / "tracked.txt").write_text("reformatted by a fix-mode gate\n", encoding="utf-8")
+        return tree
+
+    def test_residue_is_written_before_the_tree_goes(self):
+        self.add_worktrees("pr")
+        self.dirty_tracked()
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 1, "residue is a finding, not a cleanup failure")
+        self.assertNotIn(f"pr-{PR}", self.worktrees(), "the tree must still be removed")
+        saved = self.residue("pr")
+        self.assertTrue(saved.exists(), "the evidence must outlive the tree that held it")
+        body = saved.read_text(encoding="utf-8")
+        self.assertIn("M tracked.txt", body)
+        self.assertIn("reformatted by a fix-mode gate", body, "the diff is the finding")
+
+    def test_a_staged_fix_is_residue_too(self):
+        """`pre-commit` stages its own edits, per gate_diff's restore() docstring."""
+        self.add_worktrees("pr")
+        tree = self.dirty_tracked()
+        git(tree, "add", "tracked.txt")
+        code, out = self.run_cleanup()
+        self.assertEqual(code, 1, out)
+        self.assertIn("1 tracked file(s) changed", out)
+        self.assertIn("reformatted by a fix-mode gate", self.residue("pr").read_text())
+
+    def test_the_exit_code_says_finding_not_failure(self):
+        """0 = clean, 1 = ran and found something, 2 = could not run."""
+        self.add_worktrees("pr")
+        clean, _ = self.run_cleanup()
+        self.assertEqual(clean, 0)
+        self.add_worktrees("pr")
+        self.dirty_tracked()
+        dirty, _ = self.run_cleanup()
+        self.assertEqual(dirty, 1)
+
+    def test_a_dirty_base_gets_its_own_file(self):
+        """`base-<N>` dirty means gate_diff's restore did not hold — a different finding."""
+        self.add_worktrees("pr", "base")
+        self.dirty_tracked()
+        (self.scratch / f"base-{PR}" / "tracked.txt").write_text("gate residue\n", encoding="utf-8")
+        code, _ = self.run_cleanup()
+        self.assertEqual(code, 1)
+        self.assertTrue(self.residue("pr").exists())
+        self.assertTrue(self.residue("base").exists())
+        self.assertNotIn("gate residue", self.residue("pr").read_text())
+
+
+class TestItRefusesRatherThanGuessing(CleanupHarness):
+    def test_a_non_repo_is_exit_2(self):
+        argv = ["cleanup.py", "--scratch", str(self.scratch), "--pr", PR, "--repo", str(self.scratch)]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()) as err,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                main()
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("not a git repository", err.getvalue())
+
+    def test_a_missing_scratch_is_exit_2_not_a_silent_success(self):
+        argv = ["cleanup.py", "--scratch", str(self.scratch / "gone"), "--pr", PR,
+                "--repo", str(self.repo)]
+        with (
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()) as err,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                main()
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("re-derive $SCRATCH", err.getvalue())
+
+    def test_an_unexpected_error_is_exit_2_never_1(self):
+        """Exit 1 means residue. A crash reported as 1 reads as a gate rewriting files."""
+        with (
+            mock.patch("cleanup.main", side_effect=RuntimeError("boom")),
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()) as err,
+        ):
+            with self.assertRaises(SystemExit) as raised:
+                cli()
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("bug, not a finding", err.getvalue())

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -180,7 +180,7 @@ class TestResidueIsReportedAndSaved(CleanupHarness):
     def test_residue_is_written_before_the_tree_goes(self):
         self.add_worktrees("pr")
         self.dirty_tracked()
-        code, out = self.run_cleanup()
+        code, _ = self.run_cleanup()
         self.assertEqual(code, 1, "residue is a finding, not a cleanup failure")
         self.assertNotIn(f"pr-{PR}", self.worktrees(), "the tree must still be removed")
         saved = self.residue("pr")
@@ -223,27 +223,42 @@ class TestResidueIsReportedAndSaved(CleanupHarness):
 
 class TestItRefusesRatherThanGuessing(CleanupHarness):
     def test_a_non_repo_is_exit_2(self):
-        argv = ["cleanup.py", "--scratch", str(self.scratch), "--pr", PR, "--repo", str(self.scratch)]
+        argv = [
+            "cleanup.py",
+            "--scratch",
+            str(self.scratch),
+            "--pr",
+            PR,
+            "--repo",
+            str(self.scratch),
+        ]
         with (
             mock.patch.object(sys, "argv", argv),
             contextlib.redirect_stdout(io.StringIO()),
             contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as raised,
         ):
-            with self.assertRaises(SystemExit) as raised:
-                main()
+            main()
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("not a git repository", err.getvalue())
 
     def test_a_missing_scratch_is_exit_2_not_a_silent_success(self):
-        argv = ["cleanup.py", "--scratch", str(self.scratch / "gone"), "--pr", PR,
-                "--repo", str(self.repo)]
+        argv = [
+            "cleanup.py",
+            "--scratch",
+            str(self.scratch / "gone"),
+            "--pr",
+            PR,
+            "--repo",
+            str(self.repo),
+        ]
         with (
             mock.patch.object(sys, "argv", argv),
             contextlib.redirect_stdout(io.StringIO()),
             contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as raised,
         ):
-            with self.assertRaises(SystemExit) as raised:
-                main()
+            main()
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("re-derive $SCRATCH", err.getvalue())
 
@@ -253,8 +268,8 @@ class TestItRefusesRatherThanGuessing(CleanupHarness):
             mock.patch("cleanup.main", side_effect=RuntimeError("boom")),
             contextlib.redirect_stdout(io.StringIO()),
             contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as raised,
         ):
-            with self.assertRaises(SystemExit) as raised:
-                cli()
+            cli()
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("bug, not a finding", err.getvalue())

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -1428,7 +1428,12 @@ class TestCleanupRunsOnEveryPath(SkillHarness):
     a report, because "stopping here is not a failed audit".
     """
 
-    CLEANUP = re.compile(r"git worktree remove|git branch -D")
+    # The mechanism, wherever it lives. Phase 7 was three git commands until
+    # 0.35.0 and is `cleanup.py` from then on. A guard keyed only to the commands
+    # went green on a Phase 7 that no longer contained them — the retirement
+    # `reachable()`'s own docstring warns about, arrived at for real rather than
+    # hypothetically, and caught by this suite on the commit that mechanised it.
+    CLEANUP = re.compile(r"git worktree remove|git branch -D|cleanup\.py")
 
     def test_the_cleanup_is_not_in_a_phase_that_can_be_skipped(self):
         for number in (4, 5):
@@ -1442,18 +1447,67 @@ class TestCleanupRunsOnEveryPath(SkillHarness):
 
     def test_the_cleanup_is_in_the_phase_every_audit_reaches(self):
         self.assertRegex(
-            self.shell[7],
+            self.reachable(7),
             self.CLEANUP,
             "Phase 7 is the only phase reached on every path, including the Phase 1 "
             "gate stop; the cleanup belongs there",
         )
 
-    def test_both_worktrees_and_the_branch_are_removed(self):
-        """Removing the worktrees and leaving the branch still accumulates."""
-        phase7 = self.shell[7]
-        for artifact in ("$SCRATCH/pr-<N>", "$SCRATCH/base-<N>"):
-            self.assertIn(artifact, phase7, f"{artifact} is created in Phase 0 and never removed")
-        self.assertIn("git branch -D", phase7, "the fetched ref outlives the worktrees")
+    def test_every_artifact_phase_0_creates_is_removed(self):
+        """Removing the worktrees and leaving the branch still accumulates.
+
+        Read through `reachable`, because the names moved into `cleanup.py`'s
+        `WORKTREES` when Phase 7 was mechanised. `_code_only` strips docstrings and
+        comments, so the script's own explanation of the tuple cannot satisfy this
+        — only the tuple can. `tip-<N>` is in the list now: Phase 0 creates it when
+        the base was rewritten, and the prose used to ask the reader to add a line
+        for it, which is the kind of instruction that gets skipped.
+
+        Matched quote-agnostically: `_code_only` normalises source through
+        `ast.unparse`, so a double-quoted argv in the script arrives here
+        single-quoted and a literal match silently fails.
+        """
+        material = self.reachable(7)
+        for artifact in ("pr-{n}", "base-{n}", "tip-{n}"):
+            self.assertIn(artifact, material, f"{artifact} is created in Phase 0 and never removed")
+        self.assertRegex(
+            material,
+            r"""['"]branch['"],\s*['"]-D['"]""",
+            "the fetched ref outlives the worktrees",
+        )
+
+    def test_the_cleanup_exit_code_is_read_not_chained(self):
+        """`cleanup.py … && next` turns a finding into a swallowed error.
+
+        Exit 1 means residue was found and the worktree was still removed. It is
+        the same shape as Phase 5's `cmd | tail && next` trap, one phase over, and
+        the same shape as `gate_diff.py`'s 1-is-a-finding contract — so the phase
+        that consumes it has to say which of 0, 1 and 2 it is looking at.
+        """
+        phase7 = dict(self.phases)[7]
+        self.assertIn(
+            "do not chain on it",
+            phase7,
+            "Phase 7 must tell the reader that exit 1 is a finding, not a failure",
+        )
+        self.assertNotRegex(
+            self.shell[7],
+            r"cleanup\.py[^\n]*&&",
+            "chaining on cleanup.py hides the residue exit",
+        )
+
+    def test_phase_5_says_its_gates_may_dirty_the_tree(self):
+        """Otherwise the run tidies up and destroys the finding before Phase 7.
+
+        Phase 4 restores `base-<N>` after every gate run; nothing restores
+        `pr-<N>`, deliberately. A run that reads the dirt as its own mess and
+        `git checkout .`s it has thrown away the strongest row Phase 5 produces.
+        """
+        self.assertIn(
+            "do not tidy it yourself",
+            dict(self.phases)[5],
+            "Phase 5 must say the fix-mode residue is expected and is Phase 7's to report",
+        )
 
 
 class TestTheRequiredContextListIsNotSilentlyTruncated(SkillHarness):


### PR DESCRIPTION
Closes #97. Closes #95.

Phase 7's tidy-up was three commands in the prose, and the prose said nothing about
what does or does not dirty a worktree. Two separate audits therefore reasoned it
out and reached the same wrong answer — that Phase 5's `uv sync` leaves a `.venv/`
which makes `git worktree remove` refuse.

It does not. `remove` gates on `git status --porcelain`, which omits *ignored*
files, and uv, pytest, ruff and mypy each write a `.gitignore` containing `*`
inside their own directory. Measured on git 2.55.0 and uv 0.12.8, in a worktree of
a repo with **no `.gitignore` at all**:

```
uv sync --locked          -> exit=0
.venv/.gitignore contains: [*]
git status --porcelain:    []
git worktree remove       -> exit=0
```

That is the argument for a script rather than a sentence. A run that types the
command re-derives the question every time; a run that calls `cleanup.py` never
asks it. CONTRIBUTING already says so — *"a trap a script refuses cannot be
skipped, one on a checklist is visibly skipped, one in prose is silently skipped."*

## What the hand-backs missed

Phase 5 runs the repo's own gates in `$SCRATCH/pr-<N>`, and where those are
fix-mode — `pre-commit` stages its own edits, as `gate_diff.py`'s `restore()`
already records — tracked files end up modified or staged and `remove` exits 128.
Phase 4 mutates `base-<N>` and `gate_diff.py` restores it after every run; **nothing
restored `pr-<N>`.**

So the residue is written to `$SCRATCH/residue-<tree>.diff` **before** the tree
goes. `$SCRATCH` outlives the worktrees, so the evidence outlives the tree that
held it — and that is what makes the removal safe. Forcing without writing would
discard something the audit produced and had not yet reported, the loss `restore()`
declines `-x` to avoid. Per-tree rather than one file, because `pr-<N>` dirty is
Phase 5's gates while `base-<N>` dirty means `gate_diff`'s restore did not hold.

Exit `1` means residue was found and the worktree was still removed — a finding,
not a cleanup failure, matching `gate_diff.py`'s contract. Phase 7 says to read the
code and **not to chain on it**: `cleanup.py … && next` swallows the finding, the
same shape as Phase 5's `cmd | tail && next` trap one phase over.

Phase 5 now says the dirt is expected and is a *result*, so a run does not read it
as its own mess and `git checkout .` the finding away. Phase 0's worktree-reuse
remedy was a plain `git worktree remove` after a check that fails precisely when
the tree is dirty — the remedy refusing on the state it was written for — and now
calls the script.

## Tests

14 cases on real git worktrees, covering **both halves** of the claim the
hand-backs got wrong: a self-ignoring `.venv` is not residue, an un-ignored
`tests/__pycache__` is. Plus the missing path (exit 0, per #90's measurement), the
actions-bump shape, a rewritten base's `tip-<N>`, a staged fix, a dirty `base-<N>`
getting its own file, and a crash reporting 2 rather than 1.

**One case asks `uv` rather than restating it.** The hand-built `.venv/.gitignore`
fixture encodes this repo's *claim* about uv; if uv stopped self-ignoring, it would
stay green while the prose went wrong. `test_a_real_uv_venv_does_not_count_either`
builds a real venv and skips where `uv` is absent — CONTRIBUTING's rule that a
fixture built from the rule can only ever agree with it. The hand-built one stays,
because it is what CI on four interpreters actually runs.

**A guard retired itself on this commit, exactly as predicted.** `reachable()`'s
docstring warns that a guard scanning only a phase's own bash goes green the moment
its mechanism moves into a script. Mechanising Phase 7 did that to
`TestCleanupRunsOnEveryPath`. It now matches `cleanup.py` too and reads the artifact
list through `reachable()`, where `_code_only` strips docstrings — so the script's
own prose about `WORKTREES` cannot satisfy the assertion that the tuple must. That
helper also normalises source through `ast.unparse`, so argv matching had to become
quote-agnostic.

mypy's per-module override needed the new test module adding, which its own comment
predicted would be the loud failure mode. It was.

## The replay

- [x] Replayed against `Machai-Kydoimos/fpga-board-sim #384`

A **full** audit, not `--no-execute`, because residue only exists if Phase 5
actually runs. 30 turns, `is_error: false`.

```
removed: pr-384, base-384, branch pr-384
no residue: every worktree was clean when it was removed.
cleanup exit: 0
```

Verified independently rather than from the report: no worktrees registered, no
`pr-384` branch, `$SCRATCH` holding only handoff artifacts and no `residue-*` file.

**The new Phase 5 prose worked behaviourally** — the half the session that wrote it
cannot test. Unprompted, the run added its own check:

```
=== pr-384 residue (tracked files changed by the gates) ===
(empty above = the repo's own fix-mode gates changed nothing at the proposed version)
```

It went looking because the phase now tells it to, and reported the absence as a
result rather than as silence.

### What this replay does NOT show, stated plainly

**The residue path was not exercised live.** Phase 5 reproduces the *CI job's*
gates, and the run executed them as `ruff check .`, `ruff format --check .`,
`mypy .`, `rumdl check .`, `actionlint` — every one in **check** mode, because CI
cannot commit fixes and so does not ask for them. A clean tree follows and there was
nothing for the new code to save.

That qualifies this issue's own premise, which was written as though Phase 5's
gates were routinely fix-mode. In this repo `--fix` lives only in pre-commit, which
Phase 5 correctly did not run. The residue case is real — it is what `remove` exits
128 on — but it needs a repo whose **CI** runs `pre-commit run --all-files` or an
equivalent fix-mode target. Today it is covered by unit tests and by no live replay.

Constructing a synthetic fix-mode CI job to force it would be the
fixture-built-from-the-rule CONTRIBUTING warns can only agree with itself. The
honest closure is a bump in a repo whose CI genuinely fixes in place; that is worth
doing when one turns up, and is not a reason to hold this.
