### PR TITLE
fix: three defects found by auditing this repo's own bump PRs (0.37.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,113 @@ patch.
 
 ## [Unreleased]
 
+## [0.37.0] — 2026-09-03
+
+Closes [#104](https://github.com/Machai-Kydoimos/dependabot-audit/issues/104),
+[#105](https://github.com/Machai-Kydoimos/dependabot-audit/issues/105) and
+[#106](https://github.com/Machai-Kydoimos/dependabot-audit/issues/106) — three
+defects found by running this plugin against its own repository's open Dependabot
+PRs, #98 and #99. Both are `pre-commit` bumps, which is the ecosystem this plugin
+does not cover, so all three sit on the boundary path rather than in the verified
+one.
+
+**Minor, not patch.** Phase 1's boundary report gains two phases it never named,
+Phase 4 gains a step it did not require, and the report shape gains a rule about
+what a row may assert.
+
+### Changed
+
+- **Phase 1 now says which phases survive the boundary, and why** (#106). The
+  passage told an uncovered ecosystem to "say so and stop … do not improvise",
+  then fifteen lines later to report "what Phase 0's classification and Phase 6's
+  CI state established". That enumeration omitted Phases 2 and 3, which are
+  equally ecosystem-independent — so the two readings disagreed and **a run
+  taking either was equally compliant**.
+
+  Measured on #98: the run performed the currency read and the vulnerability
+  queries, established that v2.3.1 was the true latest of both the mirror and
+  `python/mypy` and that OSV and GHSA held nothing for `mypy` at any version, and
+  then spent a deviation row defending them as improvisation. On a PR with six
+  green required contexts that evidence is most of what a reader weighing a
+  boundary Hold has to go on.
+
+  The line is now stated as a property rather than a list: Phases 2 and 3 ask a
+  registry and an advisory database questions that are **falsifiable against the
+  same public source the reader can open**, and neither certifies that an
+  artifact is what the registry says it is. That certification is Phase 1's
+  alone, and it is what the boundary withholds. The Cargo failure the warning
+  comes from was an improvised *verifier* reporting green about artifact
+  integrity — not a currency read.
+
+- **Phase 4 must reconcile an exclusion the bump defeated** (#105). Where the
+  repo configures an exclusion covering files the bump newly reaches, and they
+  are rewritten anyway, the audit now establishes *why* before reporting the
+  cause. Two check-only runs settle it: once as the gate invokes the tool, once
+  forced to the repo-root manifest.
+
+  Measured on #99. `pyproject.toml` carried `extend-exclude = ["integration/fixtures"]`
+  with a comment saying it existed to stop `ruff format` tidying six Markdown
+  fixtures — "the evidence erased by the tool it is evidence about" — and it had
+  never done that job. `integration/fixtures/ruff-md-fences/pyproject.toml` is
+  the nearest config for files beneath it and shadows the root's. Forced to the
+  root, ruff reports `warning: No Python files found under the given path(s)`;
+  left to resolve normally, `1 file would be reformatted`. The old report named
+  the cause correctly and never reconciled it, **which sends the reader to the
+  wrong file**: the pattern is right, and the remedy is at the hook layer.
+
+  **The rule explicitly survives Phase 4 being skipped**, because the bump that
+  produced it was an ecosystem that skips Phase 4. The contradiction arrived in a
+  CI log instead. A Phase-4-only rule would not have fired on its own case.
+
+### Fixed
+
+- **A report could re-label a tool's count as a file class nobody measured**
+  (#104). `references/report-template.md` opened with "every row is something you
+  *ran*", which governs whether a row ran and not arithmetic performed inside
+  one — so it passed against this.
+
+  Measured on #99: `6 files reformatted, 23 files left unchanged` was reported as
+  "the other 23 markdown files it also newly scanned", on a tree holding 14 `.py`
+  and 15 `.md`. The unchanged 23 were 14 Python and **9** Markdown. The
+  conclusion it supported — that the repo's own documentation is newly in scope
+  and currently passes — was correct, and the evidence offered for it was 2.5x
+  larger than anything measured, in the one row a reader uses to size blast
+  radius. Either derive the split, or quote the tool's number unsplit; rows that
+  quote a tool verbatim are the ones worth keeping, so the rule is narrow on
+  purpose.
+
+### The replay
+
+`/dependabot-audit 99` under `claude -p --plugin-dir`, in a fresh context against
+the unreleased tree — verified from the transcript, whose first call resolves
+`discover.py` under the working tree rather than the installed 0.36.0 cache. 42
+tool calls, 2 denials, both multi-line commands re-issued as singles.
+
+| Changed here | What the run did with it |
+|---|---|
+| § Phase 1, the boundary enumeration | the deviation row for running Phases 2 and 3 is now classed **`correct`**, citing the new text. On #98 the identical work was a `prose gap` row |
+| § Phase 4, the reconciliation | performed, check-only, and reported in the Behavior-change row: run 1 `6 files would be reformatted`, run 2 forced to the root manifest `warning: No Python files found under the given path(s)`. The report's own words: *"the reconciliation SKILL.md owes there **was** performed"* |
+| § Phase 4, surviving a skipped Phase 4 | the row that carried it reads *"Phase 4 not run — uncovered ecosystem. The Phase 4-shaped observation arrived in the CI log instead"* |
+| § report shape, the count rule | *"The CI run's own summary line, quoted unsplit: `6 files reformatted, 23 files left unchanged`"* — and, separately derived, the nine newly-scoped Markdown files, `9 files already formatted` |
+
+**And the verdict changed, correctly.** #108 had landed the exclusion an hour
+earlier, so the red check was stale with respect to `main`. The run found that
+itself, simulated the merge with `git merge-tree --write-tree` rather than
+merging anything, measured the merged tree green, and returned *"hold —
+procedurally, until CI re-runs"* at **medium** confidence instead of the
+substantive Hold the same evidence produced before. Dependabot then rebased #99
+onto `main` while the follow-up issues were being written, and the PR went
+`CLEAN` — confirming the prediction the simulation had made.
+
+Two findings came out of the replay that are not fixed here, filed as
+[#110](https://github.com/Machai-Kydoimos/dependabot-audit/issues/110) — a red
+check can be stale because the base moved rather than the PR, which Phase 6's
+head-versus-parent comparison structurally cannot see — and
+[#111](https://github.com/Machai-Kydoimos/dependabot-audit/issues/111), Phase 0's
+worktree carve-out naming the ecosystem instead of the condition, now raised by
+two independent runs.
+
+
 ## [0.36.0] — 2026-09-01
 
 Closes [#94](https://github.com/Machai-Kydoimos/dependabot-audit/issues/94) and
@@ -4152,7 +4259,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.33.0...v0.34.0

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -621,8 +621,26 @@ and the refusal to report `CLEAN` on an empty selection.
 `Cargo.lock`, `poetry.lock`, `package-lock.json`, `Pipfile.lock`, `go.sum`,
 `go.mod`, `yarn.lock`, `pnpm-lock.yaml` or a `pyproject.toml`, it exits **2**
 naming the format. Report that as the boundary it is, not as a failed audit: the
-ecosystem-independent phases still ran, so say what Phase 0's classification and
-Phase 6's CI state established, and name plainly what was not checked.
+ecosystem-independent phases still ran, so say what Phase 0's classification,
+Phase 2's currency read, Phase 3's vulnerability queries and Phase 6's CI state
+established, and name plainly what was not checked.
+
+**Phases 2, 3 and 6 run for an uncovered ecosystem. Phases 1, 4 and 5 do not.**
+The line is not which phases happen to be ecosystem-independent — it is what a
+phase *asserts*. Phase 2 asks a registry which version is newest and Phase 3 asks
+a vulnerability database what it holds; both answers are falsifiable against the
+same public source the reader can open, and neither claims that an artifact is
+what the registry says it is. That claim is Phase 1's alone, and it is the one
+the boundary withholds. The Cargo failure above was an improvised **verifier**
+reporting green about artifact integrity — not a currency read, which is why the
+warning does not reach these two.
+
+Left unsaid, this cost a run a deviation row: on a `pre-commit` bump the
+enumeration above named only Phases 0 and 6, so running Phase 2 and Phase 3 had
+to be defended as improvisation. Both were load-bearing — the proposed version
+was the true latest of both the mirror and the tool it pins, and the advisory
+databases were empty at every version, which is most of what a reader weighing a
+boundary Hold has to go on.
 
 ## Phase 2 — Currency
 
@@ -801,6 +819,26 @@ Python fences inside Markdown. Nothing in the pass/fail answer moved. Diffing th
 two versions' *output* does not rescue it either, because a bump changes output
 format about as often as behavior — which is why `gate_diff.py` compares what
 each run did to the files.
+
+**A gate that rewrites files the repo excludes has defeated the exclusion, and
+that is a finding about the exclusion as much as about the tool.** Where the repo
+configures an exclusion covering files the bump newly reaches, and they were
+rewritten anyway, establish *why* before reporting the cause. Two check-only runs
+settle it: once as the gate invokes the tool, then again forced to the
+repo-root manifest with the tool's own `--config`-style flag. If only the second
+excludes the file, the root config is being shadowed — a manifest nested inside
+the excluded directory is the nearest one for files beneath it, so the root's
+exclusion is never consulted. Measured on a `ruff-pre-commit` v0.16.2 → v0.16.5
+bump, where `extend-exclude` was believed to protect six Markdown fixtures and
+never had: the nearest config reformatted them, the root config reported no files
+at all. Reported without that, the reader goes looking for a wrong exclusion
+pattern, and the remedy is in a different file from the one they open.
+
+**The contradiction can surface outside this phase.** An uncovered ecosystem
+skips Phase 4 entirely, and the same observation — a gate rewrote files the
+config declares out of scope — then arrives in a CI log instead. The
+reconciliation is owed there too. It is two read-only commands and it runs
+nothing from the PR, so `--no-execute` is not a reason to skip it.
 
 **"Inert here" is a result, not silence.** Reaching it deliberately is this phase
 working; reaching it by not looking is the failure.

--- a/skills/dependabot-audit/references/report-template.md
+++ b/skills/dependabot-audit/references/report-template.md
@@ -4,6 +4,19 @@ Evidence first, recommendation as its conclusion. Every row is something you
 *ran*, not something you assumed — if a phase was skipped, say so in the row
 rather than omitting it.
 
+**A count attributed to a class of file has to come from a command.** Quoting a
+gate's own summary is always safe; splitting one is not. `6 files reformatted, 23
+files left unchanged` says nothing about *which* 23, and re-reporting them as 23
+files of the type the finding happens to be about asserts a measurement nobody
+made. Either derive the split — one check-only invocation over that file list —
+or quote the number the tool printed, unsplit. Measured on a `ruff-pre-commit`
+v0.16.5 bump: the report called those 23 "markdown files", while the tree held 14
+`.py` and 15 `.md`, so the unchanged 23 were 14 Python and 9 Markdown. The
+conclusion it supported — that the repo's own documentation was newly in scope
+and passing — was correct, and the evidence offered for it was 2.5x larger than
+anything that had been measured. The rule is narrow on purpose: rows that quote a
+tool verbatim are the ones worth keeping.
+
 ---
 
 # Dependabot Audit — PR #\<N>

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -3872,3 +3872,141 @@ class TestTheDeviationHandBackCarriesItsEvidence(SkillHarness):
             "an unproven row that reaches the issue tracker unverified is how the "
             "same wrong cause was filed twice",
         )
+
+
+class TestTheBoundaryNamesWhichPhasesSurviveIt(SkillHarness):
+    """An uncovered ecosystem left the reader to infer which phases still run.
+
+    Phase 1 said "say so and stop. Do not improvise a procedure from the shape of
+    the ones that are here", and fifteen lines later that the boundary report
+    should carry "what Phase 0's classification and Phase 6's CI state
+    established". That enumeration omitted Phases 2 and 3, which are also
+    ecosystem-independent, so two runs taking opposite paths both looked
+    compliant.
+
+    Measured on a live `pre-commit` bump: the run ran currency and vulnerability
+    checks, found the proposed version was the true latest of both the mirror and
+    the tool it pins and that the advisory databases were empty at every version,
+    and then had to spend a deviation row defending them as improvisation. The
+    failure mode here is silence, so the guard asks that the passage commits --
+    either way would fix it, and naming them is the way it was fixed.
+    """
+
+    def phase1(self) -> str:
+        return self.material(1).lower()
+
+    def test_the_boundary_names_phases_2_and_3(self):
+        body = self.phase1()
+        for token in ("phase 2", "phase 3"):
+            self.assertIn(
+                token,
+                body,
+                f"Phase 1's boundary passage never names {token}, so whether it runs "
+                "for an uncovered ecosystem is left to each run to decide",
+            )
+
+    def test_the_boundary_says_what_admits_them(self):
+        """A list without its reason is a list the next ecosystem cannot extend.
+
+        The property is that neither phase certifies artifact integrity -- which
+        is what separates them from the improvised Cargo verifier the warning is
+        actually about. Without it the enumeration reads as an arbitrary pair.
+        """
+        self.assertRegex(
+            self.phase1(),
+            r"falsifiab",
+            "the boundary lists which phases survive it but not the property that "
+            "admits them, so it cannot be applied to a phase not on the list",
+        )
+
+
+class TestADefeatedExclusionIsReconciled(SkillHarness):
+    """A gate rewrote files the repo's own config declared excluded.
+
+    Measured on `ruff-pre-commit` v0.16.2 -> v0.16.5: the hook's `types_or` gained
+    `markdown`, six Markdown fixtures were reformatted, and `extend-exclude` in
+    the root manifest -- whose comment said it existed to prevent exactly that --
+    did not stop it, because a manifest nested in the excluded directory is the
+    nearest config for files beneath it. The report named the cause correctly and
+    never reconciled it against the exclusion, which sends the reader to the
+    wrong file: the remedy is at the hook layer, not in the pattern they would go
+    and inspect.
+    """
+
+    def phase4(self) -> str:
+        return self.material(4).lower()
+
+    def test_phase_4_requires_the_exclusion_be_reconciled(self):
+        self.assertRegex(
+            self.phase4(),
+            r"exclusion",
+            "Phase 4 never mentions an exclusion being defeated, so a gate that "
+            "rewrites excluded files reads as ordinary reformatting",
+        )
+
+    def test_the_reconciliation_is_a_measurement_not_a_judgement(self):
+        """Two runs settle it; 'consider whether' would not.
+
+        The first draft of this rule said to "establish why" and stopped there,
+        which is the shape that produced the defect -- the run did establish a
+        why, just not this one.
+        """
+        self.assertRegex(
+            self.phase4(),
+            r"shadow",
+            "the rule names no mechanism, so it cannot distinguish a shadowed root "
+            "config from a wrong pattern -- the two remedies are in different files",
+        )
+
+    def test_the_rule_survives_phase_4_being_skipped(self):
+        """The bump that motivated it was an ecosystem that skips Phase 4.
+
+        The contradiction arrived from a CI log instead, so a rule that only
+        applies when Phase 4 runs would not have fired on the case it came from.
+        """
+        self.assertRegex(
+            self.phase4(),
+            r"--no-execute is not a reason to skip it|surface outside this phase",
+            "the reconciliation is owed even where Phase 4 does not run; without "
+            "that it misses the uncovered-ecosystem path it was written for",
+        )
+
+
+class TestACountAttributedToAFileClassIsDerived(SkillHarness):
+    """A report split a gate's summary line and re-labelled half of it.
+
+    `6 files reformatted, 23 files left unchanged` became "the other 23 markdown
+    files", on a tree holding 14 `.py` and 15 `.md` -- so the unchanged 23 were 14
+    Python and 9 Markdown. The conclusion it supported was right and the evidence
+    offered for it was 2.5x larger than anything measured, in the one row a reader
+    uses to size the blast radius.
+
+    The template's existing rule -- every row is something you ran -- governs
+    whether a row ran, not arithmetic performed inside one, which is why it
+    passed against this.
+    """
+
+    def setUp(self):
+        self.template = (PLUGIN / "references/report-template.md").read_text(encoding="utf-8")
+
+    def test_the_template_forbids_an_underived_split(self):
+        self.assertRegex(
+            self.template.lower(),
+            r"has to come from a command",
+            "the template does not say a count attributed to a file class must be "
+            "derived, so re-labelling a tool's summary line stays compliant",
+        )
+
+    def test_quoting_the_tool_unsplit_stays_allowed(self):
+        """The rule has to be narrow or it forbids the good behaviour too.
+
+        Most rows quote a tool's own output verbatim, which is exactly what the
+        report shape wants. A rule that demanded every number be re-derived would
+        make those rows non-compliant.
+        """
+        self.assertRegex(
+            self.template.lower(),
+            r"unsplit",
+            "the rule must leave quoting the tool's own number available, or it "
+            "reads as a demand to re-derive every count in the report",
+        )


### PR DESCRIPTION
Closes #104, closes #105, closes #106.

Three defects found by running `/dependabot-audit` against this repo's own open Dependabot PRs, #98 and #99. Both are `pre-commit` bumps — the ecosystem this plugin does not cover — so all three sit on the boundary path, which is the half of the live exercise #109 is about.

**Minor, not patch.** Phase 1's boundary report gains two phases it never named, Phase 4 gains a step it did not require, and the report shape gains a rule about what a row may assert.

## What the old text did when it ran

**#106** — Phase 1 said *"say so and stop … do not improvise"*, then fifteen lines later that the boundary report should carry *"what Phase 0's classification and Phase 6's CI state established"*. Phases 2 and 3 are equally ecosystem-independent and appeared in neither sentence, so both readings were available and **a run taking either looked compliant**. #98's audit ran them anyway, established that v2.3.1 was the true latest of both the mirror and `python/mypy` and that OSV and GHSA held nothing for `mypy` at any version — then spent a deviation row defending that as improvisation. On a PR with six green required contexts, that was most of the report.

**#105** — #99's audit found the true cause and never reconciled it against `extend-exclude = ["integration/fixtures"]`, whose comment claimed it prevented exactly this. It never had: the fixture directory's own `pyproject.toml` is the nearest config for files beneath it and shadows the root's. A reader holding both facts would go inspect the pattern, which is correct — the remedy is at the hook layer, in a different file.

**#104** — `6 files reformatted, 23 files left unchanged` was reported as *"the other 23 markdown files"*, on a tree holding 14 `.py` and 15 `.md`. The unchanged 23 were 14 Python and **9** Markdown. The conclusion was right; the evidence offered for it was 2.5x larger than anything measured, in the row a reader uses to size blast radius.

## Guards are mutation-checked

All seven new assertions **fail** against the pre-fix prose — verified by reverting both files and running only the new classes:

```
Ran 7 tests in 0.015s
FAILED (failures=7)
```

A prose guard that passes against the text it was written for is a failure mode this repo has measured before, so this is checked rather than assumed.

## The replay

- [x] Replayed against `Machai-Kydoimos/dependabot-audit #99`

`claude -p --plugin-dir` in a fresh context. Confirmed from the transcript to be running the working tree — its first call resolves `discover.py` under `/home/rick/Projects/dependabot-audit/`, not the installed 0.36.0 cache. 42 tool calls, 2 denials (both multi-line commands, re-issued as singles).

| Changed here | What the run did with it |
|---|---|
| Phase 1's boundary enumeration | the deviation row for Phases 2 and 3 is now classed **`correct`**, citing the new text. On #98 the identical work was a `prose gap` |
| Phase 4's reconciliation | performed and reported: run 1 `6 files would be reformatted`; run 2 forced to the root manifest `warning: No Python files found under the given path(s)`. Its words: *"the reconciliation SKILL.md owes there **was** performed"* |
| surviving a skipped Phase 4 | *"Phase 4 not run — uncovered ecosystem. The Phase 4-shaped observation arrived in the CI log instead"* |
| the count rule | *"The CI run's own summary line, quoted unsplit: `6 files reformatted, 23 files left unchanged`"* — plus a separately derived `9 files already formatted` |

**The verdict changed, correctly.** #108 had landed the exclusion an hour earlier, so the red check was stale against `main`. The run found that itself, simulated the merge with `git merge-tree --write-tree` rather than merging anything, measured the merged tree green, and returned *"hold — procedurally, until CI re-runs"* at medium confidence instead of the substantive Hold the same evidence produced before.

Dependabot then rebased #99 onto `main` while the follow-up issues were being written, and the PR went `CLEAN` — confirming the prediction the simulation made.

## Not fixed here

Two findings from the replay, filed rather than folded in: #110 (a red check can be stale because the base moved, which Phase 6's head-versus-parent comparison structurally cannot see) and #111 (Phase 0's worktree carve-out names the ecosystem instead of the condition, now raised by two independent runs).

## Release

`plugin.json` is at `0.37.0` with a CHANGELOG entry. The annotated tag and GitHub Release are the post-merge step and are not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
