### PR TITLE
Read all three changelog sources and reconcile them (0.36.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,23 @@ report; Phase 0 and Phase 6 gain a derivation they only implied.
 
 ### Fixed
 
+- **An empty release window was reported as "this project publishes no releases
+  for these versions"** whatever caused it. Three causes reach it — the target
+  has no release, the *start* has no release, or the two are not in the order the
+  caller believes (a downgrade, or a backported patch line) — and only the first
+  makes that sentence true. A backport got told the project publishes nothing, by
+  the tool written to stop absence of evidence reading as evidence of absence.
+  `gap()`'s own comment claimed it said which; nothing did, and the branch had no
+  test. It now returns the reason with the window, and the reason is printed.
+
+- **Every commit body was fetched and discarded.** `commits()` asks for whole
+  messages because *"the body is where a fix says what it corrupted"* — rumdl's
+  Rust-source fix names `# [derive(Debug)]` only there — and the terminal then
+  told the reader to go and fetch the range again. The evidence file now carries
+  the full message for each **destructive-shaped** row, which are the ones
+  Phase 7 takes the verdict from; the rest stay subjects, because a body for all
+  266 of ruff's would be the wall that file exists to replace.
+
 - **`changelog.py`'s own first version reported `python/mypy` v2.3.0…v2.3.1 as
   carrying no fixes.** It carries four. Filtering on `fix(` is only honest where
   the project did the labelling, and mypy labels nothing — so the script now says

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,37 @@ report; Phase 0 and Phase 6 gain a derivation they only implied.
   exactly as `git show "<ref>:<path>"` is; a `show`-only pattern called both
   working-tree reads.
 
+### Security
+
+- **The GitHub repository was resolved with an unanchored substring test**, in
+  the prose since 0.33.0 and in this script's first cut. `project_urls` is
+  written by the package author — the party this plugin exists to *not* trust —
+  so `if "github.com/" in url` hands the audit whatever repository that author
+  names. Measured:
+
+  | `project_urls` entry | Repo the audit would have read |
+  |---|---|
+  | `https://evil.example.invalid/github.com/attacker/lookalike` | `attacker/lookalike` |
+  | `https://example.invalid/?q=github.com/attacker/repo` | `attacker/repo` |
+  | `https://github.com/../../users/octocat` | `../..`, walking out of `repos/` |
+
+  The first two point Phase 2's entire changelog read at a repository the package
+  controls: tidy release notes, no unreconciled fixes, a clean currency row. The
+  reconciliation added above is a verdict input Phase 7 reads, so this was worse
+  after #94 than before it — the feature made the target worth attacking.
+
+  Now the host is **compared**, never searched for, and both path segments are
+  validated (which is what rejects `..`, since the slug is interpolated into a
+  `gh api repos/<slug>/…` path). `--repo-slug` goes through the same check: it
+  reaches the same API path, and a typo that silently answers about something
+  else is the failure this phase is about.
+
+  Caught by CodeQL as `py/incomplete-url-substring-sanitization`, high severity,
+  on the PR that mechanised the ladder. **The prose copy was found only because
+  the script copy was flagged** — and that copy is now deleted rather than fixed,
+  because a second implementation of what `changelog.py` already does is how one
+  of them keeps the bug.
+
 ### Fixed
 
 - **`changelog.py`'s own first version reported `python/mypy` v2.3.0…v2.3.1 as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,105 @@ patch.
 
 ## [Unreleased]
 
+## [0.36.0] — 2026-09-01
+
+Closes [#94](https://github.com/Machai-Kydoimos/dependabot-audit/issues/94) and
+[#101](https://github.com/Machai-Kydoimos/dependabot-audit/issues/101). Phase 2's
+changelog ladder stopped at the first rung that answered, and every one of its
+exit conditions was an *absence* — so a rung returning real, well-formed content
+ended the read while five fix commits never entered the audit.
+
+**Minor, not patch.** Phase 2 gains a source it always reads and a row it can
+report; Phase 0 and Phase 6 gain a derivation they only implied.
+
+### Added
+
+- **`scripts/changelog.py`** (#94) reads all three sources and reconciles them.
+  The rungs were never a fallback chain: **prose is what the project chose to
+  say, and the commit range is what actually landed.** Measured on `rumdl`
+  v0.2.60…v0.2.62, the bump this was found in — rung 1 answers for both versions,
+  rung 2 answers for both, each says one `### Added` bullet, and the range holds
+  18 commits, five of them `fix(…)`. Two are `stop rewriting Rust source when
+  formatting doc comments`, which wrote `# [derive(Debug)]` to disk, and `stop
+  reading a lazy continuation as a setext underline`, in a tool the audited repo
+  runs as `rumdl check --fix` on every Markdown commit. A run honoring the ladder
+  as written reported "two additive releases" and was wrong about the only
+  interesting thing in the bump.
+
+  **The obvious heuristic does not save it.** *"Does this project document its
+  fixes at all?"* returns a confident yes: 0.2.56, 0.2.57, 0.2.59 and 0.2.60 all
+  carry a `### Fixed` section. Only the versions under audit had none, because
+  the release automation lists `feat` and drops `fix`. This is 0.33.0's failure
+  class with the absence moved out of the tooling and into the upstream project's
+  notes, where no exit status can reach it — **nothing fails.**
+
+  Exit `0` the prose names every fix, `1` it does not and they are listed, `2`
+  could not run. The evidence — both halves — goes to
+  `$SCRATCH/changelog-<repo>-<from>-<to>.md`, because no count substitutes for
+  reading a `Security` heading.
+
+- **`--write-mode` escalates a finding and never gates the search.** #94 proposed
+  making the range mandatory only where the repo runs the tool in write mode; the
+  script fetches it always. Gating the *call* on that judgement asks the auditor
+  to be right about write mode before it has the evidence, and one wrong guess
+  restores the silence the script exists to remove. One `compare` call is what
+  rung 3 already cost when it ran.
+
+- **A third row in Phase 2's scope test** (#94), where the entry names a **file
+  type** or a **document shape** rather than a setting. No config key exists to
+  grep, so "no config line matches" reads as `inert here`. Grep the tree instead
+  — and **do not pipe it into `wc`**: `git grep` exits `1` on no match and `128`
+  when it could not run, both printing nothing, so `| wc -l` reports `0` at exit 0
+  either way and turns `underivable` into `inert here`. Measured on git 2.55.0.
+  The counted sentence moved from "two cases" to "three", which CONTRIBUTING
+  already records the cost of forgetting.
+
+- **Phase 0 derives the workflow list instead of naming `<ci>`** (#101), at both
+  refs, so "diff the two lists" has two lists to diff. `ls-tree` on a missing
+  directory exits **128** and says so rather than printing nothing at exit 0, so a
+  repo with no workflows stays distinguishable from a read that failed. Phase 6
+  and `actions.md` § Phase 5 asked the same question under a second spelling
+  (`<changed>`); all three are now `<workflow>`, so the second and third are
+  visibly the first.
+
+### Changed
+
+- **`reachable()` now follows scripts named in an ecosystem reference.** It
+  followed only those named in `SKILL.md`, while `audit.py`, `gate_diff.py` and
+  `changelog.py` are all invoked from `references/uv-lock.md` — so their code was
+  in no phase's `reachable()`, and a guard about any of them was reading the
+  invocation line alone. That is the silent retirement the function's own
+  docstring warns about, sitting inside the function that warns about it.
+
+  It also needed `_code_only(printed=False)` for negative assertions only: what a
+  script *prints* is output, not a call, and `audit.py`'s advice to run
+  `uv run python -V` made the `--no-execute` guard fire on Phase 1 — the guard
+  that catches a phase executing the audited project, defeated by a phase
+  mentioning it. Opt-in, because Phase 6 asserts on printed text on purpose.
+
+- **Two ref-pinning guards widened to the property rather than the command.**
+  `git ls-tree "<ref>:<path>"` and `git diff "<ref>...<ref>" -- <path>` are pinned
+  exactly as `git show "<ref>:<path>"` is; a `show`-only pattern called both
+  working-tree reads.
+
+### Fixed
+
+- **`changelog.py`'s own first version reported `python/mypy` v2.3.0…v2.3.1 as
+  carrying no fixes.** It carries four. Filtering on `fix(` is only honest where
+  the project did the labelling, and mypy labels nothing — so the script now says
+  **which classifier ran**, and filters nothing when the project did not. Caught
+  by running it against the range the reference already cites, not by reading it.
+
+- **`section_for` found no changelog section in a file that has one per release.**
+  A generated heading links to a compare range carrying the *previous* version, so
+  the raw line matches the wrong one. Caught by replaying the script live; the
+  offline suite now pins it in both directions.
+
+- **`--jq '.commits[].commit.message'` runs eighteen messages together** with no
+  record boundary, landing one commit's subject inside the last one's body.
+  `@json` escapes the newlines so one line is one message. The same fix was needed
+  in `integration/`, where `--jq .body` returned unparseable raw text.
+
 ## [0.35.0] — 2026-09-01
 
 Closes [#97](https://github.com/Machai-Kydoimos/dependabot-audit/issues/97) and
@@ -4005,7 +4104,10 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.36.0...HEAD
+[0.36.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.35.0...v0.36.0
+[0.35.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.34.0...v0.35.0
+[0.34.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.30.1...v0.31.0

--- a/integration/test_live_changelog_sources.py
+++ b/integration/test_live_changelog_sources.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import unittest
 from typing import Any
@@ -86,3 +87,86 @@ class TestReleaseTagsDisagreeAboutThePrefix(unittest.TestCase):
     def test_rumdl_releases_with_one(self):
         tags = gh_json("repos/rvben/rumdl/releases?per_page=100", "[.[].tag_name]")
         self.assertIn("v0.2.58", tags)
+
+
+@live
+class TestARungThatAnsweredCanStillBeIncomplete(unittest.TestCase):
+    """The premise behind Phase 2's reconciliation, and behind `changelog.py`.
+
+    The ladder's rungs are not a fallback chain. Prose is what a project chose to
+    say; the commit range is what actually landed, and the two can disagree while
+    every rung returns real, well-formed, correctly-authored content. No exit
+    status anywhere can reach that.
+
+    `rumdl` v0.2.60...v0.2.62 is the case #94 was filed from, and it is durable:
+    release bodies for published tags are immutable in practice, the tag pair is
+    fixed, and the assertions below are the ones the rule rests on. If any of
+    them goes red, the project changed how it generates release notes and the
+    reference's worked example needs a new subject -- which is exactly what this
+    directory is for.
+
+    These are also the live half of `tests/test_changelog.py`'s recorded
+    fixtures. Those stay green by construction; these say whether they still
+    describe the world.
+    """
+
+    def test_the_release_notes_for_the_audited_version_document_no_fixes(self):
+        # `.body | @json`, not `.body`: a release body is multi-line, and the
+        # plain filter hands back raw text this helper cannot parse. The same
+        # escaping `changelog.py` needs to keep one commit message on one line.
+        body = gh_json("repos/rvben/rumdl/releases/tags/v0.2.61", ".body | @json") or ""
+        notes = body.split("## Downloads")[0]
+        self.assertIn("### Added", notes, "the notes are not the shape the example describes")
+        self.assertNotIn(
+            "### Fixed",
+            notes,
+            "rumdl v0.2.61 now documents fixes -- the reconciliation example needs a new subject",
+        )
+
+    def test_the_same_range_carries_fix_commits(self):
+        """The half no changelog can omit."""
+        subjects = gh_json(
+            "repos/rvben/rumdl/compare/v0.2.60...v0.2.62",
+            '[.commits[].commit.message | split("\\n")[0]]',
+        )
+        fixes = [s for s in subjects if s.startswith("fix(")]
+        self.assertGreaterEqual(
+            len(fixes),
+            5,
+            f"the range carried 5 fix commits when #94 was filed; it now carries {len(fixes)}",
+        )
+
+    def test_two_of_them_carry_the_destructive_shape_phase_2_looks_for(self):
+        """`stop rewriting Rust source when formatting doc comments` wrote
+        `# [derive(Debug)]` to disk. This is the row a run honoring the ladder as
+        written never reported."""
+        subjects = gh_json(
+            "repos/rvben/rumdl/compare/v0.2.60...v0.2.62",
+            '[.commits[].commit.message | split("\\n")[0]]',
+        )
+        marked = [s for s in subjects if re.search(r"\b(?:stops?|no longer)\b", s, re.I)]
+        self.assertGreaterEqual(len(marked), 2, f"expected the two destructive fixes, got {marked}")
+
+    def test_the_project_does_document_fixes_when_it_has_them(self):
+        """Why the obvious heuristic does not save the ladder: "does this project
+        document its fixes at all?" returns a confident yes. Only the versions
+        under audit had none."""
+        body = gh_json("repos/rvben/rumdl/releases/tags/v0.2.59", ".body | @json") or ""
+        self.assertIn("### Fixed", body.split("## Downloads")[0])
+
+    def test_mypy_labels_none_of_its_commits(self):
+        """The other classifier's premise. A filter keyed on `fix(` reports zero
+        fixes for this range, which carries four -- the defect `changelog.py`
+        shipped in its first version and the offline suite now pins."""
+        subjects = gh_json(
+            "repos/python/mypy/compare/v2.3.0...v2.3.1",
+            '[.commits[].commit.message | split("\\n")[0]]',
+        )
+        conventional = [s for s in subjects if re.match(r"^[a-z]+(\([^)]*\))?!?:", s)]
+        self.assertEqual(
+            conventional, [], "python/mypy has adopted conventional commits; the example is stale"
+        )
+        self.assertTrue(
+            [s for s in subjects if "Fix" in s],
+            "the range no longer carries the fixes the unlabelled example rests on",
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,6 @@ exclude = ["integration/fixtures"]
 # override then disappears with no warning, not even under
 # --warn-unused-configs (tested: errors went 25 -> 175). Adding a test file
 # means adding it here; forgetting is loud, which is the safer direction.
-module = ["test_audit", "test_ci_state", "test_cleanup", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry", "test_live_changelog_sources"]
+module = ["test_audit", "test_changelog", "test_ci_state", "test_cleanup", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry", "test_live_changelog_sources"]
 disallow_untyped_defs = false
 disallow_untyped_calls = false

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -207,11 +207,25 @@ whatever branch happened to be there:
 REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 
+# Derive the workflow list before reading it, at both refs. A repo can have
+# several, and a guessed `ci.yml` either fails loudly on a repo that spells it
+# `tests.yml` or — worse — succeeds and silently narrows the gate list to one.
+git ls-tree --name-only "pr-<N>:.github/workflows/";    echo "pr list exit: $?"
+git ls-tree --name-only "$BASE_SHA:.github/workflows/"; echo "base list exit: $?"
+
 git show "pr-<N>:.github/dependabot.yml" 2>/dev/null || git show "pr-<N>:renovate.json"
-git show "pr-<N>:.github/workflows/<ci>.yml"       # the gates Phase 5 reproduces
 git show "pr-<N>:.pre-commit-config.yaml"
-git show "$BASE_SHA:.github/workflows/<ci>.yml"    # the gates Phase 4 measures with
+
+# Then every name each list gave, at its own ref. Not one file: `<workflow>`
+# stands for the whole list, and Phase 6 asks for the same list narrowed to what
+# the diff touched.
+git show "pr-<N>:.github/workflows/<workflow>"       # the gates Phase 5 reproduces
+git show "$BASE_SHA:.github/workflows/<workflow>"    # the gates Phase 4 measures with
 ```
+
+`ls-tree` on a directory that is not there exits **128** and says so, rather than
+printing nothing at exit 0 — so a repo with no workflows is distinguishable from
+a read that failed, which is the distinction the two lists exist to support.
 
 **Each phase's gates come from the tree it runs them in**, and the two trees are
 not the same one: Phase 5 reproduces in `$SCRATCH/pr-<N>`, Phase 4 measures in
@@ -692,13 +706,36 @@ the same question Phase 4 asks of an actions bump, where `references/actions.md`
 calls the answer "inert here", a result and not silence.
 
 **The grep answers it only when the change is in the tool's own surface**, and
-two cases fall outside that. Both are ordinary, and both return a confident
-`inert here` that was never established:
+three cases fall outside that. All three are ordinary, and all three return a
+confident `inert here` that was never established:
 
 | The entry names | Why the config cannot answer it | What does |
 |---|---|---|
 | a **dependency** rather than a rule or a flag | it is not in this repo's config, and for a compiled wheel it is not even in this repo's *ecosystem* — a Rust crate inside a Python package, where the advisory lives on crates.io and every PyPI-side scanner is correctly clean | `references/uv-lock.md` § Phase 2 — read the shipped set out of the wheel's own SBOM. `references/actions.md` § Phase 2 for the tag-line question |
 | a rule this repo **disables** | the claim is then about the config *file*, and the verdict is about the *tool*. Config is interpreted: another file can win, a key can be spelled for a different version, a section can go unread | run the gate twice, once with the config and once without, and read the difference |
+| a **file type** or a **document shape** rather than a setting | there is no config key to grep for. `stop rewriting Rust source when formatting doc comments` is about `.rs` files, and `stop reading a lazy continuation as a setext underline` is about a blockquote followed by a setext underline — neither is a line any config could carry, and "no config line matches" reads as `inert here` | grep the **content** of the tree instead, below |
+
+**The third row is the one with no command in the table**, because its commands
+contain a pipe and a table cell cannot carry one — an escaped `\|` renders
+correctly and reaches *this* reader, who reads the raw file, as a backslash that
+breaks the regex:
+
+```bash
+git grep -lE '^(=+|-{2,})[ \t]*$' -- '*.md'; echo "shape scan exit: $?"
+git ls-files '*.rs';                         echo "type scan exit: $?"
+```
+
+**Read the exit code, and do not pipe these into `wc`.** `git grep` exits `1` on
+no match and `128` when it could not run, and both print nothing — so
+`git grep … | wc -l` reports `0` at exit 0 either way, turning "could not run"
+into `inert here`, which is the failure this whole row exists to prevent. `1` is
+a real zero; `128` is `underivable`.
+
+Exposure is how many files carry the shape, and **zero is a finding like any
+other** — the same `inert here` the first two rows earn by running something,
+rather than by finding nothing to grep. Both commands come from a run that
+improvised them unaided, because the phase said "grep this repo's config" and no
+config line could answer.
 
 That second row is Phase 6's rule one phase over. A red check does not carry a
 verdict until it is attributed; a config line does not carry `inert` until the
@@ -836,11 +873,20 @@ triggered only by `push: tags:` or `schedule:` never runs on a PR, so every chec
 on it comes from *other* workflows and none of them execute the changed line:
 
 ```bash
-# for each workflow the diff touched, read its triggers. Captured, not piped:
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# `<workflow>` is Phase 0's derived list, narrowed to what this PR's diff
+# touched — the same derivation, the same token, one filter added.
+git diff --name-only "$BASE_SHA...pr-<N>" -- '.github/workflows/'
+echo "changed-workflow list exit: $?"
+
+# Then, for each name it gave, read its triggers. Captured, not piped:
 # `sed` succeeds on empty input, so a failed read prints nothing at exit 0 and
 # reads as "this workflow has no pull_request trigger" — the reassuring answer.
-TRIGGERS=$(git show "pr-<N>:.github/workflows/<changed>.yml") \
-  || { echo "cannot read <changed>.yml at pr-<N>" >&2; exit 2; }
+TRIGGERS=$(git show "pr-<N>:<workflow>") \
+  || { echo "cannot read <workflow> at pr-<N>" >&2; exit 2; }
 printf '%s\n' "$TRIGGERS" | sed -n '/^on:/,/^[a-z]/p'
 ```
 

--- a/skills/dependabot-audit/references/actions.md
+++ b/skills/dependabot-audit/references/actions.md
@@ -311,7 +311,16 @@ runners, so local reproduction is unavailable. The substitute is **evidence that
 this pin has already run**: ask the workflow the bump changed.
 
 ```bash
-gh run list --workflow <changed>.yml --limit 10 \
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# `<workflow>` is the same derived list Phase 0 and Phase 6 use, narrowed to what
+# this PR touched. Derive it; do not guess a filename.
+git diff --name-only "$BASE_SHA...pr-<N>" -- '.github/workflows/'
+echo "changed-workflow list exit: $?"
+
+gh run list --workflow <workflow> --limit 10 \
   --json conclusion,headBranch,createdAt,displayTitle \
   --jq '.[] | "\(.conclusion)\t\(.createdAt)\t\(.displayTitle)"'
 ```

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -140,25 +140,31 @@ package that is three steps, and each has a way of failing quietly.
 
 **The repo is in PyPI's metadata, not guessable from the package name.** The
 Simple API the Phase 1 script uses carries artifacts and nothing else, so this is
-the one place to reach for the JSON API:
+the one place the JSON API is the right call. `changelog.py` reads it, and two
+things about how it reads it are load-bearing.
 
-```bash
-PKG=<name>; VER=<version>
-REPO=$(python3 - "$PKG" <<'PY'
-import json, sys, urllib.request
-d = json.load(urllib.request.urlopen(f"https://pypi.org/pypi/{sys.argv[1]}/json", timeout=30))
-for url in (d["info"].get("project_urls") or {}).values():
-    if url and "github.com/" in url:
-        print("/".join(url.split("github.com/")[1].strip("/").split("/")[:2])); break
-PY
-)
+**The host is compared, never searched for.** `project_urls` is written by the
+package author — the party this plugin exists to *not* trust — so a substring
+test on `"github.com/"` hands the audit whatever repository that author names.
+Measured against the version of this block that shipped from 0.33.0 until 0.36.0,
+and against this script's own first cut:
 
-# Do NOT construct the tag. Match it — and capture the list before filtering it,
-# so a failed lookup is a failed lookup and not an empty answer.
-TAGS=$(gh api "repos/$REPO/releases" --paginate --jq '.[].tag_name') \
-  || { echo "release list unavailable for $REPO — a lookup failure, not an absent release" >&2; exit 2; }
-TAG=$(printf '%s\n' "$TAGS" | grep -Fx -e "$VER" -e "v$VER" | head -1)
-```
+| `project_urls` entry | Repo the audit would have read |
+|---|---|
+| `https://evil.example.invalid/github.com/attacker/lookalike` | `attacker/lookalike` |
+| `https://example.invalid/?q=github.com/attacker/repo` | `attacker/repo` |
+| `https://github.com/../../users/octocat` | `../..`, walking out of `repos/` |
+
+The first two point this phase's entire changelog read at a repository the
+package author controls: tidy release notes, no unreconciled fixes, a clean
+currency row. Reported by CodeQL as `py/incomplete-url-substring-sanitization`
+on the PR that mechanised it, which is the only reason the prose copy was found.
+
+**Do not construct the tag; match it.** Projects disagree about the `v` prefix
+and change their minds mid-life, and a guessed tag returns "release not found",
+which reads exactly like "this version has no notes". The script matches against
+the published list, falls back to probing **both** spellings against the git ref,
+and reports which answered.
 
 **Constructing the tag is the quiet failure.** Projects disagree about the `v`
 prefix and change their minds mid-life. Measured 2026-08-30, on the three tools

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -174,24 +174,77 @@ A guessed tag returns "release not found", which reads exactly like "this versio
 has no notes" — so the audit reports an absence of evidence as evidence of
 absence, for a version whose notes are right there.
 
-**Then the ladder, in order. Say which rung produced the row:**
+**Then read all three sources, and reconcile them. `changelog.py` does it:**
 
-| Rung | Command | When it runs out |
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+python3 "${SCRIPTS:?not in the handoff — re-run Phase 0}/changelog.py" \
+  --scratch "$SCRATCH" --package <pkg> --from <locked> --to <proposed>
+echo "changelog exit: $?"
+```
+
+Add `--write-mode` when this repo runs the tool with `--fix`, `--write` or `-i`.
+It escalates how a destructive fix is reported and changes nothing about what is
+looked for — the range is fetched either way, because gating the *call* on that
+judgement asks the auditor to be right about write mode before it has the
+evidence.
+
+**Read the exit code; do not chain on it.** `0` the prose names every fix in the
+range, `1` it does not and the unreconciled commits are listed, `2` could not
+run. `1` is a finding, so `&&` swallows exactly the case the call is for. Use
+`--repo-slug owner/repo` instead of `--package` where the project is not on PyPI
+or its metadata carries no GitHub link.
+
+| Source | What it is | Where it runs out |
 |---|---|---|
-| 1. release notes | `gh release view "$TAG" --repo "$REPO"` | the project publishes none — check `gh api repos/$REPO/releases --jq length`, and `0` means *never*, not *not yet* |
-| 2. the repo's changelog | fetch `CHANGELOG.md` and find the section for **this exact version** | the project writes entries per *minor* release, so a patch has no section |
-| 3. the commit range | `gh api repos/$REPO/compare/<tag-before>...<tag> --jq '.commits[].commit.message'` | the tags themselves are missing, which is worth reporting |
+| 1. release notes | what the project chose to announce | it publishes none — `0` releases means *never*, not *not yet* |
+| 2. the repo's changelog | what it chose to write down | it writes entries per *minor* release, so a patch has no section |
+| 3. the commit range | **what actually landed** | the tags themselves are missing, which is worth reporting |
+| the three against each other | whether 1 and 2 cover 3 | never — this is the rung with no exit condition |
 
-Measured on `mypy` 2.3.0 → 2.3.1, which needs all three rungs: zero releases, a
-`CHANGELOG.md` whose headings run `Next Release`, `Mypy 2.3`, `Mypy 2.2` with no
-`2.3.1` between them, and then six commits in the range — a crash fix on
-overload unpacking and three `mypyc` fixes, which is the content the phase came
-for.
+**Until 0.36.0 these were a fallback chain, stopped at the first that answered,
+and that is the defect (#94).** Every exit condition above the last is an
+*absence*, so a rung returning real, well-formed content ended the ladder — and
+there was no rung whose exit condition was *"this one answered, and its answer is
+incomplete"*. Measured on `rumdl` v0.2.60…v0.2.62, the bump it was found in:
+rung 1 answers for both versions, rung 2 answers for both, each says one
+`### Added` bullet, and the range holds **18 commits, five of them `fix(…)`** —
+two being `stop rewriting Rust source when formatting doc comments`, which wrote
+`# [derive(Debug)]` to disk, and `stop reading a lazy continuation as a setext
+underline`. A run that honored the ladder as written reported "two additive
+releases" and was wrong about the only interesting thing in the bump.
 
-**"No changelog" is not a finding; "rung 3, six commits" is.** Report which rung
-answered, the same way Phase 5 reports which install ran. A patch release from a
-project that tags without releasing is ordinary — mypy is in the `dev` group of
-most repos this plugin audits — so a row that goes quiet here goes quiet often.
+**The obvious heuristic does not save it.** *"Does this project document its
+fixes at all?"* returns a confident yes — 0.2.56, 0.2.57, 0.2.59 and 0.2.60 all
+carry a `### Fixed` section. Only the versions under audit had none, because the
+release automation lists `feat` and drops `fix`. Nothing in rung 1's output says
+so, which is why this is worse than a lookup that fails: **nothing fails.**
+
+Two things the script does that a careful reading kept getting wrong, both
+measured rather than reasoned:
+
+- **It matches the tag and never builds one**, and it finds the changelog by
+  listing the repo root rather than assuming `CHANGELOG.md`. A guessed name 404s,
+  and a 404 reads exactly like "this project keeps no changelog".
+- **It says which classifier ran.** Where the project writes conventional
+  commits it reads only fix types; where it does not, it filters nothing —
+  because a filter keyed on `fix(` reports **zero fixes** for `mypy`
+  v2.3.0…v2.3.1, a range carrying four. That is this plugin's own failure class,
+  rebuilt inside the tool written to remove it, and it is what the first version
+  of the script shipped.
+
+**"No changelog" is not a finding; "the prose named one change, the range carried
+five" is.** Report which sources answered and what the reconciliation said, the
+same way Phase 5 reports which install ran. A patch release from a project that
+tags without releasing is ordinary — mypy is in the `dev` group of most repos
+this plugin audits — so a row that goes quiet here goes quiet often.
+
+The script writes both halves to `$SCRATCH/changelog-<repo>-<from>-<to>.md`.
+**Read it**: a `Security` entry outranks every vulnerability database, ships with
+no CVE, and no count in the script's output substitutes for seeing one.
 
 ### When the changelog entry names a dependency
 

--- a/skills/dependabot-audit/references/uv-lock.md
+++ b/skills/dependabot-audit/references/uv-lock.md
@@ -160,15 +160,10 @@ package author controls: tidy release notes, no unreconciled fixes, a clean
 currency row. Reported by CodeQL as `py/incomplete-url-substring-sanitization`
 on the PR that mechanised it, which is the only reason the prose copy was found.
 
-**Do not construct the tag; match it.** Projects disagree about the `v` prefix
-and change their minds mid-life, and a guessed tag returns "release not found",
-which reads exactly like "this version has no notes". The script matches against
-the published list, falls back to probing **both** spellings against the git ref,
-and reports which answered.
-
 **Constructing the tag is the quiet failure.** Projects disagree about the `v`
-prefix and change their minds mid-life. Measured 2026-08-30, on the three tools
-in one bump:
+prefix and change their minds mid-life. The script matches against the published
+list and falls back to probing **both** spellings against the git ref, reporting
+which answered. Measured 2026-08-30, on the three tools in one bump:
 
 | Project | Release tag for the audited version | Note |
 |---|---|---|
@@ -232,9 +227,9 @@ so, which is why this is worse than a lookup that fails: **nothing fails.**
 Two things the script does that a careful reading kept getting wrong, both
 measured rather than reasoned:
 
-- **It matches the tag and never builds one**, and it finds the changelog by
-  listing the repo root rather than assuming `CHANGELOG.md`. A guessed name 404s,
-  and a 404 reads exactly like "this project keeps no changelog".
+- **It finds the changelog by listing the repo root**, rather than assuming
+  `CHANGELOG.md`. A guessed name 404s, and a 404 reads exactly like "this project
+  keeps no changelog" — the tag trap above, one file over.
 - **It says which classifier ran.** Where the project writes conventional
   commits it reads only fix types; where it does not, it filters nothing —
   because a filter keyed on `fix(` reports **zero fixes** for `mypy`

--- a/skills/dependabot-audit/scripts/changelog.py
+++ b/skills/dependabot-audit/scripts/changelog.py
@@ -87,6 +87,7 @@ import re
 import subprocess
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import NoReturn
@@ -155,6 +156,11 @@ HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
 # docstring on which error this file prefers.
 MATCH_RATIO = 0.82
 
+# One path segment of a GitHub `owner/repo`. Rejects `.` and `..` outright,
+# because the slug is interpolated into a `gh api repos/<slug>/...` path and
+# `..` walks out of `repos/` into a different endpoint.
+SEGMENT = re.compile(r"^(?!\.{1,2}$)[A-Za-z0-9._-]{1,100}$")
+
 
 def fail(what: str) -> NoReturn:
     """Exit 2 -- could not run. Never 1, which means the prose came up short."""
@@ -207,6 +213,64 @@ def _gh_hard(args: list[str]) -> str:
     return out
 
 
+def valid_slug(slug: str) -> bool:
+    """Exactly two well-formed path segments.
+
+    `--repo-slug` is interpolated into `gh api repos/<slug>/...`, so `../..`
+    would walk out of `repos/` and query a different endpoint. Checked even
+    though the caller is the auditor rather than the package: the same string
+    reaches the same place, and a typo that silently answers about something
+    else is the failure mode this whole phase is about.
+    """
+    parts = slug.split("/")
+    return len(parts) == 2 and all(SEGMENT.match(p) for p in parts)
+
+
+def github_slug(url: str) -> str | None:
+    """`owner/repo` if `url` is a GitHub repository URL, else None.
+
+    **The host is compared, never searched for.** `project_urls` is written by
+    the package author -- the party this whole plugin exists to not trust -- and
+    a substring test on `"github.com/"` hands the audit whatever repository that
+    author names. Measured, against the version that shipped in the prose from
+    0.33.0 and in the first cut of this script:
+
+        https://evil.example.invalid/github.com/attacker/lookalike -> attacker/lookalike
+        https://example.invalid/?q=github.com/attacker/repo        -> attacker/repo
+        https://github.com/../../users/octocat                     -> ../..
+
+    The first two point Phase 2's entire changelog read at a repository the
+    package author controls: tidy release notes, no unreconciled fixes, a clean
+    currency row. The third walks out of `repos/` into a different API endpoint,
+    because the slug is interpolated into a `gh api` path.
+
+    That is worse now than it was before this file existed. The reconciliation
+    is a verdict input Phase 7 reads, so a package that can choose which
+    repository answers for it can choose its own Phase 2 finding.
+
+    Segments are validated too, which is what rejects `..` -- a name may not be
+    `.` or `..`, and may hold only the characters GitHub actually allows.
+    """
+    if not url:
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(url.strip())
+    except ValueError:
+        return None
+    if parsed.scheme not in ("http", "https"):
+        return None
+    # `.hostname` is already lowercased and strips any `user:pass@` and `:port`.
+    if parsed.hostname not in ("github.com", "www.github.com"):
+        return None
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) < 2:
+        return None
+    owner, repo = parts[0], parts[1].removesuffix(".git")
+    if not (SEGMENT.match(owner) and SEGMENT.match(repo)):
+        return None
+    return f"{owner}/{repo}"
+
+
 def resolve_repo(package: str) -> str:
     """`owner/repo` from PyPI's JSON metadata, which is where it actually lives.
 
@@ -227,10 +291,9 @@ def resolve_repo(package: str) -> str:
     urls = list((data.get("info", {}).get("project_urls") or {}).values())
     urls.append(data.get("info", {}).get("home_page") or "")
     for url in urls:
-        if url and "github.com/" in url:
-            parts = url.split("github.com/")[1].strip("/").split("/")
-            if len(parts) >= 2:
-                return f"{parts[0]}/{parts[1]}"
+        slug = github_slug(url)
+        if slug:
+            return slug
     fail(
         f"{package} names no GitHub repository in its PyPI metadata -- pass "
         f"--repo-slug, and say in the report that the link was not derived"
@@ -598,6 +661,8 @@ def main() -> int:
     if not scratch.is_dir():
         fail(f"{scratch} does not exist -- re-derive $SCRATCH, or Phase 0 never ran")
 
+    if args.slug and not valid_slug(args.slug):
+        fail(f"--repo-slug {args.slug!r} is not an owner/repo pair")
     slug = args.slug or resolve_repo(args.package)
     published = releases(slug)
     tags = [row["tag"] for row in published]

--- a/skills/dependabot-audit/scripts/changelog.py
+++ b/skills/dependabot-audit/scripts/changelog.py
@@ -127,10 +127,19 @@ FIX_WORDED = re.compile(
 )
 
 # How many unreconciled rows reach the terminal. The rest go to the evidence
-# file. A wall of 266 rows is the same failure as silence -- the reader's eye
-# slides off it -- and ruff 0.16.2...0.16.5 produces exactly that, with the two
-# marked rows at positions 8 and 13. Ranked first, capped second, so the cap can
-# only ever cut the tail.
+# file. A wall of rows is the same failure as silence -- the reader's eye slides
+# off it -- and ruff 0.16.2...0.16.5 produces exactly that at 266.
+#
+# Ranked first, capped second, so the cap can only ever cut the tail. Measured on
+# rumdl v0.2.60...v0.2.62: the two destructive-shaped fixes come back from the API
+# at positions 4 and 5 of 5, and the ranking puts them at 1 and 2.
+#
+# An earlier version of this comment cited ruff's own marked rows "at positions 8
+# and 13". Those were `Avoid composite Salsa keys` and `Avoid deadlock`, which the
+# narrowing described above deliberately stopped marking -- so the comment was
+# describing a superseded regex, and contradicting the one twenty lines up. That
+# range now has **zero** marked rows, which is why its wall needs the
+# multi-product note rather than a marker.
 SHOWN = 40
 
 # `fix(scope): description` / `fix!: description` / `fix: description`.

--- a/skills/dependabot-audit/scripts/changelog.py
+++ b/skills/dependabot-audit/scripts/changelog.py
@@ -348,8 +348,10 @@ def match_tag(version: str, published: list[str], slug: str) -> str | None:
     return None
 
 
-def gap(published: list[dict[str, str]], from_tag: str, to_tag: str) -> list[dict[str, str]]:
-    """The releases from `from_tag` (exclusive) to `to_tag` (inclusive).
+def gap(
+    published: list[dict[str, str]], from_tag: str, to_tag: str
+) -> tuple[list[dict[str, str]], str]:
+    """(the releases from `from_tag` exclusive to `to_tag` inclusive, why it is short).
 
     Sliced out of the API's own newest-first ordering rather than by parsing
     versions, so no PEP 440 comparison has to be right for this to be. When
@@ -357,21 +359,31 @@ def gap(published: list[dict[str, str]], from_tag: str, to_tag: str) -> list[dic
     are gathered -- which costs prose, never the range: `compare` is a call about
     two refs and does not consult this list at all. The fallible half of the
     ladder is the half the finding does not rest on.
+
+    **The second return value is the fix for this function's own defect.** An
+    empty window has three causes and they are not the same answer, but the first
+    version returned a bare `[]` for all of them and `main` printed *"this project
+    publishes no releases for these versions"* -- true for one cause and false for
+    the other two. A backported patch line got told the project publishes nothing,
+    by the tool written to stop absence of evidence reading as evidence of absence.
+    The comment here even claimed it said so; nothing did.
     """
     tags = [row["tag"] for row in published]
     if to_tag not in tags:
-        return []
+        return [], f"no published release for {to_tag}"
     top = tags.index(to_tag)
     if from_tag not in tags:
-        return [published[top]]
+        return [published[top]], f"no published release for {from_tag}; only {to_tag}'s notes"
     bottom = tags.index(from_tag)
     if bottom <= top:
         # Newest-first, so `from` at or above `to` means the versions are not in
-        # the order the caller believes -- a downgrade, or a backported patch
-        # line. Saying so beats returning an empty gap that reads as "nothing
-        # was released in between".
-        return []
-    return published[top:bottom]
+        # the order the caller believes -- a downgrade, or a backported patch line.
+        return [], (
+            f"{from_tag} is not older than {to_tag} in the published order -- "
+            "a downgrade or a backported line, so no window can be sliced. "
+            "The commit range below is unaffected; it asks about two refs."
+        )
+    return published[top:bottom], ""
 
 
 def changelog_at(slug: str, tag: str) -> tuple[str, str] | None:
@@ -610,6 +622,7 @@ def write_evidence(
     to_tag: str,
     blocks: list[str],
     missing: list[str],
+    bodies: dict[str, str],
 ) -> Path:
     """Save both halves of the comparison, so reading them is not a second fetch.
 
@@ -621,6 +634,18 @@ def write_evidence(
     The unreconciled list goes in the same file and **is never capped here**.
     The terminal shows the ranked head; this is the whole of it, so the cap
     shortens the reading and not the evidence.
+
+    **The destructive-shaped rows carry their full commit message.** `commits()`
+    fetches whole messages precisely because *"the body is where a fix says what
+    it corrupted"* -- rumdl's Rust-source fix names `# [derive(Debug)]` only
+    there -- and the first version of this file then dropped every body on the
+    floor and told the terminal reader to go and fetch the range again. A
+    docstring claiming what the code discards, in a file whose whole subject is
+    prose that does not match what landed.
+
+    Only the marked rows, because these are the ones Phase 7 takes the verdict
+    from; a body for all 266 of ruff's would be the wall this file exists to
+    replace.
     """
     out = scratch / f"changelog-{slug.replace('/', '-')}-{from_tag}-{to_tag}.md"
     header = [
@@ -638,6 +663,17 @@ def write_evidence(
             "",
             *(f"- {subject}" for subject in missing),
         ]
+    marked = [s for s in missing if DESTRUCTIVE.search(s) and bodies.get(s, "").strip()]
+    if marked:
+        tail += [
+            "",
+            f"## destructive-fix shape -- full commit message ({len(marked)})",
+            "",
+            "The shape SKILL.md Phase 2 sends you to find. The body is where the",
+            "data loss is described; the subject rarely names it.",
+        ]
+        for subject in marked:
+            tail += ["", f"### {subject}", "", "```", bodies[subject].strip(), "```"]
     out.write_text("\n".join(header + blocks + tail), encoding="utf-8")
     return out
 
@@ -681,13 +717,13 @@ def main() -> int:
     print()
 
     # --- rungs 1 and 2: what the project chose to say ------------------------
-    window = gap(published, from_tag, to_tag)
+    window, why = gap(published, from_tag, to_tag)
     blocks: list[str] = []
     for row in window:
         blocks.append(f"## rung 1 -- release notes, {row['tag']} ({row['at']})\n\n{row['body']}")
     print(f"rung 1 -- release notes: {len(window)} release(s) in the gap")
-    if not window:
-        print("         (none -- this project publishes no releases for these versions)")
+    if why:
+        print(f"         ({why})")
 
     found = changelog_at(slug, to_tag)
     sections = 0
@@ -709,6 +745,12 @@ def main() -> int:
     # --- rung 3: what actually landed ----------------------------------------
     messages = commits(slug, from_tag, to_tag)
     subjects, mode, chores = candidates(messages)
+    # Subject -> whole message, so the evidence file can carry the body of a
+    # marked row. First-wins: two commits can share a subject, and the earlier
+    # is the one the range lists first.
+    bodies: dict[str, str] = {}
+    for message in messages:
+        bodies.setdefault(subject_of(message), message)
     what = "of fix type" if mode == "conventional" else "after release chores"
     print(f"rung 3 -- commit range: {len(messages)} commit(s), {len(subjects)} {what}")
     if mode == "conventional":
@@ -726,7 +768,7 @@ def main() -> int:
     missing = sorted(
         (s for s in subjects if not reconciled(description_of(s), prose_lines)), key=rank
     )
-    saved = write_evidence(scratch, slug, from_tag, to_tag, blocks, missing)
+    saved = write_evidence(scratch, slug, from_tag, to_tag, blocks, missing, bodies)
     print(f"evidence saved to {saved}")
     print("Read it for `Security` sections -- no count here substitutes for that.")
     print()

--- a/skills/dependabot-audit/scripts/changelog.py
+++ b/skills/dependabot-audit/scripts/changelog.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+"""Phase 2's changelog ladder, plus the reconciliation the ladder cannot do.
+
+Until 0.36.0 the ladder was three rungs of prose in `references/uv-lock.md`, tried
+in order and stopped at the first that answered:
+
+    1. release notes      -- runs out when the project publishes none
+    2. the repo changelog -- runs out when a patch has no section
+    3. the commit range   -- runs out when the tags are missing
+
+**Every one of those exit conditions is an absence**, so a rung that returns real,
+well-formed content ends the ladder. There was no rung whose exit condition was
+*"this rung answered, and its answer is incomplete"* -- and that is the case the
+ladder was built out of, not an edge of it.
+
+Measured on `rumdl` v0.2.60...v0.2.62 (2026-08-26/27), the bump that produced #94:
+rung 1 answers for both versions, rung 2 answers for both, and each says exactly
+one `### Added` bullet. The range holds **18 commits, five of them `fix(...)`**,
+two in the shape Phase 2 exists to find -- `stop rewriting Rust source when
+formatting doc comments`, which wrote `# [derive(Debug)]` to disk, and `stop
+reading a lazy continuation as a setext underline`. A run that honored the ladder
+as written reported "two additive releases" and was wrong about the only
+interesting thing in the bump.
+
+**The obvious heuristic does not save it.** "Does this project document its fixes
+at all?" returns a confident yes: 0.2.56, 0.2.57, 0.2.59 and 0.2.60 all carry a
+`### Fixed` section. Only the versions under audit had none, because the project's
+release automation lists `feat` and drops `fix`. Nothing in rung 1's output says so.
+
+So the rungs are not a fallback chain. They are two different kinds of source:
+**prose is what the project chose to say, and the range is what actually landed.**
+This script reads all three, always, and reports the difference between them.
+
+## Why the range is fetched unconditionally
+
+#94 proposed making the range mandatory *where the bumped package is a gate the
+repo runs in write mode*. This script goes one step further and always fetches it,
+because gating the **call** on that judgement asks the auditor to be right about
+write mode before it has the evidence, and a wrong guess restores exactly the
+silence the script exists to remove. The judgement still matters -- it is what
+`--write-mode` sets -- but it changes how a finding is *reported*, never whether
+it is *looked for*. One `compare` call is what rung 3 already cost when it ran.
+
+## What "unreconciled" means, and which way it errs
+
+A commit counts as reconciled when its description turns up in the prose the
+other two rungs produced -- as a substring after normalisation, or close enough
+by `difflib` that a reader would call it the same entry.
+
+**Which commits are reconciled depends on who did the labelling, and the output
+says which.** Where the project writes conventional commits, only fix types are
+read: a `docs:` commit absent from a changelog is correct behaviour, and rows
+nobody acts on are how a report stops being read. Where it does not, nothing is
+filtered -- because a filter that keys on `fix(` reports **zero fixes** for a
+range full of them, which is this plugin's own failure class rebuilt inside the
+tool written to remove it. `python/mypy` v2.3.0...v2.3.1 is that case, and the
+first version of this file called it clean.
+
+**Both halves err toward reporting.** A changelog that rewords an entry past the
+threshold produces a row the auditor reads and dismisses in a second. The other
+error is the one that shipped: a fix silently counted as covered. Those costs are
+not comparable, so the threshold sits where the cheap mistake happens.
+
+The unlabelled mode is noisy at scale -- ruff 0.16.2...0.16.5 leaves 266 of 307
+unnamed, most of them `ty`, a second product under the same tags. That is
+answered by **ranking and a cap, never by filtering**: destructive shapes first,
+fix-worded next, the top `SHOWN` on the terminal and every one of them in the
+evidence file.
+
+Usage:
+    changelog.py --scratch DIR --from VERSION --to VERSION \\
+                 (--package NAME | --repo-slug OWNER/REPO) [--write-mode]
+
+Exit status: 0 = the prose names every fix in the range. 1 = it does not, and the
+unreconciled commits are listed (a Phase 2 finding, not a script failure).
+2 = could not run.
+Requires Python 3.11+. Network: `gh api`, and PyPI for `--package`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import NoReturn
+
+TIMEOUT = 60
+
+# Conventional-commit types whose absence from a changelog is worth a row.
+# `docs`, `chore`, `ci`, `test`, `refactor` and `style` are left out on purpose:
+# a changelog that omits them is behaving correctly, and rows nobody acts on are
+# how a report stops being read.
+FIX_TYPES = ("fix", "perf", "revert", "security", "sec")
+
+# SKILL.md Phase 2: *entries like "stop deleting..." or "no longer removes..."*.
+# Exactly those two shapes, and not the wider family of English negations.
+#
+# The shape is the **negation**, not the verb after it -- rumdl's `stop reading a
+# lazy continuation as a setext underline` names no destructive verb and still
+# splits one blockquote into three blocks under MD022. But a first version that
+# also matched `avoid`, `prevent` and `never` fired on `[ty] Avoid composite
+# Salsa keys for unspecialized MROs` and `[ty] Avoid deadlock when scheduling
+# watch checks` in ruff 0.16.2...0.16.5 -- ordinary English, no data loss. A
+# marker that fires on a fifth of the rows marks nothing.
+#
+# Narrowing is cheap here because this **ranks, it does not filter**: every
+# unreconciled commit is listed either way, and `FIX_WORDED` below carries the
+# looser family into second place rather than out of the report.
+DESTRUCTIVE = re.compile(r"\b(?:stops?|stopped|stopping|no longer)\b", re.IGNORECASE)
+
+# Second tier of the ranking: subjects that read like a correction without
+# carrying the destructive shape. Only ordering depends on this, so a miss costs
+# a place in a list and never a row.
+FIX_WORDED = re.compile(
+    r"\b(?:fix(?:e[sd])?|bug|crash|regress(?:ion|es)?|revert(?:s|ed)?|correct(?:s|ed)?"
+    r"|restore[sd]?|repair(?:s|ed)?|broken|incorrect|wrong|corrupt(?:s|ed|ion)?"
+    r"|data.loss|panic|deadlock|leak|overwrit(?:e|es|ing|ten))\b",
+    re.IGNORECASE,
+)
+
+# How many unreconciled rows reach the terminal. The rest go to the evidence
+# file. A wall of 266 rows is the same failure as silence -- the reader's eye
+# slides off it -- and ruff 0.16.2...0.16.5 produces exactly that, with the two
+# marked rows at positions 8 and 13. Ranked first, capped second, so the cap can
+# only ever cut the tail.
+SHOWN = 40
+
+# `fix(scope): description` / `fix!: description` / `fix: description`.
+CONVENTIONAL = re.compile(
+    r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?:\s*(?P<rest>.+)$"
+)
+
+# A changelog by any of the names projects actually use. Matched against the
+# repository's own root listing rather than constructed, for the same reason the
+# release tag is: a guessed name returns 404, and a 404 reads exactly like "this
+# project keeps no changelog".
+CHANGELOG_NAME = re.compile(
+    r"^(?:CHANGE(?:LOG|S)|HISTORY|NEWS|RELEASES?)(?:\.(?:md|rst|txt))?$", re.IGNORECASE
+)
+
+# Any ATX heading, split into its level and its text. Which heading belongs to
+# which version is `section_for`'s problem, and it is harder than it looks: the
+# link target carries the *previous* version.
+HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+
+# How alike two entries must read before one counts as the other. Deliberately
+# forgiving of rewording and deliberately not of omission -- see the module
+# docstring on which error this file prefers.
+MATCH_RATIO = 0.82
+
+
+def fail(what: str) -> NoReturn:
+    """Exit 2 -- could not run. Never 1, which means the prose came up short."""
+    print(f"error: {what}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _gh(args: list[str]) -> str | None:
+    """Run `gh`; stdout on success, `None` on any failure. Never exits.
+
+    The single network seam for GitHub, so the offline suite replaces one
+    function and drives every line of parsing and reconciliation below.
+
+    `gh` writes an API error body to **stdout** and still exits non-zero, so the
+    exit code is the signal and the body is the explanation. Reading the body
+    without the exit code is how a 404 becomes a well-formed "no releases here".
+    That is why the failure is `None` and not `""`: a caller cannot mistake "the
+    call failed" for "the answer was empty", which is this phase's own failure
+    mode in miniature.
+
+    A missing `gh` is the one thing that ends the run here rather than at the
+    call site -- no rung of this ladder can proceed without it, so a soft return
+    would only defer the same exit by three calls.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["gh", *args],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=TIMEOUT,
+        )
+    except FileNotFoundError:
+        fail("`gh` is not on PATH; every rung of this ladder is a GitHub API call")
+    except subprocess.TimeoutExpired:
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def _gh_hard(args: list[str]) -> str:
+    """`_gh`, for the calls the phase cannot proceed without. Exit 2 on failure.
+
+    The release list and the commit range are both of that kind: without either,
+    the reconciliation this script exists for cannot be attempted, and reporting
+    "no fixes found" from a call that never ran is the defect, not the report.
+    """
+    out = _gh(args)
+    if out is None:
+        fail(f"`gh {' '.join(args[:2])}` failed -- run it by hand to see why")
+    return out
+
+
+def resolve_repo(package: str) -> str:
+    """`owner/repo` from PyPI's JSON metadata, which is where it actually lives.
+
+    The Simple API the Phase 1 script uses carries artifacts and nothing else, so
+    this is the one place the JSON API is the right call. The repo is *in* the
+    metadata and is not guessable from the package name -- `mirrors-mypy` and
+    `python/mypy`, `rumdl` and `rvben/rumdl`.
+    """
+    url = f"https://pypi.org/pypi/{package}/json"
+    try:
+        with urllib.request.urlopen(url, timeout=TIMEOUT) as response:
+            data = json.load(response)
+    except urllib.error.HTTPError as exc:
+        fail(f"PyPI has no metadata for {package!r} (HTTP {exc.code})")
+    except (urllib.error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        fail(f"could not read PyPI metadata for {package!r}: {exc}")
+
+    urls = list((data.get("info", {}).get("project_urls") or {}).values())
+    urls.append(data.get("info", {}).get("home_page") or "")
+    for url in urls:
+        if url and "github.com/" in url:
+            parts = url.split("github.com/")[1].strip("/").split("/")
+            if len(parts) >= 2:
+                return f"{parts[0]}/{parts[1]}"
+    fail(
+        f"{package} names no GitHub repository in its PyPI metadata -- pass "
+        f"--repo-slug, and say in the report that the link was not derived"
+    )
+
+
+def releases(slug: str) -> list[dict[str, str]]:
+    """Every published release, newest first: tag, body, date.
+
+    `--paginate` because a long-lived project's current release is not on page
+    one of anything if the caller asks for a version a year back.
+    """
+    rows = _gh_hard(
+        [
+            "api",
+            f"repos/{slug}/releases",
+            "--paginate",
+            "--jq",
+            ".[] | {tag: .tag_name, body: .body, at: (.published_at // .created_at)}",
+        ]
+    ).strip()
+    if not rows:
+        return []
+    try:
+        return [json.loads(line) for line in rows.splitlines() if line.strip()]
+    except json.JSONDecodeError as exc:
+        fail(f"the release list for {slug} did not parse: {exc}")
+
+
+def match_tag(version: str, published: list[str], slug: str) -> str | None:
+    """The tag this project actually used for `version`, or None.
+
+    **Matched, never constructed.** Projects disagree about the `v` prefix and
+    change their minds mid-life: `ruff` releases `0.16.4` while its older tags
+    carry `v`, and `rumdl` releases `v0.2.58`. A guessed tag returns "not found",
+    which reads exactly like "this version has no notes".
+
+    Equality, not prefix: `0.2.6` must not match `v0.2.61`.
+
+    The release list answers first because it is already fetched. A version with
+    no release still usually has a tag -- `python/mypy` tags `v2.3.1` and
+    publishes nothing -- so the fallback probes both spellings against the git
+    ref. Probing both is still matching: neither spelling is assumed, and the
+    one that answers is reported.
+    """
+    for candidate in (version, f"v{version}"):
+        if candidate in published:
+            return candidate
+    for candidate in (version, f"v{version}"):
+        if _gh(["api", f"repos/{slug}/git/ref/tags/{candidate}"]) is not None:
+            return candidate
+    return None
+
+
+def gap(published: list[dict[str, str]], from_tag: str, to_tag: str) -> list[dict[str, str]]:
+    """The releases from `from_tag` (exclusive) to `to_tag` (inclusive).
+
+    Sliced out of the API's own newest-first ordering rather than by parsing
+    versions, so no PEP 440 comparison has to be right for this to be. When
+    `from_tag` has no release the slice cannot be taken and only `to_tag`'s notes
+    are gathered -- which costs prose, never the range: `compare` is a call about
+    two refs and does not consult this list at all. The fallible half of the
+    ladder is the half the finding does not rest on.
+    """
+    tags = [row["tag"] for row in published]
+    if to_tag not in tags:
+        return []
+    top = tags.index(to_tag)
+    if from_tag not in tags:
+        return [published[top]]
+    bottom = tags.index(from_tag)
+    if bottom <= top:
+        # Newest-first, so `from` at or above `to` means the versions are not in
+        # the order the caller believes -- a downgrade, or a backported patch
+        # line. Saying so beats returning an empty gap that reads as "nothing
+        # was released in between".
+        return []
+    return published[top:bottom]
+
+
+def changelog_at(slug: str, tag: str) -> tuple[str, str] | None:
+    """(filename, text) for the repo's changelog at `tag`, or None if it keeps none.
+
+    Two calls and no guessing: list the root at that ref, match a name, fetch it
+    raw. A constructed `CHANGELOG.md` 404s on a project that spells it
+    `CHANGES.rst`, and the 404 is indistinguishable from having no changelog.
+    """
+    listing = _gh(
+        ["api", f"repos/{slug}/contents?ref={tag}", "--jq", '.[] | select(.type=="file") | .name']
+    )
+    if listing is None:
+        return None
+    names = [line.strip() for line in listing.splitlines() if CHANGELOG_NAME.match(line.strip())]
+    if not names:
+        return None
+    name = sorted(names)[0]
+    text = _gh(
+        [
+            "api",
+            f"repos/{slug}/contents/{name}?ref={tag}",
+            "-H",
+            "Accept: application/vnd.github.raw",
+        ]
+    )
+    return (name, text) if text else None
+
+
+def section_for(text: str, version: str) -> str:
+    """The changelog section for exactly `version`, or "".
+
+    **The link target is removed before the heading is read.** A generated
+    changelog heads each section with a compare link carrying the *previous*
+    version -- `## [0.2.61](.../compare/v0.2.60...v0.2.61) - 2026-08-26` -- so a
+    substring test over the raw line matches 0.2.60 and hands back the wrong
+    section while looking like it worked. Measured: the first version of this
+    kept the link and found **no** section in a file that has one for every
+    release.
+
+    Then any token, not the first, because projects head their sections
+    differently: `## [0.2.62](...) - 2026-08-27` and `## Mypy 2.3` both have to
+    answer, and only one of them leads with the number.
+    """
+    lines = text.splitlines()
+    wanted = {version, f"v{version}"}
+    for index, line in enumerate(lines):
+        head = HEADING.match(line)
+        if not head:
+            continue
+        level, title = len(head.group(1)), head.group(2)
+        label = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", title)
+        tokens = {token.strip("[](){}<>,:;.") for token in label.split()}
+        if not (tokens & wanted):
+            continue
+        body = [line]
+        for following in lines[index + 1 :]:
+            nxt = HEADING.match(following)
+            if nxt and len(nxt.group(1)) <= level:
+                break
+            body.append(following)
+        return "\n".join(body).rstrip()
+    return ""
+
+
+def commits(slug: str, from_tag: str, to_tag: str) -> list[str]:
+    """Every commit message in `from_tag...to_tag`. The rung that cannot omit one.
+
+    Whole messages, not subjects: the body is where a fix says what it corrupted,
+    and rumdl's Rust-source fix names `# [derive(Debug)]` only there.
+    """
+    rows = _gh_hard(
+        [
+            "api",
+            f"repos/{slug}/compare/{from_tag}...{to_tag}",
+            "--jq",
+            ".commits[].commit.message | @json",
+            "--paginate",
+        ]
+    ).strip()
+    if not rows:
+        return []
+    # `@json` is load-bearing. A commit message is multi-line, so the plain
+    # filter runs eighteen messages together with no record boundary -- and the
+    # subject of one lands inside the body of the last. `@json` escapes the
+    # newlines, so one line is one message however long its body.
+    try:
+        return [json.loads(line) for line in rows.splitlines() if line.strip()]
+    except json.JSONDecodeError as exc:
+        fail(f"the commit range for {slug} did not parse: {exc}")
+
+
+def normalise(entry: str) -> str:
+    """An entry reduced to the words a reader would compare.
+
+    Markdown emphasis, backticks, link syntax, the leading bullet and the
+    trailing commit link all differ between a changelog entry and the commit it
+    was generated from, and none of them is content.
+    """
+    text = entry.strip()
+    text = re.sub(r"\(\[[0-9a-f]{6,}\]\([^)]*\)\)", " ", text)  # trailing ([abc123](url))
+    text = re.sub(r"\[([^\]]*)\]\([^)]*\)", r"\1", text)  # [label](url) -> label
+    text = re.sub(r"[*_`~]+", " ", text)
+    text = re.sub(r"^[-*+\s]+", "", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text.lower())
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def described(message: str) -> tuple[str, str] | None:
+    """(type, description) for a conventional-commit subject, or None.
+
+    The scope is dropped from the description because the changelog carries it
+    separately -- `fix(cli): resolve X` becomes `- **cli**: resolve X` -- so
+    keeping it on one side and not the other would make every entry a mismatch.
+    """
+    subject = message.strip().splitlines()[0] if message.strip() else ""
+    found = CONVENTIONAL.match(subject.strip())
+    if not found:
+        return None
+    return found.group("type").lower(), found.group("rest").strip()
+
+
+def labelled(messages: list[str]) -> bool:
+    """Does this project label its commits, so that filtering to fixes is safe?
+
+    **The filter is only honest when the project did the labelling.** Dropping
+    every non-`fix(...)` commit from the report is justified where the project
+    itself said which were fixes; where it did not, the same filter reports
+    "0 fix commits" for a range full of them -- which is this plugin's own
+    failure class, an absence of evidence read as evidence of absence, rebuilt
+    inside the tool written to remove it.
+
+    Measured on `python/mypy` v2.3.0...v2.3.1, the range the reference already
+    cites: six commits, **none** conventional, four of them fixes --
+    `Fix crash when unpacking return value from overload (#21830)` and three
+    `[mypyc]` ones. The first version of this file called that range clean.
+
+    A simple majority, because a project either adopted the convention or did
+    not; the mixed case is rare and falls to the safe side, which is reporting
+    more.
+    """
+    if not messages:
+        return False
+    parsed = sum(1 for message in messages if described(message))
+    return parsed * 2 > len(messages)
+
+
+def subject_of(message: str) -> str:
+    return message.strip().splitlines()[0].strip() if message.strip() else ""
+
+
+# `Bump version to 2.3.1`, `chore: bump version to v0.2.62`, `Release 1.4.0`.
+# The one exclusion applied in **both** modes, because a release chore is never
+# a finding and every project has two of them per version. Narrow on purpose,
+# and counted in the output so the accounting stays complete.
+RELEASE_CHORE = re.compile(
+    r"^(?:chore(?:\([^)]*\))?:\s*)?(?:bump|prepare|release|version)\b.*?\bv?\d+\.\d+",
+    re.IGNORECASE,
+)
+
+
+def candidates(messages: list[str]) -> tuple[list[str], str, int]:
+    """(subjects worth reconciling, which classifier ran, release chores dropped).
+
+    Two modes, and **the output says which one ran** -- the same discipline the
+    ladder applies to its rungs, one level down. A count of fixes means something
+    different depending on who did the classifying, so a reader must not have to
+    guess.
+
+    - `conventional`: the project labels its commits, so filter to `FIX_TYPES`.
+      A `docs:` commit absent from a changelog is correct behaviour.
+    - `unlabelled`: it does not, so **nothing is filtered**. Every commit the
+      prose fails to name is listed. That is noisier and it is the honest answer:
+      the script cannot tell a fix from a refactor here, and saying so beats
+      guessing quietly.
+    """
+    subjects = [subject_of(m) for m in messages if subject_of(m)]
+    kept = [s for s in subjects if not RELEASE_CHORE.match(s)]
+    chores = len(subjects) - len(kept)
+    if not labelled(messages):
+        return kept, "unlabelled", chores
+    fixes = []
+    for subject in kept:
+        parsed = described(subject)
+        if parsed and parsed[0] in FIX_TYPES:
+            fixes.append(subject)
+    return fixes, "conventional", chores
+
+
+def description_of(subject: str) -> str:
+    """The part of a subject worth comparing against a changelog entry.
+
+    Conventional subjects give up their type and scope; an unlabelled one is
+    compared whole, minus a trailing `(#1234)` PR reference, which is in every
+    GitHub squash subject and in no changelog entry.
+    """
+    parsed = described(subject)
+    text = parsed[1] if parsed else subject
+    return re.sub(r"\s*\(#\d+\)\s*$", "", text).strip()
+
+
+def reconciled(description: str, prose_lines: list[str]) -> bool:
+    """Does the prose say this? Substring first, then `difflib` for a reword.
+
+    Errs toward `False` -- see the module docstring. The threshold is compared
+    against the single best-matching prose line rather than the whole document,
+    so a long changelog cannot dilute a real match into a miss or accumulate
+    stray words into a false one.
+    """
+    want = normalise(description)
+    if not want:
+        return False
+    for line in prose_lines:
+        if want in line:
+            return True
+    best = difflib.get_close_matches(want, prose_lines, n=1, cutoff=MATCH_RATIO)
+    return bool(best)
+
+
+def rank(subject: str) -> int:
+    """Sort key: destructive shape first, fix-worded next, everything else last.
+
+    So the cap below can only ever cut the tail. The two rows Phase 2 came for
+    sat at positions 8 and 13 of 266 in ruff 0.16.2...0.16.5, in the order the
+    API returned them.
+    """
+    if DESTRUCTIVE.search(subject):
+        return 0
+    return 1 if FIX_WORDED.search(subject) else 2
+
+
+def write_evidence(
+    scratch: Path,
+    slug: str,
+    from_tag: str,
+    to_tag: str,
+    blocks: list[str],
+    missing: list[str],
+) -> Path:
+    """Save both halves of the comparison, so reading them is not a second fetch.
+
+    Phase 2 reads the prose for `Security` sections, which no count in this
+    script's output can stand in for. Release bodies carry download tables and
+    install instructions; those are left in, because trimming what looks like
+    boilerplate is how a `Security` heading below one gets trimmed with it.
+
+    The unreconciled list goes in the same file and **is never capped here**.
+    The terminal shows the ranked head; this is the whole of it, so the cap
+    shortens the reading and not the evidence.
+    """
+    out = scratch / f"changelog-{slug.replace('/', '-')}-{from_tag}-{to_tag}.md"
+    header = [
+        f"# Phase 2 evidence for {slug} {from_tag}...{to_tag}",
+        "",
+        "Written by `changelog.py`. Read the prose for `Security` sections: a",
+        "privately disclosed fix ships with no CVE and every scanner reports clean.",
+        "",
+    ]
+    tail: list[str] = []
+    if missing:
+        tail = [
+            "",
+            f"## unreconciled -- in the range, in none of the prose above ({len(missing)})",
+            "",
+            *(f"- {subject}" for subject in missing),
+        ]
+    out.write_text("\n".join(header + blocks + tail), encoding="utf-8")
+    return out
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Phase 2's changelog ladder, reconciled.")
+    parser.add_argument("--scratch", required=True, help="$SCRATCH from the Phase 0 handoff")
+    parser.add_argument("--from", dest="old", required=True, help="the version the lockfile has")
+    parser.add_argument("--to", dest="new", required=True, help="the version the bump proposes")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--package", help="PyPI name; the repo comes from its metadata")
+    source.add_argument("--repo-slug", dest="slug", help="owner/repo, when it is already known")
+    parser.add_argument(
+        "--write-mode",
+        action="store_true",
+        help="this repo runs the tool with --fix/--write/-i, so a destructive fix is data loss",
+    )
+    args = parser.parse_args()
+
+    scratch = Path(args.scratch)
+    if not scratch.is_dir():
+        fail(f"{scratch} does not exist -- re-derive $SCRATCH, or Phase 0 never ran")
+
+    slug = args.slug or resolve_repo(args.package)
+    published = releases(slug)
+    tags = [row["tag"] for row in published]
+
+    to_tag = match_tag(args.new, tags, slug)
+    from_tag = match_tag(args.old, tags, slug)
+    if to_tag is None:
+        fail(f"{slug} has no release and no tag for {args.new} -- rung 3 has nothing to compare to")
+    if from_tag is None:
+        fail(
+            f"{slug} has no release and no tag for {args.old} -- rung 3 has nothing to compare from"
+        )
+
+    print(f"repo:  {slug}" + ("" if args.slug else f"  (from {args.package}'s PyPI metadata)"))
+    print(f"range: {from_tag}...{to_tag}")
+    print()
+
+    # --- rungs 1 and 2: what the project chose to say ------------------------
+    window = gap(published, from_tag, to_tag)
+    blocks: list[str] = []
+    for row in window:
+        blocks.append(f"## rung 1 -- release notes, {row['tag']} ({row['at']})\n\n{row['body']}")
+    print(f"rung 1 -- release notes: {len(window)} release(s) in the gap")
+    if not window:
+        print("         (none -- this project publishes no releases for these versions)")
+
+    found = changelog_at(slug, to_tag)
+    sections = 0
+    if found:
+        name, text = found
+        for row in window or [{"tag": to_tag}]:
+            body = section_for(text, row["tag"].removeprefix("v"))
+            if body:
+                sections += 1
+                blocks.append(f"## rung 2 -- {name}, {row['tag']}\n\n{body}")
+        print(f"rung 2 -- {name}: {sections} section(s) for the versions in the gap")
+    else:
+        print("rung 2 -- no changelog file at this tag")
+
+    prose_lines = [
+        normalise(line) for block in blocks for line in block.splitlines() if normalise(line)
+    ]
+
+    # --- rung 3: what actually landed ----------------------------------------
+    messages = commits(slug, from_tag, to_tag)
+    subjects, mode, chores = candidates(messages)
+    what = "of fix type" if mode == "conventional" else "after release chores"
+    print(f"rung 3 -- commit range: {len(messages)} commit(s), {len(subjects)} {what}")
+    if mode == "conventional":
+        print(
+            f"         classifier: conventional commits, so only {'/'.join(FIX_TYPES[:3])} are read"
+        )
+    else:
+        print("         classifier: this project does not label its commits, so")
+        print("         nothing is filtered -- every unnamed commit is listed below")
+    if chores:
+        print(f"         ({chores} release chore(s) excluded)")
+    print()
+
+    # --- the reconciliation --------------------------------------------------
+    missing = sorted(
+        (s for s in subjects if not reconciled(description_of(s), prose_lines)), key=rank
+    )
+    saved = write_evidence(scratch, slug, from_tag, to_tag, blocks, missing)
+    print(f"evidence saved to {saved}")
+    print("Read it for `Security` sections -- no count here substitutes for that.")
+    print()
+
+    noun = "fix commit(s)" if mode == "conventional" else "commit(s)"
+    if not missing:
+        print(
+            f"RECONCILED: the prose names all {len(subjects)} {noun} in the range."
+            if subjects
+            else f"RECONCILED: the range carries no {noun} to reconcile."
+        )
+        return 0
+
+    print(f"UNRECONCILED: {len(missing)} of {len(subjects)} {noun} are in the range")
+    print("and in none of the prose above.")
+    print()
+    destructive = [s for s in missing if DESTRUCTIVE.search(s)]
+    for subject in missing[:SHOWN]:
+        mark = "   <- destructive-fix shape" if DESTRUCTIVE.search(subject) else ""
+        print(f"  {subject}{mark}")
+    if len(missing) > SHOWN:
+        print(
+            f"  ... and {len(missing) - SHOWN} more, all of them in the file above."
+            "\n  Ranked, so nothing marked was cut."
+        )
+    print()
+    if mode == "unlabelled" and len(missing) > SHOWN:
+        # Gated on having actually elided rows, not on the ratio. Measured on
+        # ruff 0.16.2...0.16.5 (266 of 307), where the repository ships `ty`
+        # under the same tags and those subjects are most of the range -- saying
+        # so stops a true count being read as an accusation. An earlier version
+        # gated on the ratio alone and fired on mypy's 4 of 4, where the project
+        # ships one product and the changelog really has no section. When the
+        # whole list is on screen the reader can see that for themselves.
+        print(
+            f"Most of this range is unnamed ({len(missing)} of {len(subjects)}), which is\n"
+            "usual for a repository shipping more than one product under one tag.\n"
+            "The ranked head above is the part to read first; this is not a claim\n"
+            "that the project omitted that many fixes."
+        )
+        print()
+    if destructive:
+        mode_note = (
+            "this repo runs the tool in write mode, so"
+            if args.write_mode
+            else "if this repo runs the tool in write mode (--fix/--write/-i) then"
+        )
+        print(
+            f"{len(destructive)} carr{'ies' if len(destructive) == 1 else 'y'} the shape "
+            "Phase 2 sends you to find. Read the full\nmessage in the range: "
+            f"{mode_note}\nthese are data-loss bugs in a mode that runs automatically, "
+            "and they reach\nPhase 7's verdict rather than its footnotes."
+        )
+    else:
+        print(
+            "None carries the destructive-fix shape, but the prose still does not name\n"
+            "them. Report the gap and what the commits say -- that is the row."
+        )
+    return 1
+
+
+def cli() -> NoReturn:
+    """Entry point. Anything unforeseen becomes exit 2, never exit 1.
+
+    Exit 1 here means the prose came up short -- a finding for the report. An
+    unhandled exception exits 1 too, so without this a crash would be read as a
+    project having quietly dropped its fixes. Set `DEPENDABOT_AUDIT_DEBUG` to
+    re-raise.
+    """
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:
+        if os.environ.get("DEPENDABOT_AUDIT_DEBUG"):
+            raise
+        fail(
+            f"unexpected {type(exc).__name__}: {exc}\n"
+            "       This is a bug, not a finding. Set DEPENDABOT_AUDIT_DEBUG=1 "
+            "for the traceback."
+        )
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -47,13 +47,16 @@ from changelog import (
     candidates,
     cli,
     described,
+    github_slug,
     labelled,
     main,
     match_tag,
     normalise,
     rank,
     reconciled,
+    resolve_repo,
     section_for,
+    valid_slug,
 )
 
 # --- recorded: rvben/rumdl, the bump behind #94 ------------------------------
@@ -654,6 +657,139 @@ class TestItRefusesRatherThanGuessing(ChangelogHarness):
             cli()
         self.assertEqual(caught.exception.code, 2)
         self.assertIn("This is a bug, not a finding", err.getvalue())
+
+
+class TestThePackageCannotChooseWhichRepositoryAnswersForIt(unittest.TestCase):
+    """`project_urls` is written by the package author.
+
+    That is the party this whole plugin exists to not trust, and until 0.36.0
+    both the prose (since 0.33.0) and this script's first cut resolved the
+    repository with `if "github.com/" in url` — an unanchored substring test.
+
+    A package that wants a clean Phase 2 row can supply
+    `https://evil.invalid/github.com/attacker/lookalike` and have the audit read
+    *that* repository's release notes: tidy, additive, no unreconciled fixes.
+    The reconciliation is a verdict input Phase 7 reads, so this is worse after
+    #94 than it was before — the feature made the target worth attacking.
+
+    Reported by CodeQL as `py/incomplete-url-substring-sanitization`, high
+    severity, on the PR that mechanised the ladder. The prose copy was found only
+    because the script copy was flagged.
+    """
+
+    def test_a_lookalike_host_is_not_github(self):
+        for url in (
+            "https://evil.example.invalid/github.com/attacker/lookalike",
+            "https://example.invalid/?q=github.com/attacker/repo",
+            "https://github.com.attacker.invalid/github.com/a/b",
+            "https://notgithub.com/a/b",
+        ):
+            self.assertIsNone(github_slug(url), f"{url} resolved to a repository")
+
+    def test_a_path_cannot_walk_out_of_the_repos_endpoint(self):
+        """The slug is interpolated into `gh api repos/<slug>/...`."""
+        for url in (
+            "https://github.com/../../users/octocat",
+            "https://github.com/./../org/repo",
+        ):
+            slug = github_slug(url)
+            if slug is not None:
+                self.assertNotIn("..", slug, f"{url} produced a traversing slug")
+
+    def test_a_non_http_scheme_is_rejected(self):
+        """Not redundant with the host check, though it looks it.
+
+        `javascript:alert(1)//github.com/a/b` parses with no hostname, so the
+        host check alone would already reject it. **`//github.com/attacker/repo`
+        does not** — a protocol-relative URL parses with hostname `github.com`
+        and resolves without this check, which is why the mutation that deleted
+        it first went green. Pinned by the second case here.
+        """
+        for url in ("javascript:alert(1)//github.com/a/b", "file:///github.com/a/b", ""):
+            self.assertIsNone(github_slug(url))
+        self.assertIsNone(
+            github_slug("//github.com/attacker/repo"),
+            "a protocol-relative URL parses with hostname github.com and must "
+            "still be rejected: the scheme is what says this is a real link",
+        )
+
+    def test_the_real_forms_still_resolve(self):
+        """Erring toward rejection would be its own defect: an unresolved repo
+        sends Phase 2 back to having no method at all."""
+        for url, want in (
+            ("https://github.com/rvben/rumdl", "rvben/rumdl"),
+            ("https://github.com/rvben/rumdl.git", "rvben/rumdl"),
+            ("https://www.github.com/astral-sh/ruff/issues", "astral-sh/ruff"),
+            ("http://github.com/python/mypy", "python/mypy"),
+            ("https://github.com/psf/requests/", "psf/requests"),
+        ):
+            self.assertEqual(github_slug(url), want, url)
+
+    def test_the_metadata_is_read_through_the_same_check(self):
+        """The guard belongs on the resolution, not beside it — the flaw was in
+        `resolve_repo`'s loop, so a helper nothing calls fixes nothing."""
+        payload = {
+            "info": {
+                "project_urls": {
+                    "Homepage": "https://evil.example.invalid/github.com/attacker/lookalike",
+                    "Source": "https://github.com/rvben/rumdl",
+                }
+            }
+        }
+        with mock.patch("changelog.urllib.request.urlopen") as opened:
+            opened.return_value.__enter__.return_value = io.StringIO(json.dumps(payload))
+            self.assertEqual(resolve_repo("rumdl"), "rvben/rumdl")
+
+    def test_a_package_naming_only_a_lookalike_fails_rather_than_guessing(self):
+        payload = {"info": {"project_urls": {"Homepage": "https://evil.invalid/github.com/a/b"}}}
+        with (
+            mock.patch("changelog.urllib.request.urlopen") as opened,
+            contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as caught,
+        ):
+            opened.return_value.__enter__.return_value = io.StringIO(json.dumps(payload))
+            resolve_repo("malicious")
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("names no GitHub repository", err.getvalue())
+
+    def test_the_auditors_own_slug_is_validated_too(self):
+        """`--repo-slug` reaches the same API path. Checked even though the
+        auditor types it: a typo that silently answers about something else is
+        the failure this phase is about."""
+        for good in ("rvben/rumdl", "astral-sh/ruff", "a/b"):
+            self.assertTrue(valid_slug(good), good)
+        for bad in ("../..", "a/b/c", "rvben", "", "a/../b", "./x"):
+            self.assertFalse(valid_slug(bad), bad)
+
+    def test_the_slug_check_is_wired_into_the_run(self):
+        """A validator nothing calls validates nothing.
+
+        Mutation-checked: deleting the call in `main()` left the unit test above
+        green, because it exercises the function and not the path. This drives
+        the whole entry point.
+        """
+        with tempfile.TemporaryDirectory() as scratch:
+            argv = [
+                "changelog.py",
+                "--scratch",
+                scratch,
+                "--repo-slug",
+                "../..",
+                "--from",
+                "1.0.0",
+                "--to",
+                "2.0.0",
+            ]
+            with (
+                mock.patch("changelog._gh", lambda args: None),
+                mock.patch.object(sys, "argv", argv),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()) as err,
+                self.assertRaises(SystemExit) as caught,
+            ):
+                main()
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("is not an owner/repo pair", err.getvalue())
 
 
 class TestAFailedCallIsNotAnEmptyAnswer(unittest.TestCase):

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -32,7 +32,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from typing import Any
+from typing import Any, ClassVar
 from unittest import mock
 
 sys.path.insert(
@@ -47,6 +47,7 @@ from changelog import (
     candidates,
     cli,
     described,
+    gap,
     github_slug,
     labelled,
     main,
@@ -792,6 +793,115 @@ class TestThePackageCannotChooseWhichRepositoryAnswersForIt(unittest.TestCase):
         self.assertIn("is not an owner/repo pair", err.getvalue())
 
 
+class TestAnEmptyWindowSaysWhyItIsEmpty(unittest.TestCase):
+    """Three causes, three answers -- the first version gave one.
+
+    `gap()` returned a bare `[]` whether the target had no release, the versions
+    were out of order, or the project published nothing, and `main` printed
+    *"this project publishes no releases for these versions"* for all three. Two
+    of those are false, and one of them is false about a project that visibly
+    does publish releases.
+
+    That is this plugin's own failure class -- an absence of evidence reported as
+    evidence of absence -- inside the tool written to remove it, which is the
+    second time in one sprint. The comment in `gap()` even claimed it said so.
+    Found by reading the function against its own docstring, and the branch had
+    no test at all.
+    """
+
+    ROWS: ClassVar[list[dict[str, str]]] = [
+        {"tag": "v3.0.0", "body": "", "at": "2026-03-01T00:00:00Z"},
+        {"tag": "v2.0.0", "body": "", "at": "2026-02-01T00:00:00Z"},
+        {"tag": "v1.0.0", "body": "", "at": "2026-01-01T00:00:00Z"},
+    ]
+
+    def test_the_ordinary_window_carries_no_note(self):
+        window, why = gap(self.ROWS, "v1.0.0", "v3.0.0")
+        self.assertEqual([r["tag"] for r in window], ["v3.0.0", "v2.0.0"])
+        self.assertEqual(why, "", "a window that sliced cleanly needs no explanation")
+
+    def test_a_target_with_no_release_says_so(self):
+        window, why = gap(self.ROWS, "v1.0.0", "v9.9.9")
+        self.assertEqual(window, [])
+        self.assertIn("no published release for v9.9.9", why)
+
+    def test_a_start_with_no_release_gathers_the_target_and_says_so(self):
+        """`python/mypy` reaches this every time it tags without releasing."""
+        window, why = gap(self.ROWS, "v0.1.0", "v3.0.0")
+        self.assertEqual([r["tag"] for r in window], ["v3.0.0"])
+        self.assertIn("no published release for v0.1.0", why)
+
+    def test_versions_out_of_order_are_not_reported_as_no_releases(self):
+        """The false one. A downgrade or a backported patch line got told the
+        project publishes nothing."""
+        window, why = gap(self.ROWS, "v3.0.0", "v1.0.0")
+        self.assertEqual(window, [])
+        self.assertIn("downgrade or a backported line", why)
+        self.assertNotIn("publishes no releases", why)
+
+    def test_the_reason_reaches_the_terminal(self):
+        """A note `main` does not print explains nothing."""
+        repo = Repo(
+            "example/backport",
+            releases=[("v3.0.0", "### Added\n\n- three\n"), ("v1.0.0", "### Added\n\n- one\n")],
+            files={},
+            commits=["fix: something the notes never mention"],
+        )
+        out = io.StringIO()
+        with tempfile.TemporaryDirectory() as scratch:
+            argv = [
+                "changelog.py",
+                "--scratch",
+                scratch,
+                "--repo-slug",
+                repo.slug,
+                "--from",
+                "3.0.0",
+                "--to",
+                "1.0.0",
+            ]
+            with (
+                mock.patch("changelog._gh", fake_gh(repo)),
+                mock.patch.object(sys, "argv", argv),
+                contextlib.redirect_stdout(out),
+            ):
+                main()
+        printed = out.getvalue()
+        self.assertIn("downgrade or a backported line", printed)
+        self.assertNotIn("publishes no releases", printed)
+
+    def test_the_range_is_still_read_when_the_window_cannot_be_sliced(self):
+        """The prose half is the fallible half; `compare` asks about two refs and
+        does not consult the release list at all."""
+        repo = Repo(
+            "example/backport",
+            releases=[("v3.0.0", "### Added\n\n- three\n"), ("v1.0.0", "### Added\n\n- one\n")],
+            files={},
+            commits=["fix: something the notes never mention"],
+        )
+        out = io.StringIO()
+        with tempfile.TemporaryDirectory() as scratch:
+            argv = [
+                "changelog.py",
+                "--scratch",
+                scratch,
+                "--repo-slug",
+                repo.slug,
+                "--from",
+                "3.0.0",
+                "--to",
+                "1.0.0",
+            ]
+            with (
+                mock.patch("changelog._gh", fake_gh(repo)),
+                mock.patch.object(sys, "argv", argv),
+                contextlib.redirect_stdout(out),
+            ):
+                status = main()
+        self.assertEqual(status, 1, "the fix in the range is still a finding")
+        self.assertIn("something the notes never mention", out.getvalue())
+
+
 class TestAFailedCallIsNotAnEmptyAnswer(unittest.TestCase):
     """The seam's own contract, tested one layer below the seam.
 
@@ -849,6 +959,42 @@ class TestTheEvidenceOutlivesTheTerminal(ChangelogHarness):
         self.assertIn("evidence saved to", out)
         self.assertIn("update h2 to 0.4.16", evidence)
         self.assertIn("Security", evidence)
+
+    def test_a_marked_row_carries_its_full_commit_message(self):
+        """`commits()` fetches whole messages because *"the body is where a fix
+        says what it corrupted"* — and the first version dropped every body and
+        told the terminal reader to go fetch the range again. rumdl's Rust-source
+        fix names `# [derive(Debug)]` only in the body.
+        """
+        repo = self.rumdl_61_62()
+        repo.commits = [
+            *RUMDL_61_62[:8],
+            "fix(cli): stop rewriting Rust source when formatting doc comments\n\n"
+            "`rumdl fmt lib.rs` wrote `# [derive(Debug)]` to disk and the file\n"
+            "stopped being Rust.",
+            *RUMDL_61_62[9:],
+        ]
+        _, out, evidence = self.run_main(repo, "--from", "0.2.60", "--to", "0.2.62")
+        self.assertIn("## destructive-fix shape -- full commit message", evidence)
+        self.assertIn("wrote `# [derive(Debug)]` to disk", evidence)
+        self.assertNotIn(
+            "wrote `# [derive(Debug)]` to disk",
+            out,
+            "the body belongs in the file; the terminal shows the ranked subjects",
+        )
+
+    def test_an_unmarked_row_does_not_carry_a_body(self):
+        """Only the rows Phase 7 takes the verdict from. A body for all 266 of
+        ruff's would be the wall this file exists to replace."""
+        repo = self.rumdl_61_62()
+        repo.commits = [
+            "fix(MD057): respect closed-world self-reference policy\n\nA long body.",
+            "chore: bump version to v0.2.62",
+        ]
+        _, _, evidence = self.run_main(repo, "--from", "0.2.60", "--to", "0.2.62")
+        self.assertIn("respect closed-world self-reference policy", evidence)
+        self.assertNotIn("A long body.", evidence)
+        self.assertNotIn("destructive-fix shape -- full commit message", evidence)
 
     def test_a_clean_run_still_writes_the_file(self):
         status, _, evidence = self.run_main(

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -4,10 +4,11 @@ No network: `_gh` is the single seam every GitHub call goes through, so the fake
 below drive the real tag matching, section extraction, classification and
 reconciliation, and only the subprocess is replaced.
 
-**Every fixture here is recorded from the live API, not written to fit the rule.**
-That is the trap this file exists downstream of: a reconciliation rule tested
-against changelogs invented from the rule can only agree with itself. The
-subjects, release bodies and changelog sections below are verbatim from
+**Every fixture the reconciliation is judged on is recorded from the live API,
+not written to fit the rule.** That is the trap this file exists downstream of: a
+reconciliation rule tested against changelogs invented from the rule can only
+agree with itself. The subjects, release bodies and changelog sections below are
+verbatim from
 
     gh api repos/rvben/rumdl/compare/v0.2.60...v0.2.62 --jq '.commits[].commit.message'
     gh api repos/rvben/rumdl/releases/tags/v0.2.61 --jq .body
@@ -18,6 +19,13 @@ recorded 2026-09-01. The live half of the same claims is in
 `integration/test_live_changelog_sources.py`, which goes red when the world moves
 -- these stay green, because they are about this script's reading of what the
 world said that day.
+
+**Four fixtures are synthetic, and say so in their names**: `example/wall`,
+`example/backport`, the `astral-sh/ruff` stub, and `ROWS`. They test structure
+rather than judgement -- the cap, the ranking, the tag prefix, an empty window --
+where real data would be arbitrary and the property under test is not about the
+world at all. Keeping the two kinds apart is the point: an invented changelog may
+never decide whether the reconciliation is right.
 
     python3 -m unittest discover -s tests -v
 """
@@ -149,16 +157,23 @@ RUMDL_59_60 = [
     "fix(deps): update h2 to 0.4.16",
     "chore: bump version to v0.2.60",
 ]
+# Full 40-character hashes, as the API actually emits them. A first version
+# abbreviated the URLs, which `normalise` happens to strip either way -- so the
+# test passed while the fixture had stopped being what the world sends, and a
+# future change to that regex would have been checked against a shortened form
+# nobody publishes.
 RUMDL_NOTES_59 = (
     "\n### Fixed\n\n"
-    "- **MD033**: ignore escaped HTML tag openers ([eaa4075](https://github.com/rvben/rumdl/commit/eaa4075))\n"
-    "- **config**: match absolute patterns through symlinks ([5dd6158](https://github.com/rvben/rumdl/commit/5dd6158))\n"
+    "- **MD033**: ignore escaped HTML tag openers "
+    "([eaa4075](https://github.com/rvben/rumdl/commit/eaa4075d665f8174256ddbeb21ecb8d64f34525a))\n"
+    "- **config**: match absolute patterns through symlinks "
+    "([5dd6158](https://github.com/rvben/rumdl/commit/5dd615823eb3128009dd0534829f18e96a73a2c6))\n"
     "- **MD013**: stop reflow from joining a setext heading into its underline "
-    "([9ec9e17](https://github.com/rvben/rumdl/commit/9ec9e17))\n"
+    "([9ec9e17](https://github.com/rvben/rumdl/commit/9ec9e17458f45c6e621de3352a678870c71441e3))\n"
 )
 RUMDL_NOTES_60 = (
     "\n### Fixed\n\n- **deps**: update h2 to 0.4.16 "
-    "([a650302](https://github.com/rvben/rumdl/commit/a650302))\n"
+    "([a650302](https://github.com/rvben/rumdl/commit/a6503022a5b0268138fbec2068d8e9a7abd27e64))\n"
 )
 
 # --- recorded: python/mypy, the range the reference already cites ------------

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,726 @@
+"""Regression tests for changelog.py.
+
+No network: `_gh` is the single seam every GitHub call goes through, so the fakes
+below drive the real tag matching, section extraction, classification and
+reconciliation, and only the subprocess is replaced.
+
+**Every fixture here is recorded from the live API, not written to fit the rule.**
+That is the trap this file exists downstream of: a reconciliation rule tested
+against changelogs invented from the rule can only agree with itself. The
+subjects, release bodies and changelog sections below are verbatim from
+
+    gh api repos/rvben/rumdl/compare/v0.2.60...v0.2.62 --jq '.commits[].commit.message'
+    gh api repos/rvben/rumdl/releases/tags/v0.2.61 --jq .body
+    gh api repos/rvben/rumdl/contents/CHANGELOG.md?ref=v0.2.62 -H 'Accept: application/vnd.github.raw'
+    gh api repos/python/mypy/compare/v2.3.0...v2.3.1 --jq '.commits[].commit.message'
+
+recorded 2026-09-01. The live half of the same claims is in
+`integration/test_live_changelog_sources.py`, which goes red when the world moves
+-- these stay green, because they are about this script's reading of what the
+world said that day.
+
+    python3 -m unittest discover -s tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+from typing import Any
+from unittest import mock
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
+)
+
+from changelog import (
+    DESTRUCTIVE,
+    SHOWN,
+    _gh,
+    _gh_hard,
+    candidates,
+    cli,
+    described,
+    labelled,
+    main,
+    match_tag,
+    normalise,
+    rank,
+    reconciled,
+    section_for,
+)
+
+# --- recorded: rvben/rumdl, the bump behind #94 ------------------------------
+
+RUMDL_61_62 = [
+    "feat(cli): add multi-document stdin batches",
+    "docs(cli): document stdin batch protocol",
+    "fix(MD057): respect closed-world self-reference policy",
+    "test(cli): add stdin batch performance smoke test",
+    "docs(changelog): record stdin batch support",
+    "fix(cli): resolve canonical stdin batch target paths",
+    "test(lint-context): use native canonical path fixtures",
+    "fix(cli): report document-level fixes as fixed",
+    "fix(cli): stop rewriting Rust source when formatting doc comments",
+    "fix(lint-context): stop reading a lazy continuation as a setext underline",
+    "chore: bump version to v0.2.61",
+    "feat(flavor): add support for Markdown with Gherkin (MDG)",
+    "docs(mdg): correct the tag-line rationale and the flavor selection note",
+    "ci(windows): name cargo-binstall in the scoped mise installs",
+    "ci: pin the mise version at every mise-action call site",
+    "ci: track the mise version each workflow passes to mise-action",
+    "ci(deps): move upd to v0.8.2 and align the last mise pin",
+    "chore: bump version to v0.2.62",
+]
+
+# The whole of what rung 1 says for each. Additive, both of them.
+RUMDL_NOTES_61 = (
+    "\n### Added\n\n- **cli**: add `--stdin-batch` for NUL-framed multi-document "
+    "linting and `--stdin-batch-closed-world` for supplied-document-only link "
+    "resolution\n\n\n## Downloads\n\n| File | Platform | Checksum |\n"
+)
+RUMDL_NOTES_62 = (
+    "\n### Added\n\n- **flavor**: add support for Markdown with Gherkin (MDG) "
+    "([db62377](https://github.com/rvben/rumdl/commit/db62377aa7e63865f682bf16d790c6ff5eb40b31))"
+    "\n\n\n## Downloads\n\n| File | Platform | Checksum |\n"
+)
+
+# Rung 2, verbatim -- including the compare link whose target carries the
+# *previous* version, which is what broke the first `section_for`.
+RUMDL_CHANGELOG = """\
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+## [0.2.62](https://github.com/rvben/rumdl/compare/v0.2.61...v0.2.62) - 2026-08-27
+
+### Added
+
+- **flavor**: add support for Markdown with Gherkin (MDG) ([db62377](https://github.com/rvben/rumdl/commit/db62377aa7e63865f682bf16d790c6ff5eb40b31))
+
+## [0.2.61](https://github.com/rvben/rumdl/compare/v0.2.60...v0.2.61) - 2026-08-26
+
+### Added
+
+- **cli**: add `--stdin-batch` for NUL-framed multi-document linting and `--stdin-batch-closed-world` for supplied-document-only link resolution
+
+## [0.2.60](https://github.com/rvben/rumdl/compare/v0.2.59...v0.2.60) - 2026-08-22
+
+### Fixed
+
+- **deps**: update h2 to 0.4.16 ([a650302](https://github.com/rvben/rumdl/commit/a6503022a5b0268138fbec2068d8e9a7abd27e64))
+
+## [0.2.59](https://github.com/rvben/rumdl/compare/v0.2.58...v0.2.59) - 2026-08-22
+
+### Fixed
+
+- **MD033**: ignore escaped HTML tag openers ([eaa4075](https://github.com/rvben/rumdl/commit/eaa4075d665f8174256ddbeb21ecb8d64f34525a))
+- **config**: match absolute patterns through symlinks ([5dd6158](https://github.com/rvben/rumdl/commit/5dd615823eb3128009dd0534829f18e96a73a2c6))
+- **MD013**: stop reflow from joining a setext heading into its underline ([9ec9e17](https://github.com/rvben/rumdl/commit/9ec9e17458f45c6e621de3352a678870c71441e3))
+
+## [0.2.58](https://github.com/rvben/rumdl/compare/v0.2.57...v0.2.58) - 2026-08-19
+
+### Added
+
+- **wasm**: load extends chains from embedder-supplied config files ([e7c7d8f](https://github.com/rvben/rumdl/commit/e7c7d8f9fa64f1a74195f52cae9d328a8fae9389))
+"""
+
+# The positive control, and the strongest one available: 0.2.59's release notes
+# name all three of its fixes, and one of them carries the destructive shape.
+RUMDL_59_60 = [
+    "fix(MD013): stop reflow from joining a setext heading into its underline",
+    "docs: point the schema instructions at src/config/",
+    "docs(scope): reject general regex ignore surfaces",
+    "fix(config): match absolute patterns through symlinks",
+    "fix(MD033): ignore escaped HTML tag openers",
+    "chore: bump version to v0.2.59",
+    "fix(deps): update h2 to 0.4.16",
+    "chore: bump version to v0.2.60",
+]
+RUMDL_NOTES_59 = (
+    "\n### Fixed\n\n"
+    "- **MD033**: ignore escaped HTML tag openers ([eaa4075](https://github.com/rvben/rumdl/commit/eaa4075))\n"
+    "- **config**: match absolute patterns through symlinks ([5dd6158](https://github.com/rvben/rumdl/commit/5dd6158))\n"
+    "- **MD013**: stop reflow from joining a setext heading into its underline "
+    "([9ec9e17](https://github.com/rvben/rumdl/commit/9ec9e17))\n"
+)
+RUMDL_NOTES_60 = (
+    "\n### Fixed\n\n- **deps**: update h2 to 0.4.16 "
+    "([a650302](https://github.com/rvben/rumdl/commit/a650302))\n"
+)
+
+# --- recorded: python/mypy, the range the reference already cites ------------
+#
+# Zero releases, a CHANGELOG.md with no 2.3.1 section, and six commits of which
+# four are fixes -- none of them conventionally labelled. The first version of
+# changelog.py reported this range as carrying no fixes at all.
+
+MYPY_30_31 = [
+    "Bump version to 2.3.1+dev",
+    "Fix crash when unpacking return value from overload (#21830)",
+    "[mypyc] Clear coroutine env on coroutine completion (#21734)",
+    "[mypyc] Fix `default_factory` for inherited dataclass (#21785)",
+    "[mypyc] Fix crash on double yielding Iterators (#21826)",
+    "Bump version to 2.3.1",
+]
+
+MYPY_CHANGELOG = """\
+# Mypy Release Notes
+
+## Next Release
+
+## Mypy 2.3
+
+Some notes about the 2.3 feature release.
+
+## Mypy 2.2
+
+Older notes.
+"""
+
+
+class Repo:
+    """One repository as the five calls in `changelog.py` see it."""
+
+    def __init__(
+        self,
+        slug: str,
+        releases: list[tuple[str, str]] | None = None,
+        tags: list[str] | None = None,
+        files: dict[str, str] | None = None,
+        commits: list[str] | None = None,
+    ) -> None:
+        self.slug = slug
+        self.releases = releases or []
+        self.tags = tags or [tag for tag, _ in (releases or [])]
+        self.files = files or {}
+        self.commits = commits or []
+
+
+def fake_gh(repo: Repo, log: list[str] | None = None) -> Any:
+    """A `_gh` that answers from `repo`, and `None` for anything absent.
+
+    `None` rather than `""` throughout, because that distinction is the thing
+    under test in half these cases: a call that failed must never be readable as
+    an answer that was empty.
+    """
+
+    def fake(args: list[str]) -> str | None:
+        joined = " ".join(args)
+        if log is not None:
+            log.append(joined)
+        if f"repos/{repo.slug}/releases" in joined:
+            return "\n".join(
+                json.dumps({"tag": tag, "body": body, "at": "2026-08-26T00:00:00Z"})
+                for tag, body in repo.releases
+            )
+        if "/git/ref/tags/" in joined:
+            return "{}" if joined.rsplit("/", 1)[-1] in repo.tags else None
+        if "/compare/" in joined:
+            return "\n".join(json.dumps(m) for m in repo.commits)
+        if "/contents?" in joined:
+            return "\n".join(repo.files)
+        if "/contents/" in joined:
+            name = joined.split("/contents/")[1].split("?")[0]
+            return repo.files.get(name)
+        return None
+
+    return fake
+
+
+class ChangelogHarness(unittest.TestCase):
+    def run_main(self, repo: Repo, *argv: str) -> tuple[int, str, str]:
+        """(exit status, stdout, the evidence file's text).
+
+        The file is read before the temporary directory goes, because the
+        directory is the thing under test as much as the text is: exactly one
+        evidence file per run, whatever the verdict.
+        """
+        with tempfile.TemporaryDirectory() as scratch:
+            full = ["changelog.py", "--scratch", scratch, "--repo-slug", repo.slug, *argv]
+            out = io.StringIO()
+            with (
+                mock.patch("changelog._gh", fake_gh(repo)),
+                mock.patch.object(sys, "argv", full),
+                contextlib.redirect_stdout(out),
+            ):
+                status = main()
+            # Copy the directory listing out before the context manager takes it.
+            written = list(pathlib.Path(scratch).iterdir())
+            self.assertEqual(len(written), 1, "exactly one evidence file per run")
+            return status, out.getvalue(), written[0].read_text(encoding="utf-8")
+
+    def rumdl_61_62(self) -> Repo:
+        return Repo(
+            "rvben/rumdl",
+            releases=[
+                ("v0.2.62", RUMDL_NOTES_62),
+                ("v0.2.61", RUMDL_NOTES_61),
+                ("v0.2.60", RUMDL_NOTES_60),
+                ("v0.2.59", RUMDL_NOTES_59),
+                ("v0.2.58", "\n### Added\n\n- **wasm**: load extends chains\n"),
+            ],
+            files={"CHANGELOG.md": RUMDL_CHANGELOG, "Cargo.toml": ""},
+            commits=RUMDL_61_62,
+        )
+
+    def rumdl_58_60(self) -> Repo:
+        repo = self.rumdl_61_62()
+        repo.commits = RUMDL_59_60
+        return repo
+
+    def mypy(self) -> Repo:
+        return Repo(
+            "python/mypy",
+            releases=[],
+            tags=["v2.3.1", "v2.3.0"],
+            files={"CHANGELOG.md": MYPY_CHANGELOG},
+            commits=MYPY_30_31,
+        )
+
+
+class TestTheRungThatAnsweredIsNotTheWholeAnswer(ChangelogHarness):
+    """#94, reduced to one assertion.
+
+    Both prose rungs return real, well-formed, correctly-authored content for
+    exactly the right versions, and five fixes never enter the audit. Nothing
+    fails; no exit status anywhere can reach it.
+    """
+
+    def test_the_range_carries_fixes_the_prose_does_not_name(self):
+        status, out, _ = self.run_main(self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62")
+        self.assertEqual(status, 1, "a range whose prose omits five fixes is a finding")
+        self.assertIn("UNRECONCILED: 5 of 5", out)
+
+    def test_both_prose_rungs_did_answer(self):
+        """The point of the case: this is not a lookup failure wearing a finding's
+        clothes. Rung 1 and rung 2 both produced content for both versions."""
+        _, out, _ = self.run_main(self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62")
+        self.assertIn("rung 1 -- release notes: 2 release(s)", out)
+        self.assertIn("rung 2 -- CHANGELOG.md: 2 section(s)", out)
+
+    def test_the_two_destructive_fixes_are_marked(self):
+        _, out, _ = self.run_main(self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62")
+        for subject in (
+            "stop rewriting Rust source when formatting doc comments",
+            "stop reading a lazy continuation as a setext underline",
+        ):
+            line = next(ln for ln in out.splitlines() if subject in ln)
+            self.assertIn("destructive-fix shape", line, f"{subject!r} was not marked")
+
+    def test_write_mode_changes_the_wording_and_not_the_search(self):
+        """The judgement escalates a finding; it never gates the call that finds it."""
+        plain = self.run_main(self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62")
+        armed = self.run_main(
+            self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62", "--write-mode"
+        )
+        self.assertEqual(plain[0], armed[0], "the flag must not change what was found")
+        self.assertIn("UNRECONCILED: 5 of 5", plain[1])
+        self.assertIn("if this repo runs the tool in write mode", plain[1])
+        self.assertIn("this repo runs the tool in write mode, so", armed[1])
+
+
+class TestTheReconciliationCanAlsoSayYes(ChangelogHarness):
+    """The anti-vacuity half. A matcher that never matches would pass every test
+    above, and would be the same defect one layer down.
+
+    rumdl v0.2.58...v0.2.60 is the strongest control available: 0.2.59's notes
+    name all three of its fixes, **including the destructive-shaped one**, so a
+    marker cannot smuggle a row past a matcher that is working.
+    """
+
+    def test_a_range_whose_prose_names_its_fixes_is_clean(self):
+        status, out, _ = self.run_main(self.rumdl_58_60(), "--from", "0.2.58", "--to", "0.2.60")
+        self.assertEqual(status, 0, out)
+        self.assertIn("RECONCILED: the prose names all 4 fix commit(s)", out)
+
+    def test_a_destructive_shape_that_is_documented_is_not_a_finding(self):
+        prose = [normalise(line) for line in RUMDL_NOTES_59.splitlines() if normalise(line)]
+        subject = "fix(MD013): stop reflow from joining a setext heading into its underline"
+        self.assertTrue(DESTRUCTIVE.search(subject), "the fixture must carry the shape")
+        parsed = described(subject)
+        assert parsed is not None
+        self.assertTrue(
+            reconciled(parsed[1], prose),
+            "a fix the changelog names is reconciled however alarming its wording",
+        )
+
+    def test_a_reworded_entry_still_reconciles(self):
+        """Generated changelogs re-punctuate and re-link. `difflib` covers that
+        much and no more -- see the next test for where it stops."""
+        prose = [normalise("- **cli**: resolve the canonical stdin batch target paths")]
+        self.assertTrue(reconciled("resolve canonical stdin batch target paths", prose))
+
+    def test_a_different_fix_does_not_reconcile_against_a_similar_one(self):
+        """The threshold has to fail somewhere, or it is not a threshold."""
+        prose = [normalise("- **cli**: resolve canonical stdin batch target paths")]
+        self.assertFalse(
+            reconciled("stop rewriting Rust source when formatting doc comments", prose)
+        )
+
+
+class TestAProjectThatDoesNotLabelItsCommits(ChangelogHarness):
+    """The defect this file's own first version shipped.
+
+    Filtering on `fix(` is only honest where the project did the labelling.
+    `python/mypy` v2.3.0...v2.3.1 carries four fixes and no conventional commits,
+    and the first version of `changelog.py` reported it as carrying none -- an
+    absence of evidence read as evidence of absence, rebuilt inside the tool
+    written to remove it.
+    """
+
+    def test_mypys_four_fixes_are_not_reported_as_zero(self):
+        status, out, _ = self.run_main(self.mypy(), "--from", "2.3.0", "--to", "2.3.1")
+        self.assertEqual(status, 1, out)
+        self.assertIn("UNRECONCILED: 4 of 4", out)
+        self.assertIn("Fix crash when unpacking return value from overload", out)
+
+    def test_the_output_says_which_classifier_ran(self):
+        """The ladder's own discipline one level down: a count of fixes means
+        something different depending on who classified them."""
+        _, unlabelled, _ = self.run_main(self.mypy(), "--from", "2.3.0", "--to", "2.3.1")
+        _, conventional, _ = self.run_main(self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62")
+        self.assertIn("does not label its commits", unlabelled)
+        self.assertIn("classifier: conventional commits", conventional)
+
+    def test_the_two_fixtures_really_do_differ(self):
+        self.assertTrue(labelled(RUMDL_61_62))
+        self.assertFalse(labelled(MYPY_30_31))
+
+    def test_release_chores_are_excluded_and_counted(self):
+        """`Bump version to 2.3.1` is never a finding, and every project has two
+        per release -- so the exclusion is named in the output rather than silent."""
+        _, out, _ = self.run_main(self.mypy(), "--from", "2.3.0", "--to", "2.3.1")
+        self.assertIn("(2 release chore(s) excluded)", out)
+        self.assertNotIn("Bump version to 2.3.1", out.split("UNRECONCILED")[1])
+
+    def test_nothing_is_filtered_when_the_project_did_not_label(self):
+        """`[mypyc] Clear coroutine env on coroutine completion` reads like neither
+        a fix nor a chore. It is a fix, and it is in the report because the
+        unlabelled mode filters nothing."""
+        kept, mode, _ = candidates(MYPY_30_31)
+        self.assertEqual(mode, "unlabelled")
+        self.assertIn("[mypyc] Clear coroutine env on coroutine completion (#21734)", kept)
+
+
+class TestTheTagIsMatchedRatherThanConstructed(ChangelogHarness):
+    """Projects disagree about the `v` prefix and change their minds mid-life.
+
+    A guessed tag returns "not found", which reads exactly like "this version has
+    no notes" -- the reference already records `ruff` releasing `0.16.4` while its
+    older tags carry `v`, and `rumdl` releasing `v0.2.58`.
+    """
+
+    def test_a_prefixed_project_is_matched(self):
+        _, out, _ = self.run_main(self.rumdl_61_62(), "--from", "0.2.60", "--to", "0.2.62")
+        self.assertIn("range: v0.2.60...v0.2.62", out)
+
+    def test_an_unprefixed_project_is_matched(self):
+        repo = Repo(
+            "astral-sh/ruff",
+            releases=[("0.16.4", "### Bug fixes\n"), ("0.16.3", "### Bug fixes\n")],
+            files={},
+            commits=["Fix something (#1)"],
+        )
+        _, out, _ = self.run_main(repo, "--from", "0.16.3", "--to", "0.16.4")
+        self.assertIn("range: 0.16.3...0.16.4", out)
+
+    def test_a_shared_prefix_is_not_a_match(self):
+        """`0.2.6` must not find `v0.2.61`. The equality is the guard, and the
+        reference's existing tag recipe makes the same point about `grep -Fx`."""
+        repo = self.rumdl_61_62()
+        log: list[str] = []
+        with (
+            mock.patch("changelog._gh", fake_gh(repo, log)),
+            tempfile.TemporaryDirectory() as scratch,
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            argv = [
+                "changelog.py",
+                "--scratch",
+                scratch,
+                "--repo-slug",
+                repo.slug,
+                "--from",
+                "0.2.6",
+                "--to",
+                "0.2.62",
+            ]
+            with mock.patch.object(sys, "argv", argv), self.assertRaises(SystemExit) as caught:
+                main()
+        self.assertEqual(caught.exception.code, 2, "an unmatched version must not be guessed at")
+        self.assertTrue(
+            any("git/ref/tags/0.2.6" in call for call in log),
+            "the fallback should have probed the git ref before giving up",
+        )
+
+    def test_a_version_with_no_release_falls_back_to_the_tag(self):
+        """mypy publishes nothing and tags `v2.3.1`. Probing both spellings is
+        still matching: neither is assumed, and the one that answers is used."""
+        _, out, _ = self.run_main(self.mypy(), "--from", "2.3.0", "--to", "2.3.1")
+        self.assertIn("range: v2.3.0...v2.3.1", out)
+
+
+class TestTheChangelogSectionSurvivesItsOwnHeading(ChangelogHarness):
+    """A generated changelog heads each section with a compare link carrying the
+    **previous** version. The first `section_for` read the raw heading and found
+    no section at all in a file that has one per release -- caught by replaying
+    the script against the live repo, not by reading it."""
+
+    def test_a_linked_heading_matches_its_own_version(self):
+        found = section_for(RUMDL_CHANGELOG, "0.2.61")
+        self.assertIn("[0.2.61]", found.splitlines()[0])
+        self.assertIn("stdin-batch", found)
+
+    def test_the_link_target_does_not_win(self):
+        """`## [0.2.61](...compare/v0.2.60...v0.2.61)` contains `v0.2.60`. Asking
+        for 0.2.60 must return 0.2.60's section, which is the one with `h2` in it."""
+        found = section_for(RUMDL_CHANGELOG, "0.2.60")
+        self.assertIn("[0.2.60]", found.splitlines()[0])
+        self.assertIn("update h2 to 0.4.16", found)
+
+    def test_a_heading_that_does_not_lead_with_the_version_still_matches(self):
+        """`## Mypy 2.3`. Any token, not the first."""
+        self.assertIn("2.3 feature release", section_for(MYPY_CHANGELOG, "2.3"))
+
+    def test_a_version_with_no_section_returns_nothing(self):
+        """mypy writes per *minor* release, so 2.3.1 has none. That is rung 2
+        running out, and it must be empty rather than approximately 2.3."""
+        self.assertEqual(section_for(MYPY_CHANGELOG, "2.3.1"), "")
+
+    def test_the_section_stops_at_the_next_heading_of_its_level(self):
+        """Asserted on content, not on the version string: 0.2.62's own heading
+        links to `compare/v0.2.61...v0.2.62`, so `0.2.61` is legitimately inside
+        its first line. That is the same conflation `section_for` guards against,
+        and a test written the lazy way inherits it."""
+        found = section_for(RUMDL_CHANGELOG, "0.2.62")
+        self.assertIn("Gherkin", found)
+        self.assertNotIn("stdin-batch", found, "0.2.61's entry leaked into 0.2.62's section")
+        self.assertEqual(len([ln for ln in found.splitlines() if ln.startswith("## ")]), 1)
+
+
+class TestTheMarkerRanksAndTheCapCutsTheTail(ChangelogHarness):
+    """266 rows is the same failure as silence -- the reader's eye slides off it.
+
+    Answered by ranking and a cap, never by filtering: the evidence file holds
+    every row, and the rows Phase 2 came for cannot be the ones cut.
+    """
+
+    def test_ordinary_english_does_not_carry_the_destructive_shape(self):
+        """Measured on ruff 0.16.2...0.16.5, where a broader first version fired
+        on both of these. A marker on a fifth of the rows marks nothing."""
+        for subject in (
+            "[ty] Avoid composite Salsa keys for unspecialized MROs (#27592)",
+            "[ty] Avoid deadlock when scheduling watch checks (#27605)",
+        ):
+            self.assertIsNone(DESTRUCTIVE.search(subject), subject)
+
+    def test_the_shape_the_prose_names_still_matches(self):
+        for subject in (
+            "fix(cli): stop rewriting Rust source when formatting doc comments",
+            "MD002 no longer removes the heading",
+        ):
+            self.assertIsNotNone(DESTRUCTIVE.search(subject), subject)
+
+    def test_destructive_outranks_fix_worded_outranks_the_rest(self):
+        self.assertEqual(rank("fix(cli): stop rewriting Rust source"), 0)
+        self.assertEqual(rank("[mypyc] Fix crash on double yielding"), 1)
+        self.assertEqual(rank("[ty] Add an opt-in unsound-return-statement lint"), 2)
+
+    def test_nothing_marked_is_ever_cut(self):
+        """A long unlabelled range with the marked row last in API order."""
+        wall = [f"Add feature number {n} (#{n})" for n in range(SHOWN + 20)]
+        wall.append("Stop deleting the trailing newline (#999)")
+        repo = Repo(
+            "example/wall",
+            releases=[("v2.0.0", "### Added\n\n- nothing relevant\n"), ("v1.0.0", "")],
+            files={},
+            commits=wall,
+        )
+        status, out, evidence = self.run_main(repo, "--from", "1.0.0", "--to", "2.0.0")
+        self.assertEqual(status, 1)
+        shown = out.split("UNRECONCILED")[1]
+        self.assertIn("Stop deleting the trailing newline", shown)
+        self.assertIn("destructive-fix shape", shown.splitlines()[3])
+        self.assertIn("and 21 more", shown)
+        self.assertIn("Add feature number 0 (#0)", evidence)
+
+    def test_the_evidence_file_is_never_capped(self):
+        wall = [f"Add feature number {n} (#{n})" for n in range(SHOWN + 20)]
+        repo = Repo(
+            "example/wall",
+            releases=[("v2.0.0", "### Added\n\n- nothing relevant\n"), ("v1.0.0", "")],
+            files={},
+            commits=wall,
+        )
+        _, _, evidence = self.run_main(repo, "--from", "1.0.0", "--to", "2.0.0")
+        listed = [ln for ln in evidence.splitlines() if ln.startswith("- Add feature")]
+        self.assertEqual(len(listed), SHOWN + 20)
+
+    def test_the_multi_product_note_only_appears_once_rows_were_cut(self):
+        """It fired on mypy's 4-of-4 when it keyed on the ratio, where the project
+        ships one product and the changelog really has no section."""
+        _, small, _ = self.run_main(self.mypy(), "--from", "2.3.0", "--to", "2.3.1")
+        self.assertNotIn("more than one product", small)
+
+
+class TestItRefusesRatherThanGuessing(ChangelogHarness):
+    def _expect_exit(self, code: int, repo: Repo, *argv: str) -> str:
+        err = io.StringIO()
+        with tempfile.TemporaryDirectory() as scratch:
+            full = ["changelog.py", "--scratch", scratch, "--repo-slug", repo.slug, *argv]
+            with (
+                mock.patch("changelog._gh", fake_gh(repo)),
+                mock.patch.object(sys, "argv", full),
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(err),
+                self.assertRaises(SystemExit) as caught,
+            ):
+                main()
+        self.assertEqual(caught.exception.code, code, err.getvalue())
+        return err.getvalue()
+
+    def test_a_missing_scratch_directory_is_exit_2(self):
+        repo = self.rumdl_61_62()
+        argv = [
+            "changelog.py",
+            "--scratch",
+            "/nonexistent/scratch",
+            "--repo-slug",
+            repo.slug,
+            "--from",
+            "0.2.60",
+            "--to",
+            "0.2.62",
+        ]
+        with (
+            mock.patch("changelog._gh", fake_gh(repo)),
+            mock.patch.object(sys, "argv", argv),
+            contextlib.redirect_stderr(io.StringIO()),
+            self.assertRaises(SystemExit) as caught,
+        ):
+            main()
+        self.assertEqual(caught.exception.code, 2)
+
+    def test_a_failed_release_list_is_exit_2_not_an_empty_ladder(self):
+        """The distinction the whole phase turns on. A call that failed must not
+        become "this project publishes no releases"."""
+        repo = self.rumdl_61_62()
+        with (
+            mock.patch("changelog._gh", lambda args: None),
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "changelog.py",
+                    "--scratch",
+                    ".",
+                    "--repo-slug",
+                    repo.slug,
+                    "--from",
+                    "0.2.60",
+                    "--to",
+                    "0.2.62",
+                ],
+            ),
+            contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as caught,
+        ):
+            main()
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("releases", err.getvalue())
+
+    def test_an_unknown_version_is_exit_2(self):
+        self._expect_exit(2, self.rumdl_61_62(), "--from", "0.2.60", "--to", "9.9.9")
+
+    def test_a_crash_is_exit_2_and_never_exit_1(self):
+        """Exit 1 means the prose came up short. An unhandled exception exits 1
+        too, so without `cli()` a crash would be read as a project having quietly
+        dropped its fixes."""
+        with (
+            mock.patch("changelog.main", side_effect=RuntimeError("boom")),
+            contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as caught,
+        ):
+            cli()
+        self.assertEqual(caught.exception.code, 2)
+        self.assertIn("This is a bug, not a finding", err.getvalue())
+
+
+class TestAFailedCallIsNotAnEmptyAnswer(unittest.TestCase):
+    """The seam's own contract, tested one layer below the seam.
+
+    Every other case here replaces `_gh` wholesale, so nothing in them reaches
+    the line that decides what a failure *is* -- a mutation turning its `None`
+    into `""` left all thirty-four green. That distinction is load-bearing in two
+    places: `match_tag` reads a non-`None` probe as "this tag exists" and would
+    hand back a constructed tag, and `_gh_hard` reads `None` as "could not run"
+    and would otherwise let a failed release list become "this project publishes
+    no releases" -- the ladder's own failure mode, inside the tool written to
+    remove it.
+
+    So this patches `subprocess.run` instead, and asserts the invariant the
+    callers rest on: `None` if and only if the call failed.
+    """
+
+    def _run(self, code: int, stdout: str) -> Any:
+        return mock.patch(
+            "changelog.subprocess.run",
+            return_value=subprocess.CompletedProcess([], code, stdout=stdout, stderr=""),
+        )
+
+    def test_a_non_zero_exit_is_a_failure_even_when_it_printed_a_body(self):
+        """`gh` writes an API error body to stdout and still exits non-zero, so
+        the exit code is the signal and the body is the explanation."""
+        with self._run(1, '{"message":"Not Found","status":"404"}'):
+            self.assertIsNone(_gh(["api", "repos/x/y/releases"]))
+
+    def test_a_zero_exit_with_no_output_is_a_real_and_empty_answer(self):
+        """`python/mypy` publishes no releases. That is content, not a failure."""
+        with self._run(0, ""):
+            self.assertEqual(_gh(["api", "repos/python/mypy/releases"]), "")
+
+    def test_the_hard_wrapper_stops_on_the_failure_and_passes_the_emptiness_through(self):
+        with self._run(1, ""), contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as caught:
+                _gh_hard(["api", "repos/x/y/releases"])
+            self.assertEqual(caught.exception.code, 2)
+        with self._run(0, ""):
+            self.assertEqual(_gh_hard(["api", "repos/python/mypy/releases"]), "")
+
+    def test_a_failed_probe_does_not_become_a_tag_that_exists(self):
+        """`match_tag`'s fallback probes both spellings. If a failure read as
+        success it would return the first thing it tried, which is exactly the
+        constructed tag the reference forbids."""
+        with self._run(1, '{"message":"Not Found"}'):
+            self.assertIsNone(match_tag("9.9.9", [], "rvben/rumdl"))
+
+
+class TestTheEvidenceOutlivesTheTerminal(ChangelogHarness):
+    def test_the_prose_rungs_are_saved_for_the_security_read(self):
+        """No count in the output substitutes for reading the notes: a privately
+        disclosed fix ships with no CVE and every scanner reports clean."""
+        _, out, evidence = self.run_main(self.rumdl_58_60(), "--from", "0.2.58", "--to", "0.2.60")
+        self.assertIn("evidence saved to", out)
+        self.assertIn("update h2 to 0.4.16", evidence)
+        self.assertIn("Security", evidence)
+
+    def test_a_clean_run_still_writes_the_file(self):
+        status, _, evidence = self.run_main(
+            self.rumdl_58_60(), "--from", "0.2.58", "--to", "0.2.60"
+        )
+        self.assertEqual(status, 0)
+        self.assertIn("rung 1 -- release notes", evidence)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_plugin_layout.py
+++ b/tests/test_plugin_layout.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 import unittest
+from typing import ClassVar
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / ".claude-plugin/plugin.json"
@@ -92,6 +94,75 @@ class TestNothingShadowsASkill(unittest.TestCase):
             plugin_name(),
             command_names(),
             f"commands/{plugin_name()}.md shadows the plugin's own skill address",
+        )
+
+
+class TestTheChangelogIndexIsComplete(unittest.TestCase):
+    """A `## [x.y.z]` heading with no link reference renders as literal text.
+
+    Markdown resolves `[0.34.0]` against a definition at the bottom of the file;
+    without one the brackets stay on the page and the compare link is gone. It is
+    silent in the only place it matters — the rendered view — and it had been
+    silent for two releases: 0.34.0 and 0.35.0 both shipped headings with no
+    definition, and `[Unreleased]` still compared from v0.33.0, so the "what has
+    landed since the last release" link spanned three of them.
+
+    Both directions, because a definition left behind after a heading is renamed
+    is the same defect pointing the other way.
+    """
+
+    text: ClassVar[str]
+
+    VERSION_HEADING = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.MULTILINE)
+    VERSION_DEF = re.compile(r"^\[(\d+\.\d+\.\d+)\]:", re.MULTILINE)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    def test_every_version_heading_has_a_link_reference(self):
+        headings = set(self.VERSION_HEADING.findall(self.text))
+        defined = set(self.VERSION_DEF.findall(self.text))
+        self.assertEqual(
+            sorted(headings - defined),
+            [],
+            "these versions have a heading and no link definition, so they render "
+            "as literal bracketed text with no compare link",
+        )
+
+    def test_no_link_reference_outlives_its_heading(self):
+        headings = set(self.VERSION_HEADING.findall(self.text))
+        defined = set(self.VERSION_DEF.findall(self.text))
+        self.assertEqual(sorted(defined - headings), [], "these link definitions name no section")
+
+    def test_unreleased_compares_from_the_newest_release(self):
+        """It is the link a reader follows to see what has landed since the last
+        release. Left stale it spans several, and says the opposite of that."""
+        newest = max(
+            self.VERSION_HEADING.findall(self.text), key=lambda v: [int(p) for p in v.split(".")]
+        )
+        # Compiled with re.M explicitly: `assertRegex` compiles a bare string
+        # without flags, so `^`/`$` would only ever match the whole document.
+        wanted = re.compile(
+            rf"^\[Unreleased\]: \S+/compare/v{re.escape(newest)}\.\.\.HEAD$", re.MULTILINE
+        )
+        self.assertRegex(
+            "\n".join(ln for ln in self.text.splitlines() if ln.startswith("[Unreleased]:")),
+            wanted,
+            f"[Unreleased] must compare from v{newest}, the newest release in this file",
+        )
+
+    def test_the_newest_heading_matches_the_shipped_version(self):
+        """The manifest is what the harness installs; the changelog is what the
+        reader is told was installed."""
+        newest = max(
+            self.VERSION_HEADING.findall(self.text), key=lambda v: [int(p) for p in v.split(".")]
+        )
+        manifest = json.loads((ROOT / ".claude-plugin/plugin.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            manifest["version"],
+            newest,
+            "plugin.json and CHANGELOG.md disagree about which version this is",
         )
 
 

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -3381,32 +3381,81 @@ class TestPhase2CanReachAChangelogAtAll(SkillHarness):
     """
 
     def _ladder(self) -> str:
-        for _, section in self._handoffs(2):
-            for block in bash_blocks(section):
-                if "project_urls" in block:
-                    return block
-        self.fail("Phase 2 documents no way to find the project's repository")
+        """What Phase 2 *runs* to find the repo and the tag, not what it says.
+
+        This used to return the bash block whose heredoc re-implemented the
+        resolution in six lines. 0.36.0 deleted that block: it was a second
+        implementation of what `changelog.py` already did, and it carried the
+        same `"github.com/" in url` substring test — so fixing the flaw in one
+        copy would have left it live in the other. Re-anchored to `reachable`,
+        which follows the script, rather than re-anchored to nothing.
+        """
+        code = self.reachable(2)
+        self.assertIn(
+            "changelog.py",
+            "\n".join(block for _, section in self._handoffs(2) for block in bash_blocks(section)),
+            "Phase 2 documents no way to find the project's repository",
+        )
+        return code
 
     def test_the_tag_is_matched_against_the_release_list_not_constructed(self):
         """Guessing the prefix returns "release not found", which reads exactly
         like "this version has no notes"."""
-        block = self._ladder()
-        self.assertIn("tag_name", block, "the tag comes from the release list")
+        code = self._ladder()
+        self.assertIn("tag_name", code, "the tag comes from the release list")
         self.assertRegex(
-            block,
-            r"grep -Fx.*-e \"\$VER\".*-e \"v\$VER\"",
+            code,
+            r"for candidate in \(version, f'v\{version\}'\)",
             "both spellings must be matched against what the project actually "
             "published, rather than one of them assumed",
         )
 
+    def test_the_repo_url_is_matched_on_its_host_not_by_substring(self):
+        """`project_urls` is written by the package author, who is exactly the
+        party this plugin exists to not trust.
+
+        `"github.com/" in url` resolved `https://evil.invalid/github.com/a/b` to
+        `a/b`, pointing the whole phase at a repository the package chooses —
+        tidy notes, no unreconciled fixes, a clean currency row. It shipped in
+        the prose from 0.33.0 and in this script's first cut, and CodeQL caught
+        it as `py/incomplete-url-substring-sanitization`.
+        """
+        code = self._ladder()
+        self.assertRegex(
+            code,
+            r"hostname not in \('github\.com', 'www\.github\.com'\)",
+            "the host must be compared, never searched for",
+        )
+        self.assertNotRegex(
+            code,
+            r"'github\.com/' in url",
+            "the substring test is the defect, not a second line of defence",
+        )
+
     def test_a_failed_lookup_is_not_read_as_an_absent_release(self):
         """The same distinction Phase 0 draws for every derived output, at the
-        point where the two look identical: an empty tag."""
-        block = self._ladder()
-        self.assertIn(
-            "a lookup failure, not an absent release",
-            block,
-            "a failed `gh api` must exit, not fall through to 'no release for this version'",
+        point where the two look identical: an empty answer.
+
+        The bash block used to carry this as a `|| { ...; exit 2; }` and a
+        sentence. The script carries it as a type: `_gh` returns `None` on
+        failure and `""` on a call that succeeded with no rows, and the release
+        list goes through the wrapper that exits on `None`. Same property, and
+        the guard follows it rather than following the sentence that described
+        it -- `python/mypy` really does publish zero releases, so `""` here has
+        to stay a real answer.
+        """
+        code = self._ladder()
+        # DOTALL on both: these span a function body, and `assertRegex` compiles
+        # a bare string with no flags.
+        self.assertRegex(
+            code,
+            re.compile(r"def releases\(slug: str\).*?_gh_hard\(", re.DOTALL),
+            "the release list must go through the wrapper that exits on failure",
+        )
+        self.assertRegex(
+            code,
+            re.compile(r"def _gh_hard\(.*?if out is None:\s+fail\(", re.DOTALL),
+            "and that wrapper has to actually exit, not return an empty string",
         )
 
     def _uv_lock_phase2(self) -> str:

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -44,6 +44,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from typing import ClassVar
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 PLUGIN = ROOT / "skills/dependabot-audit"
@@ -133,15 +134,42 @@ def tables(body: str) -> list[list[str]]:
     return found
 
 
-def _code_only(source: str) -> str:
+def _code_only(source: str, *, printed: bool = True) -> str:
     """A Python module's executable text, with comments and docstrings removed.
 
     An AST round-trip drops comments for free; docstrings have to be taken off
     each scope explicitly. Both matter for the same reason: a guard asserting
     that a phase *asks GitHub which checks are required* must not be satisfied by
     a docstring that merely says so.
+
+    `printed=False` additionally drops the string constants a script hands to
+    `print()`. **That is for negative assertions only, and it is not the default.**
+    What a script prints is output, not a call — `audit.py` advises the reader to
+    run ``uv run python -V`` inside the synced environment, and once `reachable()`
+    began following scripts named in the ecosystem references, that sentence made
+    the `--no-execute` guard fire on Phase 1: the guard that catches a phase
+    *executing* the audited project, defeated by a phase *mentioning* it. Same
+    failure the harness docstring names, one artifact over.
+
+    It stays opt-in because printed text is exactly what several positive guards
+    are about — Phase 6's hedge is asserted as `CONSISTENT WITH` in `reachable(6)`
+    precisely so the hedge reaches the reader of the output and not only the
+    reader of the prose. Stripping it by default silently retired that guard,
+    which is how this parameter came to exist rather than a blanket rule.
     """
     tree = ast.parse(source)
+    if not printed:
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "print"
+            ):
+                node.args = [
+                    arg
+                    for arg in node.args
+                    if not (isinstance(arg, ast.Constant) and isinstance(arg.value, str))
+                ]
     for node in ast.walk(tree):
         if not isinstance(node, ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
             continue
@@ -195,7 +223,7 @@ class SkillHarness(unittest.TestCase):
         # phase number -> the shell in it, concatenated
         cls.shell = {n: "\n".join(bash_blocks(body)) for n, body in cls.phases}
 
-    def reachable(self, number: int) -> str:
+    def reachable(self, number: int, *, printed: bool = True) -> str:
         """What Phase N actually *runs*: its shell, plus every script it invokes.
 
         A guard that scans only the phase's own bash silently retires itself the
@@ -220,13 +248,23 @@ class SkillHarness(unittest.TestCase):
         module docstring names `isRequired`, `totalCount` and `check-runs` while
         explaining them, so deleting all three from the actual query left every
         guard green. A rule must not be satisfiable by a comment claiming it.
+
+        **A script named in an ecosystem reference counts too.** Until 0.36.0
+        this followed scripts named in `SKILL.md`'s own body and nowhere else,
+        while `audit.py`, `gate_diff.py` and `changelog.py` are all invoked from
+        `references/uv-lock.md` — so their code was in no phase's `reachable()`
+        and a guard about any of them was reading the invocation line alone. That
+        is the retirement this docstring warns about, sitting in the function
+        that warns about it.
         """
         parts = [self.shell[number]]
+        named = dict(self.phases)[number]
         for name, section in self._handoffs(number):
             del name
             parts.extend(bash_blocks(section))
-        for path in _scripts_named_in(dict(self.phases)[number]):
-            parts.append(_code_only(path.read_text(encoding="utf-8")))
+            named += "\n" + section
+        for path in _scripts_named_in(named):
+            parts.append(_code_only(path.read_text(encoding="utf-8"), printed=printed))
         return "\n".join(parts)
 
     def _handoffs(self, number: int) -> list[tuple[str, str]]:
@@ -1176,7 +1214,16 @@ class TestTheRepoConfigIsReadAtARef(SkillHarness):
     # Files whose *content the audit interprets*: the gates it reproduces, and
     # the bot config that decides whether a currency gap is lag or a hold.
     INTERPRETED = ("workflows/", ".pre-commit-config", "dependabot.yml", "renovate.json")
-    AT_A_REF = re.compile(r'git show "(?:pr-<N>|\$\{?BASE_SHA\}?|\$\{?DEFAULT\}?):')
+    # The property is **being pinned**, not which plumbing does the pinning.
+    # `git show` reads a file at a ref, `git ls-tree` lists a directory at one —
+    # both in `<ref>:<path>` form — and `git diff <ref>...<ref> -- <path>` names
+    # two refs and reads neither working tree. 0.36.0 added one of each while
+    # deriving the workflow list, and a `show`-only pattern called both
+    # working-tree reads.
+    AT_A_REF = re.compile(
+        r'git (?:show|ls-tree[^"\n]*) "(?:pr-<N>|\$\{?BASE_SHA\}?|\$\{?DEFAULT\}?):'
+        r'|git diff[^"\n]*"\$\{?BASE_SHA\}?\.{2,3}pr-<N>"'
+    )
 
     def test_phase_0_reads_the_gate_list_at_a_ref(self):
         self.assertRegex(
@@ -3207,6 +3254,70 @@ class TestExposureIsEstablishedRatherThanAssumed(SkillHarness):
             "closed for a red check by attributing it",
         )
 
+    COUNTS: ClassVar[dict[str, int]] = {
+        "one": 1,
+        "two": 2,
+        "three": 3,
+        "four": 4,
+        "five": 5,
+        "six": 6,
+    }
+
+    def _scope_table(self) -> list[str]:
+        for table in tables(dict(self.phases)[2]):
+            if any("Why the config cannot answer it" in row for row in table):
+                return [row for row in table if row.startswith("| ") and "---" not in row]
+        self.fail("Phase 2 has no scope-test table")
+
+    def test_the_counted_sentence_matches_the_table_it_counts(self):
+        """CONTRIBUTING's own trap: *"The rule named two of the four until
+        0.29.0."* A counted list stops covering what it was written for the
+        moment a row is added, and the sentence keeps reading as complete.
+
+        0.36.0 added the third row — an entry naming a **file type** or a
+        **document shape** rather than a setting, where no config key exists to
+        grep and "no config line matches" reads as `inert here`. Found by a run
+        that improvised `git grep` over `*.md` and a count of `.rs` files.
+        """
+        rows = len(self._scope_table()) - 1  # the header is a row too
+        found = re.search(
+            r"\b(one|two|three|four|five|six) cases? fall outside", dict(self.phases)[2]
+        )
+        self.assertIsNotNone(found, "Phase 2 no longer counts the cases the grep cannot answer")
+        assert found is not None
+        self.assertEqual(
+            self.COUNTS[found.group(1)],
+            rows,
+            f"the sentence says {found.group(1)} cases and the table has {rows} rows",
+        )
+
+    def test_the_third_case_greps_the_tree_rather_than_the_config(self):
+        """The affected path is a file type and a document shape, so exposure is
+        how many files carry it — and zero is a finding like any other."""
+        phase2 = self.material(2)
+        self.assertRegex(
+            phase2,
+            r"git grep -lE .*\*\.md.*\n.*git ls-files",
+            "Phase 2 must give the content greps, not only say to grep content",
+        )
+        self.assertRegex(
+            phase2,
+            r"(?is)`1` is a real zero; `128` is `underivable`|exits `1` on\s*\n?no match and `128`",
+            "and it must separate no-match from could-not-run, or the third row "
+            "rebuilds the very confusion it was added to remove",
+        )
+
+    def test_the_third_case_does_not_pipe_the_count(self):
+        """`git grep … | wc -l` prints 0 at exit 0 whether it matched nothing or
+        could not run, which turns `underivable` into `inert here`. The class-wide
+        pipe guard already forbids it; this says the prose warns about it too,
+        because the reader is the one who will reach for `wc`."""
+        self.assertIn(
+            "do not pipe these into `wc`",
+            dict(self.phases)[2],
+            "the reader has to be told why the obvious shortening is wrong",
+        )
+
 
 class TestPhase0ClearsAStaleWorktreeRegistration(SkillHarness):
     """`$SCRATCH` lives under `$TMPDIR`, so it disappears between audits.
@@ -3311,17 +3422,240 @@ class TestPhase2CanReachAChangelogAtAll(SkillHarness):
                 return section
         self.fail("Phase 2 no longer hands off to uv-lock.md")
 
-    def test_all_three_rungs_are_named(self):
-        section = self._uv_lock_phase2()
-        for rung in ("gh release view", "CHANGELOG.md", "/compare/"):
-            self.assertIn(rung, section, f"the ladder is missing {rung}")
+    def _source_table(self) -> list[str]:
+        """The table that says what the three sources are, not the section.
 
-    def test_the_row_says_which_rung_answered(self):
-        """ "No changelog" is not a finding; "rung 3, six commits" is."""
+        Anchored here because the section discusses release notes in four places,
+        so a guard scanning the whole of it stayed green when the table's own row
+        was renamed — mutation-checked, and that is the only place a reader looks
+        to learn what the three are.
+        """
+        for table in tables(self._uv_lock_phase2()):
+            if any("runs out" in row for row in table):
+                return table
+        self.fail("uv-lock.md § Phase 2 has no source table")
+
+    def test_all_three_sources_are_named_in_the_table(self):
+        """The reader has to know what the three are, whoever fetches them."""
+        rows = "\n".join(self._source_table())
+        for source in ("release notes", "changelog", "commit range"):
+            self.assertIn(source, rows, f"the source table no longer names {source}")
+
+    def test_all_three_sources_are_actually_reached(self):
+        """And the mechanism has to exist, not merely be described.
+
+        Read from `reachable`, so mechanising the ladder into `changelog.py`
+        moved the assertion rather than retiring it — which is what happened in
+        0.36.0, and what this method's harness docstring says to expect.
+        """
+        code = self.reachable(2)
+        for call in ("/releases", "/contents", "/compare/"):
+            self.assertIn(call, code, f"nothing Phase 2 runs asks for {call}")
+
+    def test_the_report_says_which_sources_answered(self):
+        """ "No changelog" is not a finding; "the prose named one, the range
+        carried five" is."""
         self.assertRegex(
             self._uv_lock_phase2(),
-            r"[Ss]ay which rung produced the row|which rung answered",
-            "Phase 2 must report which rung produced the row, as Phase 5 reports which install ran",
+            r"[Rr]eport which sources? answered|which rung answered|[Ss]ay which rung",
+            "Phase 2 must report which sources answered, as Phase 5 reports which install ran",
+        )
+
+
+class TestARungThatAnsweredCanStillBeIncomplete(SkillHarness):
+    """#94. The ladder's stopping rule was *"did source N produce text?"*; the
+    phase's question is *"what behavior changed across this range?"*
+
+    Those diverge whenever a project generates release notes from a **subset** of
+    its commits. Measured on `rumdl` v0.2.60…v0.2.62: rung 1 answers for both
+    versions, rung 2 answers for both, and five `fix(…)` commits — two of them
+    `stop …` entries in a tool the audited repo runs as `--fix` on every Markdown
+    commit — never entered the audit. **Nothing failed**, which is why no exit
+    status anywhere could reach it, and why this is worse than #91's absence.
+
+    The guards below are on `uv-lock.md` § Phase 2 alone. `actions.md` § Phase 2
+    carries its own `compare` call for the tag-line question, and a guard reading
+    every reference at once is satisfied by that one while saying nothing about
+    this.
+    """
+
+    def _section(self) -> str:
+        for name, section in self._handoffs(2):
+            if name == "uv-lock.md":
+                return section
+        self.fail("Phase 2 no longer hands off to uv-lock.md")
+
+    def test_the_ladder_has_an_exit_that_is_incompleteness_and_not_absence(self):
+        """Every exit condition used to be an absence — the project publishes
+        none, the patch has no section, the tags are missing — so a source that
+        returned real content ended the ladder. The reconciliation is the one
+        with no exit condition, and the prose has to say so."""
+        self.assertRegex(
+            self._section(),
+            r"(?is)\|[^|\n]*\bagainst each other\b[^|\n]*\|[^|\n]*\|[^|\n]*\bnever\b",
+            "the source table needs a row for reconciling the three, whose "
+            "'where it runs out' is never — otherwise every exit is an absence "
+            "again and a source that answered ends the read",
+        )
+
+    def test_the_range_is_read_whatever_the_write_mode_judgement_says(self):
+        """`--write-mode` escalates a finding; it must not gate the call that
+        finds one. Gating the fetch asks the auditor to be right about write mode
+        before it has the evidence, and a wrong guess restores the silence."""
+        self.assertRegex(
+            self._section(),
+            r"(?is)changes nothing about what is looked for|"
+            r"the range is fetched either way|never whether it is \*?looked for",
+            "Phase 2 must say the compare range is read regardless of write mode",
+        )
+
+    def test_the_write_mode_flag_is_documented_where_it_is_passed(self):
+        self.assertIn("--write-mode", self.reachable(2))
+        self.assertRegex(
+            self._section(),
+            r"--fix.*--write.*-i|--fix`, `--write` or `-i`",
+            "the reader has to know which repo condition sets the flag",
+        )
+
+    def test_the_classifier_is_named_the_way_the_source_is(self):
+        """A count of fixes means something different depending on who did the
+        labelling, so the output says which ran. `python/mypy` v2.3.0…v2.3.1
+        carries four fixes and no conventional commits; a filter keyed on `fix(`
+        called it clean, which is this plugin's own failure class rebuilt inside
+        the tool written to remove it."""
+        self.assertRegex(
+            self._section(),
+            r"(?is)says which classifier ran|which classifier",
+            "the prose must say that the script reports which classifier it used",
+        )
+        self.assertIn(
+            "classifier",
+            self.reachable(2),
+            "and the script has to print it, or it lives only where the reader "
+            "of the output never sees it",
+        )
+
+    def test_the_worked_example_is_the_bump_it_was_found_in(self):
+        """Kept concrete and kept checkable: `integration/` holds the live half,
+        and goes red when rumdl changes how it generates notes."""
+        section = self._section()
+        self.assertIn("v0.2.60…v0.2.62", section)
+        self.assertRegex(
+            section,
+            r"18 commits.*five of them|five of them `fix",
+            "the example has to carry the counts, or it is an anecdote",
+        )
+
+    def test_the_evidence_file_is_pointed_at_for_the_security_read(self):
+        """No count substitutes for seeing a `Security` heading: a privately
+        disclosed fix ships with no CVE and every scanner reports clean."""
+        self.assertRegex(
+            self._section(),
+            r"(?is)`\$SCRATCH/changelog-.*`.*\n?.*Security",
+            "Phase 2 must name the file it wrote and say to read it for Security",
+        )
+
+
+class TestAPlaceholderForARepositoryPathIsDerived(SkillHarness):
+    """#101. `git show "pr-<N>:.github/workflows/<ci>.yml"` never said how to
+    learn `<ci>`, so every run invented a way to list the directory or guessed a
+    filename — and the guess is quiet in the direction that matters. A repo whose
+    workflow is `tests.yml` makes `ci.yml` exit non-zero and at least loud; a repo
+    with **several** workflows has no single right answer, and picking one
+    silently narrows the gate list that Phase 4 and Phase 5 both consume.
+
+    The same gap appeared three times under two spellings — Phase 0's `<ci>`,
+    Phase 6's `<changed>`, `actions.md` § Phase 5's `<changed>` — which is also
+    why 0.36.0 made them one token: a reader who solves it in Phase 0 could not
+    see that Phase 6 was asking the same question.
+
+    **Narrow on purpose.** #101 also proposed the general form, that no
+    placeholder anywhere is left underived. Measured across both references and
+    `SKILL.md`, 37 placeholders appear in a fence and never in their phase's
+    prose — `<owner>`, `<N>`, `<sha>` and the rest, all of them answered by
+    Phase 0's outputs table or by context. A guard with 37 exceptions is a guard
+    that gets weakened until it discriminates nothing, so this one is about the
+    class that actually bit: a placeholder standing for a **path in the
+    repository**, which cannot be answered from context because only the tree
+    knows.
+    """
+
+    # `<tok>` sitting inside a repository path: `.github/workflows/<workflow>`,
+    # `pr-<N>:<workflow>`, `--workflow <workflow>`. `<N>` is the audited PR and
+    # comes from the argument, so it is never the token in question.
+    PATH_TOKEN = re.compile(r"<(?!N>)([a-z][a-z0-9_-]*)>")
+    # Something in the same block that asks the tree what is there.
+    DERIVES = re.compile(r"git ls-tree --name-only|git diff --name-only|git ls-files")
+
+    def _blocks_naming_a_workflow(self) -> list[tuple[str, int, str]]:
+        """Every block that names a workflow, however it spells the path.
+
+        `<workflow>` is in the selector because Phase 6 reads
+        `git show "pr-<N>:<workflow>"` — the placeholder stands for the whole
+        path there, so a selector keyed on `workflows/` skipped the block
+        entirely and the derivation guard passed on a phase it never looked at.
+        Mutation-checked by deleting Phase 6's derivation, which went green.
+        """
+        found = [
+            (file, number, code)
+            for file, number, code in _every_block()
+            if "workflows/" in code or "--workflow " in code or "<workflow>" in code
+        ]
+        self.assertTrue(found, "no block reads a workflow any more")
+        return found
+
+    def test_every_block_that_names_a_workflow_derives_the_list_first(self):
+        for file, number, code in self._blocks_naming_a_workflow():
+            self.assertRegex(
+                code,
+                self.DERIVES,
+                f"{file} Phase {number} names a workflow file without asking the "
+                f"tree which workflows exist. A guessed name either fails loudly "
+                f"or — worse — succeeds and narrows the gate list to one",
+            )
+
+    def test_the_placeholder_is_one_token_across_every_phase_that_asks(self):
+        """Two spellings for one derivation is how the second one stops looking
+        like the first."""
+        tokens = set()
+        for _, _, code in self._blocks_naming_a_workflow():
+            tokens |= {t for t in self.PATH_TOKEN.findall(code) if "workflow" in t or t == "ci"}
+        self.assertEqual(
+            tokens,
+            {"workflow"},
+            "the workflow placeholder must be spelled the same everywhere it is "
+            "asked for, or the same question reads as three different ones",
+        )
+
+    def test_phase_0_derives_the_list_at_both_refs(self):
+        """A gate on only one side of the bump is itself a finding, and Phase 0
+        already says to diff the two lists — which needs two lists."""
+        block = next(
+            code
+            for _, number, code in self._blocks_naming_a_workflow()
+            if number == 0 and "ls-tree" in code
+        )
+        # Asserted on the `ls-tree` line, not on the ref appearing anywhere: the
+        # block also does `git show "$BASE_SHA:.github/workflows/<workflow>"`,
+        # which satisfied a looser assertion while the base *listing* was gone —
+        # so the guard passed on exactly the half-derived state it exists for.
+        for ref in ("pr-<N>", r"\$BASE_SHA"):
+            self.assertRegex(
+                block,
+                rf'git ls-tree --name-only "{ref}:\.github/workflows/"',
+                f"Phase 0 does not list the workflows at {ref}, so it cannot diff "
+                f"the two lists — and a gate on one side of the bump is a finding",
+            )
+
+    def test_the_derivation_is_loud_when_it_cannot_run(self):
+        """`ls-tree` on a missing directory exits 128 and says so, rather than
+        printing nothing at exit 0 — measured on git 2.55.0. The prose has to
+        carry that, because "no workflows" and "could not read" are the two
+        answers the gate list must not confuse."""
+        self.assertRegex(
+            self.material(0),
+            r"(?is)ls-tree[^.]*?exits \*\*128\*\*|exits \*\*128\*\* and says so",
+            "Phase 0 must say that a failed listing is loud, not empty",
         )
 
 
@@ -3377,7 +3711,7 @@ class TestNoExecutePhaseBuildsTheAuditedProject(SkillHarness):
 
     def test_no_no_execute_phase_builds_the_audited_project(self):
         for number in self.NO_EXECUTE:
-            code = self._uncommented(self.reachable(number))
+            code = self._uncommented(self.reachable(number, printed=False))
             hits = sorted(set(self.EXECUTES.findall(code)))
             self.assertEqual(
                 hits,
@@ -3410,7 +3744,7 @@ class TestNoExecutePhaseBuildsTheAuditedProject(SkillHarness):
     def test_the_pattern_still_finds_a_real_violation_in_the_document(self):
         """Phase 5 installs frozen and says so; if it stops matching, so has the pattern."""
         self.assertRegex(
-            self._uncommented(self.reachable(5)),
+            self._uncommented(self.reachable(5, printed=False)),
             self.EXECUTES,
             "Phase 5 is documented as the phase that installs the PR; a pattern that "
             "no longer matches it cannot be trusted over Phases 0-3",

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -3390,13 +3390,15 @@ class TestPhase2CanReachAChangelogAtAll(SkillHarness):
         copy would have left it live in the other. Re-anchored to `reachable`,
         which follows the script, rather than re-anchored to nothing.
         """
-        code = self.reachable(2)
+        # Asserted before the return, and on the *prose*: `reachable(2)` only
+        # contains the script's code because the prose names it, so this gives
+        # a deleted invocation its own message instead of four regex misses.
         self.assertIn(
             "changelog.py",
             "\n".join(block for _, section in self._handoffs(2) for block in bash_blocks(section)),
             "Phase 2 documents no way to find the project's repository",
         )
-        return code
+        return self.reachable(2)
 
     def test_the_tag_is_matched_against_the_release_list_not_constructed(self):
         """Guessing the prefix returns "release not found", which reads exactly


### PR DESCRIPTION
Closes #94 and #101. Sprint C, and the last one in the plan.

## What was wrong

Phase 2's changelog ladder stopped at the first rung that answered, and **every one of its exit conditions was an absence** — the project publishes no releases, the patch has no section, the tags are missing. There was no rung whose exit condition was *"this one answered, and its answer is incomplete"*, so a rung returning real, well-formed content ended the read.

Measured on `rumdl` v0.2.60…v0.2.62, the bump it was found in:

| | |
|---|---|
| rung 1, release notes | answers for both versions — one `### Added` bullet each |
| rung 2, `CHANGELOG.md` | answers for both versions — the same bullet |
| rung 3, the commit range | **18 commits, five of them `fix(…)`** |

Two of the five are `stop rewriting Rust source when formatting doc comments`, which wrote `# [derive(Debug)]` to disk, and `stop reading a lazy continuation as a setext underline` — in a tool the audited repo runs as `rumdl check --fix` on every Markdown commit. A run honoring the ladder as written reported "two additive releases" and was wrong about the only interesting thing in the bump.

**Nothing failed**, which is why no exit status anywhere could reach it. And the obvious heuristic does not save it: *"does this project document its fixes at all?"* returns a confident yes — 0.2.56, 0.2.57, 0.2.59 and 0.2.60 all carry a `### Fixed` section. Only the versions under audit had none.

## What changed

**`scripts/changelog.py`** reads all three sources and reports the difference. It matches the tag rather than building one, finds the changelog by listing the repo root rather than assuming `CHANGELOG.md`, and **says which classifier ran**. Exit `0` the prose names every fix, `1` it does not and they are listed, `2` could not run.

`--write-mode` **escalates a finding and never gates the search.** #94 proposed fetching the range only where the repo runs the tool in write mode; this fetches it always, because gating the *call* on that judgement asks the auditor to be right about write mode before it has the evidence, and one wrong guess restores the silence the script exists to remove.

**A third row in Phase 2's scope test**, where the entry names a **file type** or a **document shape** rather than a setting — no config key exists to grep, so "no config line matches" reads as `inert here`. And **#101**: Phase 0 derives the workflow list at both refs instead of naming a bare `<ci>`; Phase 6 and `actions.md` § Phase 5 asked the same question under a second spelling, and all three are now `<workflow>`.

## Two defects in my own script, found by running it rather than reading it

- It reported `python/mypy` v2.3.0…v2.3.1 as carrying **no fixes**. It carries four. Filtering on `fix(` is honest only where the project did the labelling — this plugin's own failure class, rebuilt inside the tool written to remove it.
- `section_for` found **no** changelog section in a file that has one per release. A generated heading links to a compare range carrying the *previous* version, so the raw line matches the wrong one.

## Where I went past what #94 asked

#101 also proposed a general guard: no placeholder anywhere is left underived. **Measured: 37 placeholders appear in a bash fence and never in their phase's prose** — `<owner>`, `<N>`, `<sha>` and the rest, all answered by Phase 0's outputs table or by context. A guard with 37 exceptions is one that gets weakened until it discriminates nothing, so I built the narrow guard for placeholders standing for a path *in the repository*, which has none. Saying so rather than shipping it.

## Testing

**38 new tests** (`tests/test_changelog.py`, 5 live in `integration/`, 11 prose guards). 396 total, all green; ruff, ruff-format and mypy clean.

Every fixture in `tests/test_changelog.py` is **recorded from the live API, not written to fit the rule** — a reconciliation rule tested against changelogs invented from the rule can only agree with itself. The live half is in `integration/`, which goes red when the world moves.

**Three existing guards caught real defects in this change as it was written**: a block reading `$BASE_SHA` without re-sourcing the handoff (three separate times), a `git grep` piped into `wc` that reports `0` at exit 0 whether it matched nothing or could not run, and an escaped pipe in a table cell that reaches this reader as a literal backslash.

**Every new guard is mutation-checked by deleting what it protects** — 8 script mutations, 8 prose, 6 for #101, 5 for the scope table, 4 for the changelog index. Two initial misses were genuine guard weaknesses (one satisfied by a `git show` rather than the `ls-tree` it was about; one whose selector skipped Phase 6 entirely) and are fixed.

## Replay gate

Replayed against **fpga-board-sim #384**, the PR the defect was found in, with `claude -p --plugin-dir` in a fresh context. Read from the transcript, not the report: `changelog.py` ran twice, `ls-tree --name-only` derived the workflow list, `--write-mode` was passed, both content greps from the new third row ran, and `gh release view` — the rung-1 command the script replaces — was never issued.

**Both classifier modes were exercised on real data in one run.** rumdl took the conventional path: 18 commits, 5 fix, 5 unreconciled, the two destructive-shaped ones ranked to the top. ruff took the unlabelled path: 90 commits, 80 unreconciled, correctly reported as ordinary monorepo traffic rather than as 80 hidden fixes.

The run then used the new third scope row to settle exposure **by measurement** — zero `.rs` files, and 0.2.60 in `--fix` mode rewrote nothing across 15 setext-shaped Markdown files — reaching `inert here` by running something.

Phase 8 handed back seven deviations: **six `correct`, one `prose gap`** (a repo whose test suite shells out to an external toolchain), self-marked *"verify before filing"* per the 0.35.0 evidence rule. **No plugin defects.** `cleanup.py` left the clone clean: porcelain empty, no worktrees, no `pr-384` branch.

## Also fixed in passing

`CHANGELOG.md`'s link references stopped at 0.33.0 — **0.34.0 and 0.35.0 shipped headings with no definition**, so they rendered as literal bracketed text, and `[Unreleased]` still compared from v0.33.0 across three releases. Fixed, and guarded in both directions plus against drift from `plugin.json`.