### PR TITLE
fix: exclude the md-fence fixtures from ruff-format at the hook layer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,13 @@ repos:
       # then reformatted.
       - id: ruff-check
         args: [--fix]
+      # `extend-exclude` in pyproject.toml does not reach the fixtures: the hook
+      # passes filenames explicitly, and integration/fixtures/ruff-md-fences/
+      # ships its own pyproject.toml, which is the nearest config for files
+      # inside it and shadows this repo's. Excluding here filters the paths
+      # before ruff resolves any config at all. See #107.
       - id: ruff-format
+        exclude: ^integration/fixtures/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v2.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,18 @@
 target-version = "py311"        # tomllib
 line-length = 100
 # The ruff replay fixture is deliberately mis-formatted Python inside Markdown
-# fences: it is the input whose reformatting the test measures. Left included,
-# this repo's own `ruff format` hook would tidy it on the next commit and the
-# test would pass against a fixture with nothing left to find — the evidence
-# erased by the tool it is evidence about.
+# fences: it is the input whose reformatting the test measures. Tidied, the test
+# would pass against a fixture with nothing left to find — the evidence erased by
+# the tool it is evidence about.
+#
+# This setting is not what prevents that. It governs ruff's own discovery, so a
+# bare `ruff format .` skips the fixtures; it does **not** reach the pre-commit
+# hook, which passes filenames explicitly and resolves config per file, and
+# `integration/fixtures/ruff-md-fences/pyproject.toml` shadows this file for
+# everything under that directory. Measured: with the nearest config,
+# `ruff format --check --force-exclude <fixture>.md` reformats; forced to this
+# one via `--config pyproject.toml` it reports no files. The hook-level
+# `exclude:` in .pre-commit-config.yaml is what actually protects them (#107).
 extend-exclude = ["integration/fixtures"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
Closes #107. Unblocks #99, which cannot go green without it.

## What the old configuration did when it ran

Nothing. `pyproject.toml` carried

```toml
extend-exclude = ["integration/fixtures"]
```

with a comment stating it was what kept the md-fence fixtures from being tidied by this repo's own `ruff format` hook. It never did that job.

`extend-exclude` governs ruff's own **discovery**, so a bare `ruff format .` skips the fixtures. The hook does not discover — pre-commit passes filenames explicitly, and ruff resolves config per file. `integration/fixtures/ruff-md-fences/pyproject.toml` is the nearest config for everything under that directory, so it shadows the root and the root's exclude is never consulted:

```console
$ ruff@0.16.5 format --check --force-exclude integration/fixtures/ruff-md-fences/doc-one.md
1 file would be reformatted

$ ruff@0.16.5 format --check --force-exclude --config pyproject.toml integration/fixtures/ruff-md-fences/doc-one.md
warning: No Python files found under the given path(s)
```

Under `v0.16.2` the fixtures survived only because `.md` never reached the hook at all — `types_or: [python, pyi, jupyter]`. v0.16.5 adds `markdown` to that list and spends the accident.

## Why the hook layer

`exclude:` in `.pre-commit-config.yaml` filters paths **before** ruff resolves any config, so it does not depend on which `pyproject.toml` wins. Adding an exclusion to the fixture's own `pyproject.toml` would also have worked and would have been wrong: that file is fixture input, and its comment says so — *"The audited repo's config, not this one's."*

The stale `pyproject.toml` comment is corrected in the same commit rather than deferred, since it asserted the protection this change had to add.

## Inert today

At `v0.16.2` — main's current pin — `ruff-format` never sees a `.md` file, so this changes no behaviour until #99 rebases onto it. Verified below.

## The replay

- [x] Replayed against `Machai-Kydoimos/dependabot-audit #99`

Throwaway clone, checked out at #99's head (`0ab4088`). **Unfixed** — reproduces CI byte-for-byte:

```
ruff check...............................................................Passed
ruff format..............................................................Failed
- hook id: ruff-format
- files were modified by this hook
6 files reformatted, 23 files left unchanged
mypy.....................................................................Passed
```

**With this change applied**, same tree, same rev:

```
ruff check...............................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
unittest (stdlib, no network)............................................Passed
```

`git status` after the fixed run: zero files modified besides `.pre-commit-config.yaml` itself. The fixtures survive intact, which is the entire point of excluding them.

And on **main at v0.16.2**, confirming inertness — before and after the change, identically:

```
ruff check...............................................................Passed
ruff format..............................................................Passed
mypy.....................................................................Passed
unittest (stdlib, no network)............................................Passed
```

## Counts

CI's `6 files reformatted, 23 files left unchanged` reconciles at #99's head: 14 `.py` + 15 `.md` = 29 = 6 + 23. The 23 unchanged are 14 Python and 9 Markdown — not 23 Markdown, which is the miscount filed as #104.

## Not versioned

No bump to `.claude-plugin/plugin.json` and no CHANGELOG entry: the plugin's procedure and shipped surface are unchanged, and this is repo lint configuration. Say the word if you'd rather it carried a patch version and a Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
