### PR TITLE
Detect a red check invalidated by the base moving, and condition the worktrees (0.38.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,104 @@ patch.
 
 ## [Unreleased]
 
+## [0.38.0] — 2026-09-03
+
+Closes [#110](https://github.com/Machai-Kydoimos/dependabot-audit/issues/110) and
+[#111](https://github.com/Machai-Kydoimos/dependabot-audit/issues/111), both
+raised by live runs against this repository's own bump PRs.
+
+**Minor, not patch.** Phase 6 gains a question it did not ask, Phase 7 gains a
+fourth verdict, and Phase 0's worktree rule changes on which runs it fires.
+
+### Added
+
+- **Phase 6 now asks whether the base moved under the check results** (#110), and
+  `ci_state.py` answers it. CI runs on `refs/pull/<N>/merge` — the base merged
+  with the head — so a fix landing on the default branch invalidates every result
+  on the PR, with **no event on the PR to re-trigger them**. Attribution cannot
+  see this: it compares the head against `pr-<N>^` and *both of those commits are
+  unchanged*, so the row reads `attributable`, correctly, about a merge that no
+  longer exists.
+
+  Observed on this repo's #99. The fix for what the red check caught merged to
+  `main` as `09911c1` at 2026-09-03T17:43:31Z; the red `Lint & type-check` had
+  started 2026-09-01T01:14:41Z, **2d 16h earlier**, so it could not have contained
+  its own fix. A report that stopped at Phase 6 carried a substantive Hold on a PR
+  whose only blocker had already been repaired.
+
+  **The comparison is a timestamp, not a ref, and that is the finding inside the
+  finding.** The obvious signal is the merge ref — compare `refs/pull/<N>/merge`'s
+  base parent against the branch tip, which is what the issue proposed. Measured,
+  it does not work: `refs/pull/<N>/merge` and `potentialMergeCommit` are recomputed
+  *lazily*, and querying `mergeable` is what pokes them, so by the time either is
+  read it names the current base while the check results still do not. Commit
+  dates are not recomputed by being read. `baseRef`'s tip committed after a
+  settled check started means that check could not have contained it — no local
+  `git`, which is what let this go into `ci_state.py` rather than staying prose.
+
+  Three states, and the third is load-bearing as usual: a settled context with no
+  start time, or an unreadable base tip, is **underivable** rather than "current".
+  A *queued* context has no start time either and never will until it starts, so
+  it is excluded — reading it as underivable would fire on every PR with a pending
+  job and retire the signal.
+
+  Verified in both directions live: silent on #99 as it stands (base tip 18:39:15Z,
+  checks 18:43:34Z), and firing on `cli/cli` #14196, whose seven contexts predate
+  the current `trunk` by 15d 20h.
+
+- **A fourth verdict, `Hold, pending a re-run`** (#110). "Red, and the base still
+  explains it" and "red, but the base has moved" are different recommendations:
+  the first owes the reader a cause, the second owes a commit and an action.
+  Phase 7's table gains two rows for the distinction, above the `attributable`
+  row so the first-match read reaches them. Collapsing the two is what produced
+  the Hold above.
+
+### Changed
+
+- **Phase 0 creates the worktrees on a condition, not on an ecosystem** (#111).
+  The old rule said *an actions bump consumes neither worktree*. That is true and
+  it is not the reason: what makes them pointless is that **Phases 4 and 5 will
+  not run**, which is equally true of an uncovered ecosystem, a `pull` tier, a
+  non-bot author, `--no-execute`, and Phase 1 finding anything. Every input is on
+  disk before the decision — `discover.py` writes `$ECOSYSTEM`, `$SCOPE_GATE` and
+  `$MAY_EXECUTE` one command earlier.
+
+  Two live runs deviated from the old rule independently, each reasoning out the
+  uncovered-ecosystem case and each writing it up rather than acting on it. The
+  Phase 0 outputs table carried the same rule in its own words and is updated with
+  it, because a reader following the table alone got whichever statement was not
+  changed.
+
+  **`--no-execute` is not `$MAY_EXECUTE`**, and #111's own text conflated them.
+  `discover.py` derives `MAY_EXECUTE` from the author, the cross-repository check
+  and `push`; it never sees the flag. The rule now names both inputs.
+
+- **Phase 6 separates reading the simulated merge from re-gating it.** #110 held
+  that `git merge-tree --write-tree` "works under `--no-execute` for any gate that
+  is itself read-only". Half right: reading a file out of the written tree is
+  read-only and always available, but *running* the repo's gate against it
+  executes the bumped tool, which is the whole of `$MAY_EXECUTE`. Recorded as
+  written, that would have put a Phase 5 action inside the flag that exists to
+  forbid it.
+
+### Fixed
+
+- **A prose guard that stopped discriminating when a row moved.** Phase 7's
+  attributable-row guard took the first row mentioning `attributable` and
+  returned, so the new stale-base rows — inserted above it, and about *not*
+  reporting a red as attributable — satisfied it on behalf of the row it was
+  written for. It now selects on the verdict cell and checks every match.
+  Mutation-checked afterwards against the defect it was written for.
+
+- **Two new guards that went green under mutation, caught before they shipped.**
+  One asserted a phrase over the whole of `render`'s output and was satisfied by a
+  different `print` higher up; it now slices at the row. The other asserted the
+  rollup query's field names, which occur more than once in the same reachable
+  code, so deleting any one from the query passed — removed rather than kept as
+  coverage, with the negative result recorded in the test. `SkillHarness` gains
+  `flat()`, because `SKILL.md` is hard-wrapped and three guards matching more than
+  a few words failed on their own fixed prose.
+
 ## [0.37.0] — 2026-09-03
 
 Closes [#104](https://github.com/Machai-Kydoimos/dependabot-audit/issues/104),
@@ -4259,7 +4357,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.37.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.38.0...HEAD
+[0.38.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.34.0...v0.35.0

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -184,13 +184,30 @@ below does not reach it: that paragraph is keyed to `git worktree add` refusing,
 and Phase 0 never gets that far. `prune` is a no-op when state is clean, needs no
 path argument, and clears `pr-<N>` and `base-<N>` together.
 
-**An actions bump consumes neither worktree — do not create them for one.**
-`references/actions.md` reads the diff with `git show "pr-<N>:…"` throughout,
-Phase 4 reads release notes, and Phase 5's substitute is `gh run list`. Two
-worktrees added and removed for nothing, on every actions bump. The **fetch**
-stays either way: `git show` needs the ref, and Phase 7 still has a branch to
-remove. Where the ecosystem is not yet known, the scope diff settles it and costs
-one command.
+**Create the worktrees only where Phase 4 or Phase 5 will run.** They are the two
+phases that need a tree; every other read here reaches the PR through
+`git show` at a ref. Four paths run neither, and the condition is the phases
+rather than any one of the four:
+
+| Condition | Already on disk as | Why neither phase runs |
+|---|---|---|
+| an actions bump | `$ECOSYSTEM=github-actions` | `references/actions.md` reads the diff with `git show "pr-<N>:…"` throughout, Phase 4 reads release notes, and Phase 5's substitute is `gh run list` |
+| an ecosystem this plugin does not cover | `$ECOSYSTEM`, `$SCOPE_GATE=beyond` or `underivable` | Phase 1's boundary stops the audit before either |
+| a `pull` tier, a non-bot author, or a cross-repository head | `$MAY_EXECUTE=no` | both phases open by testing it for `yes` |
+| `--no-execute` | **not** `$MAY_EXECUTE` — the flag is yours, and `discover.py` never sees it | the arguments section defines the run as Phases 0–3 and 6–7 |
+| Phase 1 finding anything | `$SCOPE_GATE=beyond` | both phases name it as a reason to skip |
+
+Every row's input exists before the decision: `discover.py` writes `$ECOSYSTEM`,
+`$SCOPE_GATE` and `$MAY_EXECUTE` one command earlier, and the flag is a word in
+the invocation. **This rule used to name the ecosystem instead of the property**,
+and two live runs deviated from it independently — each reasoning out that an
+uncovered ecosystem consumes no worktree either, and each writing the gap up
+rather than acting on it (#111). Naming one of five conditions needed four more
+exceptions; the property is the same in all five, so it is stated once.
+
+The **fetch** stays on every path: `git show` needs the ref, Phase 6's merge
+simulation needs `pr-<N>`, and Phase 7 still has a branch to remove. Where the
+ecosystem is not yet known, the scope diff settles it and costs one command.
 
 And the part no script can read for you — the bot's configuration, which decides
 whether a currency gap in Phase 2 is lag or a deliberate hold, and the repo's
@@ -273,8 +290,8 @@ discarded unread rather than saved.
 | `$HEAD_SHA` | the full 40-character commit under audit |
 | `$BASE_SHA` | the merge base, from GitHub's own `compare` endpoint — never a local `git merge-base` against `$DEFAULT`, which collapses onto the head once the PR lands. **And whether it is the bot's branch point**, which is a separate answer |
 | `pr-<N>` | the fetched branch, registered in the **user's** repo |
-| `$SCRATCH/pr-<N>` | worktree at the PR's head — Phase 5 reproduces in it. Not created for an actions bump, which consumes no worktree |
-| `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below. Same exception |
+| `$SCRATCH/pr-<N>` | worktree at the PR's head — Phase 5 reproduces in it. **Created only where Phase 4 or Phase 5 will run**; the table above says how that is read off `$ECOSYSTEM`, `$SCOPE_GATE` and `$MAY_EXECUTE` before either phase is reached |
+| `$SCRATCH/base-<N>` | worktree at the merge base — **Phase 4 measures in it**, and the reason is below. Same condition, and not a second exception |
 | the repo's gates | read at a ref, **once per tree they will run in**: `pr-<N>` for Phase 5, `$BASE_SHA` for Phase 4. A gate on only one side is a finding |
 | `$OWNER`, `$NAME` | the repo's owner and name, for Phase 6's GraphQL variables |
 | `$CREATED_AT` | when the PR was opened, ISO-8601. **Phase 2 compares release publish times against it** — the cooldown asks whether a release was three days old *then*, not now |
@@ -1119,6 +1136,63 @@ It is also the direction that costs least to be wrong in, and therefore gets
 least scrutiny: a false Hold looks conservative, so nobody goes back to check
 whether the bump was the cause.
 
+**A red check can be stale because the *base* moved, not the PR.** CI runs on
+`refs/pull/<N>/merge` — the base merged with the head — so a fix landing on the
+default branch invalidates every result here, with no event on the PR to
+re-trigger them. The labels above cannot see it: their comparison is the head
+against `pr-<N>^`, and **both of those commits are unchanged**. The row reads
+`attributable`, correctly, about a merge that no longer exists.
+
+The script detects it, and what it compares is a **timestamp, not a ref**: the
+base branch's tip committed *after* a settled check started means that check
+could not have contained it. It prints `THE BASE MOVED UNDER THESE RESULTS`,
+names every row that predates the tip, and marks those rows procedural. Measured
+on this plugin's own #99 — red `Lint & type-check` started 2026-09-01T01:14:41Z
+and the fix for what it caught landed on `main` 2d 16h later — and silent on the
+same PR after Dependabot rebased it, which is the half that keeps the signal
+worth reading.
+
+**Reading the merge ref instead does not work**, and it is the obvious thing to
+reach for. `refs/pull/<N>/merge` and `potentialMergeCommit` are recomputed
+lazily, and *querying* `mergeable` is what pokes them — so by the time either is
+read it usually names the current base while the check results still do not.
+Commit dates are not recomputed by being read, and the comparison needs no local
+`git`, which is what lets `ci_state.py` keep it.
+
+**Detecting it is the script's; settling it is yours.** Simulate the merge and
+read the result:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# Exit 1 is a conflicting merge — a real answer, and a different finding from
+# staleness. Do not read it as "could not run".
+MERGED=$(git merge-tree --write-tree "origin/$DEFAULT" "pr-<N>") \
+  || { echo "the merged tree conflicts — report that, not staleness" >&2; exit 1; }
+git show "$MERGED:<the file the failing check named>"
+```
+
+`--write-tree` writes a tree to the object store and prints its hash: nothing is
+checked out, nothing is merged, nothing from the PR is executed. **Reading out of
+that tree is read-only and available under `--no-execute`. Re-running the repo's
+gate against it is not** — a check-only gate still executes the bumped tool, which
+is the whole of `$MAY_EXECUTE`, so extracting the tree and gating it takes Phase 5's
+permission and belongs beside it in the report.
+
+Verified on #99 while writing this: `git merge-tree --write-tree origin/main
+pr-99` printed `7716296`, and reading `.pre-commit-config.yaml` out of that tree
+showed the bumped `rev: v0.16.5` **and** the `exclude: ^integration/fixtures/`
+that had landed on `main` underneath it — the reconciliation the red check could
+not have seen, in one command that ran no gate at all.
+
+**Say which kind of hold this is.** "Red, and the base still explains it" is a
+finding about the bump. "Red, and the base has moved" is a wait for a re-run, and
+the reader is owed the difference: the first names a cause, the second names a
+commit and an action. Phase 7's table has a row for each, and the second is
+**Hold, pending a re-run**.
+
 **Three CI-state traps the script cannot cover**, because each is about whether
 the answer is *current* rather than how to read it:
 
@@ -1186,6 +1260,12 @@ Verdicts are one of:
   on a **separate branch**. Never push onto the bot's branch; that stops it
   managing the PR.
 - **Hold** — a discrepancy, a regression, or a behavior change that breaks a gate.
+- **Hold, pending a re-run** — the PR cannot merge and nothing about the bump is
+  why: a result that describes a state which no longer exists. It is a *wait*,
+  not a finding, and the two are not interchangeable — this verdict owes the
+  reader the commit that invalidated the result and the action that settles it,
+  where **Hold** owes a cause. Reporting one as the other is how a report Holds a
+  bump on a defect somebody already fixed.
 
 ### Which evidence produces which verdict
 
@@ -1209,6 +1289,8 @@ there by exhaustion is indistinguishable in the report from no finding at all.
 | Actions: the tag rolled **behind** the proposed SHA | **Hold.** Close the bot's PR and replace it by hand; a bot cannot express a downgrade |
 | Phase 4: base differs, PR differs — the change is real and unabsorbed | **Hold** |
 | Phase 5: the frozen install failed, or a repo gate failed | **Hold** |
+| A red required check the script marked **stale — the base moved under it** — and the simulated merge reads clean | **Hold, pending a re-run.** Name the base commit that invalidated it, say the merge was simulated and what the tree showed, and give the reader the re-run rather than a cause. The label on the row stays right about two commits that did not change and silent about the one that did, so do not report it as **attributable** |
+| A red required check the script marked **stale**, and the merged tree was **not** read | **Not a Hold on this bump** — the red is unattributed *and* may describe a merge that no longer exists, which are two separate reasons it cannot carry a verdict. Report the check, the base commit, and that the simulation was not made. If this row would decide the verdict, confidence is **low** |
 | A red **required** check labelled **attributable** | **Hold** — the PR cannot merge either way. But read the failing step's log at **both commits** before the report says the bump *caused* it: green-then-red is consistent with the bump, not proof, and the wider the interval the weaker the claim |
 | A red required check labelled **pre-existing** | **Not a Hold on this bump.** Report it as its own finding, take the verdict from the remaining evidence, and say the PR is unmergeable until someone fixes it |
 | A red required check labelled **underivable** | **Not a Hold on this bump** — nothing established the cause, and a Hold that rests on an unattributed red row is correct only by accident. Report the red check *and* that the comparison could not be made; the PR is unmergeable until it is fixed. If this row would decide the verdict, confidence is **low** |

--- a/skills/dependabot-audit/scripts/ci_state.py
+++ b/skills/dependabot-audit/scripts/ci_state.py
@@ -39,6 +39,7 @@ import json
 import os
 import subprocess
 import sys
+import textwrap
 from datetime import datetime
 from typing import Any, NoReturn
 
@@ -66,13 +67,19 @@ query($owner:String!, $name:String!, $number:Int!, $cursor:String) {
   repository(owner:$owner, name:$name) {
     pullRequest(number:$number) {
       mergeable mergeStateStatus reviewDecision
+      baseRef { name target { ... on Commit { oid committedDate } } }
       commits(last:1) { nodes { commit { oid committedDate statusCheckRollup { state
         contexts(first:100, after:$cursor) {
           totalCount
           pageInfo { hasNextPage endCursor }
           nodes {
-            ... on CheckRun      { name    conclusion isRequired(pullRequestNumber:$number) }
-            ... on StatusContext { context state      isRequired(pullRequestNumber:$number) }
+            # The start time is `base_drift`'s only input, and the two shapes
+            # name the same thing differently. Wrapped, not shortened: the
+            # columns are what make the two lines comparable at a glance.
+            ... on CheckRun      { name    conclusion startedAt
+                                   isRequired(pullRequestNumber:$number) }
+            ... on StatusContext { context state      createdAt
+                                   isRequired(pullRequestNumber:$number) }
           }
         } } } } }
     }
@@ -211,6 +218,9 @@ def _context(node: dict[str, Any]) -> dict[str, Any] | None:
         "result": (result or "PENDING").upper(),
         "required": bool(node.get("isRequired")),
         "kind": "CheckRun" if node.get("name") else "StatusContext",
+        # The two shapes name it differently, and reading only `startedAt` leaves
+        # every StatusContext permanently underivable in `base_drift` below.
+        "started": node.get("startedAt") or node.get("createdAt") or "",
     }
 
 
@@ -266,9 +276,17 @@ def rollup(owner: str, name: str, number: int) -> dict[str, Any]:
             # hasNextPage without a cursor cannot be followed. Say so rather than
             # looping forever or reporting the partial list as complete.
             break
+    base = pull.get("baseRef") or {}
+    base_target = base.get("target") or {}
     return {
         "head_oid": head_oid,
         "head_committed": head_committed,
+        # The branch this PR merges *into*, as it is now — not `$BASE_SHA`, which
+        # is where the PR branched off and does not move. `base_drift` needs the
+        # tip, because a fix landing there invalidates the checks below.
+        "base_ref": base.get("name") or "",
+        "base_oid": base_target.get("oid") or "",
+        "base_committed": base_target.get("committedDate") or "",
         "rollup_state": state,
         "merge_state": pull.get("mergeStateStatus") or "",
         "mergeable": pull.get("mergeable") or "",
@@ -380,6 +398,72 @@ def attribute(
     }
 
 
+def base_drift(report: dict[str, Any]) -> dict[str, Any]:
+    """Did these check results include the base branch as it is **now**?
+
+    CI runs on `refs/pull/<N>/merge` — the base merged with the head — so a commit
+    landing on the default branch invalidates every result on the PR, with no
+    event on the PR to re-trigger them. `attribute()` cannot see this: its
+    comparison is the head against `pr-<N>^` and **both of those commits are
+    unchanged**. It labels the row `attributable`, correctly, about a merge that
+    no longer exists.
+
+    Observed on this plugin's own #99. The fix for what the check caught merged to
+    `main` as `09911c1` at 2026-09-03T17:43:31Z; the red `Lint & type-check` on the
+    PR had started at 2026-09-01T01:14:41Z, **2d 16h earlier**, so it could not
+    have contained its own fix. A report that stopped at Phase 6 carried a
+    substantive Hold on a PR whose only blocker had already been repaired.
+
+    **Why a timestamp and not the merge ref.** `potentialMergeCommit` and
+    `refs/pull/<N>/merge` are recomputed lazily, and *querying* `mergeable` is
+    what pokes them — so by the time either is read it usually names the current
+    base while the check results still do not. Measured on the same PR: the
+    parents of `potentialMergeCommit` had already caught up. Commit dates are not
+    recomputed by being read, and this needs no local git, which keeps the
+    no-fetch property this script is written to.
+
+    Three states, and the third is the one that matters. "Could not compare" must
+    not arrive as "every check included the current base" — the same asymmetry as
+    `$SCOPE_GATE` and the truncated context list above.
+    """
+    when = report.get("base_committed") or ""
+    settled = [c for c in report["contexts"] if c["result"] in FAILING | PASSING]
+    unknown: dict[str, Any] = {
+        "state": "underivable", "stale": [], "behind": "",
+        "why": "", "base_ref": report.get("base_ref") or "",
+        "base_oid": report.get("base_oid") or "", "base_committed": when,
+    }  # fmt: skip
+    if not when:
+        return {**unknown, "why": "the base branch's tip was not readable"}
+    # A queued context has no start time and never will until it starts, so
+    # reading that as underivable would fire on every PR with a pending job and
+    # retire the signal. A context that has *concluded* and still has no start
+    # time is a comparison genuinely not made.
+    blind = [c["name"] for c in settled if not c["started"]]
+    if blind:
+        return {
+            **unknown,
+            "why": f"no start time for {', '.join(sorted(blind))}, which have concluded",
+        }
+    stale = [c["name"] for c in settled if c["started"] < when]
+    if not stale:
+        return {
+            **unknown,
+            "state": "no",
+            "why": "every settled check started after the base branch last moved",
+        }
+    return {
+        **unknown,
+        "state": "yes",
+        "stale": sorted(stale),
+        "behind": interval(when, min(c["started"] for c in settled if c["name"] in stale)),
+        "why": (
+            f"{report.get('base_ref') or 'the base branch'} moved to "
+            f"{(report.get('base_oid') or '')[:9]} after these checks started"
+        ),
+    }
+
+
 def analyse(report: dict[str, Any]) -> dict[str, Any]:
     """Findings, and the three states, without deciding the verdict.
 
@@ -399,6 +483,12 @@ def analyse(report: dict[str, Any]) -> dict[str, Any]:
     # GitHub has computed it. Not "nothing blocks" — not established.
     report["merge_state_underivable"] = report["merge_state"] in ("", "UNKNOWN")
     report["findings"] = bool(report["required_red"]) or report["blocked"]
+    # Deliberately after `findings` and deliberately not part of it. Drift
+    # qualifies rows; it never invents one. A default branch that moved while an
+    # all-green PR sat there carries no finding about the bump, and folding it in
+    # would exit 1 on every audit of an active repository — which is how a signal
+    # stops being read.
+    report["base_drift"] = base_drift(report)
     return report
 
 
@@ -422,6 +512,27 @@ def render(report: dict[str, Any]) -> None:
     if report["merge_state_underivable"]:
         print("  !! mergeStateStatus is UNKNOWN: computed lazily, and this is also what")
         print("     a merged PR returns. That is *not established*, not 'nothing blocks'.")
+
+    drift = report["base_drift"]
+    if drift["state"] == "yes":
+        print(f"\n  !! THE BASE MOVED UNDER THESE RESULTS — {drift['why']}")
+        print("     CI runs on refs/pull/<N>/merge, so every result below predates")
+        print(f"     {drift['base_oid'][:9]} by {drift['behind']} and describes a merge")
+        print("     that no longer exists. Nothing on the PR re-triggers it.")
+        # Wrapped, and not truncated to the first few. Measured on `cli/cli`
+        # #14196, where seven context names ran to 190 characters on one line and
+        # the warning above them stopped being readable.
+        print("     Started before it:")
+        # `break_on_hyphens=False`: check names are full of them, and
+        # `close-from-default-branch` split across two lines reads as two
+        # different checks.
+        for line in textwrap.wrap(", ".join(drift["stale"]), width=66, break_on_hyphens=False):
+            print(f"       {line}")
+        print("     Simulate the merge and re-gate before a red row carries a Hold, or")
+        print("     a green one carries a merge — see Phase 6's fourth trap.")
+    elif drift["state"] == "underivable":
+        print(f"\n  !! BASE STALENESS UNDERIVABLE — {drift['why']}.")
+        print("     Not 'these results include the current base': never established.")
 
     for ctx in report["required"]:
         mark = "OK " if ctx["result"] in PASSING else "BAD"
@@ -463,6 +574,15 @@ def render(report: dict[str, Any]) -> None:
         if attr["weakened"]:
             print("       Say the weakened basis out loud; passing it off as the")
             print("       parent's answer is the failure this comparison exists to avoid.")
+        if ctx["name"] in report["base_drift"]["stale"]:
+            # The label above is still correct — both commits it compares are
+            # unchanged. What it cannot say is that the result describes a merge
+            # that has been superseded, and that is what a reader takes the Hold
+            # from.
+            print("       AND THE BASE MOVED: this result is for a merge that no longer")
+            print("       exists, so the label above is right about two commits that did")
+            print("       not change and silent about the one that did. Procedural, not")
+            print("       substantive, until the merged tree is re-gated.")
 
     if report["red"] and report["parent_names"]:
         missing = [c["name"] for c in report["red"] if c["name"] not in report["parent_names"]]

--- a/tests/test_ci_state.py
+++ b/tests/test_ci_state.py
@@ -33,14 +33,27 @@ from ci_state import cli, main
 HEAD = "h" * 40
 PARENT = "p" * 40
 BASE = "b" * 40
+# The base branch's tip, which is not $BASE_SHA: the merge base is where the
+# PR branched, this is where the branch it merges into has got to since.
+BASE_TIP = "t" * 40
 
 
-def check_run(name: str, conclusion: str, *, required: bool = False) -> dict[str, Any]:
-    return {"name": name, "conclusion": conclusion, "isRequired": required}
+# After `page`'s default `base_committed`, so the ordinary context began *after*
+# the base branch last moved and the staleness comparison stays quiet. A test
+# about a moved base moves the base, not this.
+STARTED = "2026-08-01T01:00:00Z"
 
 
-def status_context(context: str, state: str, *, required: bool = False) -> dict[str, Any]:
-    return {"context": context, "state": state, "isRequired": required}
+def check_run(
+    name: str, conclusion: str | None, *, required: bool = False, started: str | None = STARTED
+) -> dict[str, Any]:
+    return {"name": name, "conclusion": conclusion, "isRequired": required, "startedAt": started}
+
+
+def status_context(
+    context: str, state: str, *, required: bool = False, started: str | None = STARTED
+) -> dict[str, Any]:
+    return {"context": context, "state": state, "isRequired": required, "createdAt": started}
 
 
 def page(
@@ -53,8 +66,20 @@ def page(
     rollup_state: str = "SUCCESS",
     oid: str = HEAD,
     committed: str = "2026-08-01T00:00:00Z",
+    base_ref: str = "main",
+    base_oid: str | None = BASE_TIP,
+    base_committed: str | None = "2026-07-01T00:00:00Z",
 ) -> dict[str, Any]:
-    """One GraphQL response. `total` defaults to the node count (nothing truncated)."""
+    """One GraphQL response. `total` defaults to the node count (nothing truncated).
+
+    `base_committed` defaults to a month *before* the contexts start, which is the
+    ordinary case: the base branch has not moved since CI ran. A test asking about
+    a moved base pushes it past the start times, and `None` on either base field
+    is the shape a repository with an unreadable base ref returns.
+    """
+    target: dict[str, Any] | None = None
+    if base_oid is not None or base_committed is not None:
+        target = {"oid": base_oid, "committedDate": base_committed}
     return {
         "data": {
             "repository": {
@@ -62,6 +87,7 @@ def page(
                     "mergeable": "MERGEABLE",
                     "mergeStateStatus": merge_state,
                     "reviewDecision": review,
+                    "baseRef": {"name": base_ref, "target": target},
                     "commits": {
                         "nodes": [
                             {
@@ -676,3 +702,141 @@ class TestNoCallIsMadeForAnAnswerNothingReads(CiStateHarness):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAStaleRedCanBelongToAMergeThatMoved(CiStateHarness):
+    """A red check can be invalidated by the **base** moving, with no event on
+    the PR to re-trigger it.
+
+    CI runs on `refs/pull/<N>/merge` — the base merged with the head — so a fix
+    landing on the default branch invalidates the result while nothing on the PR
+    changes. `attribute()` cannot see it: its comparison is the head against
+    `pr-<N>^`, and **both of those commits are unchanged**. It labels the row
+    `attributable`, correctly, about a merge that no longer exists.
+
+    Measured on this repo's own #99, which discriminates in both directions:
+
+        pre-fix head 0ab4088   Lint & type-check FAILURE, started 2026-09-01T01:14:41Z
+                               base tip 09911c1 landed  2026-09-03T17:43:31Z
+                               -> 2d 16h too early to contain its own fix
+
+        after the rebase       checks started           2026-09-03T18:43:34Z
+                               base tip 515653a landed  2026-09-03T18:39:15Z
+                               -> current; the comparison must stay quiet
+
+    A report that stopped at Phase 6 carried a substantive Hold on a PR whose
+    only blocker had already been repaired.
+
+    Why the timestamp and not the merge ref: `potentialMergeCommit` and
+    `refs/pull/<N>/merge` are both recomputed *lazily*, and querying `mergeable`
+    is what pokes them — so by the time this script reads one it usually names
+    the current base while the check results still do not. The commit dates are
+    not recomputed by being read.
+    """
+
+    def _moved(self, nodes, **kw):
+        """A base tip that landed *after* the contexts started."""
+        return page(nodes, base_committed="2026-08-02T00:00:00Z", **kw)
+
+    def test_a_base_that_landed_after_the_check_is_reported(self):
+        fake, _ = self._fake_gh(
+            [self._moved([check_run("Lint & type-check", "FAILURE", required=True)])],
+            runs={PARENT: [("Lint & type-check", "SUCCESS")]},
+            dates={PARENT: "2026-07-30T00:00:00Z"},
+        )
+        report = self._json(fake)
+        self.assertEqual(report["base_drift"]["state"], "yes")
+        self.assertIn("Lint & type-check", report["base_drift"]["stale"])
+
+    def test_the_attributable_row_says_the_merge_no_longer_exists(self):
+        """The label stays `attributable` — both commits it compares are
+        unchanged, so nothing about it is wrong. What is missing is that the
+        result describes a merge that has been superseded, and that is what a
+        reader takes the Hold from."""
+        fake, _ = self._fake_gh(
+            [self._moved([check_run("Lint & type-check", "FAILURE", required=True)])],
+            runs={PARENT: [("Lint & type-check", "SUCCESS")]},
+            dates={PARENT: "2026-07-30T00:00:00Z"},
+        )
+        _, out, _ = self._run(fake)
+        self.assertIn("ATTRIBUTABLE", out, "the label itself is still correct")
+        # Sliced at the row, not searched whole. The first draft of this asserted
+        # over the entire output and went green against a `render()` with the
+        # row-level line deleted -- the block-level warning higher up matched it.
+        # A guard satisfied by a different print is the "written from the fix"
+        # failure CONTRIBUTING names, and it took a mutation run to see it.
+        # `\s+` and not a space: `render` wraps, and this phrase straddles a
+        # newline. A literal-space regex reports the sentence as absent.
+        row = out[out.index("  RED  ") :].lower()
+        self.assertRegex(
+            row,
+            r"merge that no longer\s+exists",
+            "the red row survives with no sign that the base moved under it, which "
+            "is the report that Held #99 on a defect already fixed",
+        )
+        self.assertIn("procedural", row, "and it must say which kind of Hold that makes")
+
+    def test_a_base_older_than_the_checks_stays_quiet(self):
+        """The other half of the #99 measurement. A comparison that fires on
+        every PR of an active repository is one a reader learns to skip."""
+        fake, _ = self._fake_gh(
+            [page([check_run("Lint & type-check", "FAILURE", required=True)])],
+            runs={PARENT: [("Lint & type-check", "SUCCESS")]},
+            dates={PARENT: "2026-07-30T00:00:00Z"},
+        )
+        report = self._json(fake)
+        self.assertEqual(report["base_drift"]["state"], "no")
+        _, out, _ = self._run(fake)
+        self.assertNotRegex(out.lower(), r"base .*moved|merge that no longer exists")
+
+    def test_an_unreadable_base_is_underivable_rather_than_current(self):
+        """Third state, and it is the one that matters. "Could not compare" must
+        not arrive as "every check included the current base" — the same
+        asymmetry as `$SCOPE_GATE` and the truncated context list."""
+        fake, _ = self._fake_gh(
+            [page([check_run("t", "FAILURE", required=True)], base_oid=None, base_committed=None)]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["base_drift"]["state"], "underivable")
+
+    def test_a_settled_context_with_no_start_time_is_underivable(self):
+        """A null `startedAt` on a check that has already concluded leaves the
+        comparison unmade for that row, and "unmade" is not "current"."""
+        fake, _ = self._fake_gh([page([check_run("t", "FAILURE", required=True, started=None)])])
+        report = self._json(fake)
+        self.assertEqual(report["base_drift"]["state"], "underivable")
+
+    def test_a_queued_context_with_no_start_time_does_not_force_underivable(self):
+        """A check that has not started has no start time and never will until it
+        does. Reading that as underivable would fire on every PR with a pending
+        job, which retires the signal."""
+        fake, _ = self._fake_gh([
+            page([
+                check_run("done", "SUCCESS", required=True),
+                check_run("queued", None, required=True, started=None),
+            ])
+        ])  # fmt: skip
+        report = self._json(fake)
+        self.assertEqual(report["base_drift"]["state"], "no")
+
+    def test_drift_alone_does_not_invent_a_finding(self):
+        """Exit 1 means the CI state carries a finding. An all-green PR on a repo
+        whose default branch moved has none, and flipping the code there would
+        make every audit of an active repository exit 1."""
+        fake, _ = self._fake_gh([self._moved([check_run("t", "SUCCESS", required=True)])])
+        code, out, _ = self._run(fake)
+        self.assertEqual(code, 0)
+        self.assertIn("base", out.lower(), "quiet exit, but the reader still gets told")
+
+    def test_a_status_context_is_compared_on_created_at(self):
+        """The two context shapes name the field differently — `CheckRun` has
+        `startedAt`, `StatusContext` has `createdAt` — and reading only the first
+        leaves every status context permanently underivable."""
+        fake, _ = self._fake_gh(
+            [self._moved([status_context("ci/legacy", "FAILURE", required=True)])],
+            statuses={PARENT: [("ci/legacy", "SUCCESS")]},
+            dates={PARENT: "2026-07-30T00:00:00Z"},
+        )
+        report = self._json(fake)
+        self.assertEqual(report["base_drift"]["state"], "yes")
+        self.assertIn("ci/legacy", report["base_drift"]["stale"])

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -303,6 +303,20 @@ class SkillHarness(unittest.TestCase):
         parts.extend(section for _, section in self._handoffs(number))
         return "\n".join(parts)
 
+    def flat(self, number: int) -> str:
+        """`material`, lowercased, with every run of whitespace collapsed to one
+        space.
+
+        `SKILL.md` is hard-wrapped, so any guard matching more than four or five
+        words in a row is matching across a newline — and the wrap point moves
+        whenever a word earlier in the paragraph changes. Three guards written
+        the obvious way failed on their own fixed prose, and `.{0,400}` between
+        two phrases silently matches nothing at all, because `re.search` has no
+        DOTALL here. Flatten once, in the harness, rather than sprinkling the
+        whitespace class through every guard.
+        """
+        return re.sub(r"\s+", " ", self.material(number)).lower()
+
     def _scan(self, pattern):
         """{match -> [phase numbers it appears in]}, in phase order."""
         found: dict[str, list[int]] = {}
@@ -840,19 +854,33 @@ class TestTheAttributableLabelIsHedgedLikeTheOthers(SkillHarness):
         )
 
     def test_phase_7s_hold_row_does_not_assert_causation_by_itself(self):
+        """The row that turns an attributable red into a bare **Hold**.
+
+        Selected on the *verdict* cell and not on the word "attributable"
+        anywhere in the row, and checked for every match rather than the first.
+        The looser version took whichever attributable row came first in the
+        table and stopped, so a later row inserted above it -- the stale-base
+        pair, whose whole content is "do not report this as attributable" --
+        satisfied the guard on behalf of the row it was written for.
+        """
+        found = 0
         for table in tables(dict(self.phases)[7]):
             for row in table:
-                if "attributable" in row.lower() and "hold" in row.lower():
-                    self.assertIn(
-                        "both commits",
-                        row.lower(),
-                        "an evidence table saying a check is red — true — while "
-                        "implying a cause it never established is the same "
-                        "family as the rewritten base and the hand-joined "
-                        "required list, and this is the row that acts on it",
-                    )
-                    return
-        self.fail("Phase 7 has no verdict row for an attributable red check")
+                cells = [c.strip().lower() for c in row.split("|")]
+                if len(cells) < 3 or "attributable" not in cells[1]:
+                    continue
+                if not cells[2].startswith("**hold**"):
+                    continue
+                found += 1
+                self.assertIn(
+                    "both commits",
+                    row.lower(),
+                    "an evidence table saying a check is red — true — while "
+                    "implying a cause it never established is the same "
+                    "family as the rewritten base and the hand-joined "
+                    "required list, and this is the row that acts on it",
+                )
+        self.assertTrue(found, "Phase 7 has no verdict row for an attributable red check")
 
 
 class TestPhase5SaysWhatItActuallyExercised(SkillHarness):
@@ -4009,4 +4037,173 @@ class TestACountAttributedToAFileClassIsDerived(SkillHarness):
             r"unsplit",
             "the rule must leave quoting the tool's own number available, or it "
             "reads as a demand to re-derive every count in the report",
+        )
+
+
+class TestTheWorktreeCarveOutNamesTheCondition(SkillHarness):
+    """Phase 0 created two worktrees on paths that consume neither.
+
+    The carve-out was right and its condition was wrong: it said *an actions
+    bump*, when what makes the worktrees pointless is that **Phases 4 and 5 will
+    not run** -- which is also true of an uncovered ecosystem, of a `pull` tier,
+    of `--no-execute`, and of Phase 1 finding anything.
+
+    Two live runs on 2026-09-03 hit the uncovered-ecosystem case, neither created
+    the worktrees, and both wrote it up as a gap rather than acting on it -- the
+    shape #102 records as the one that precedes a defect. Filed as #111.
+    """
+
+    def carve_out(self) -> str:
+        return dict(self.phases)[0].lower()
+
+    def test_the_rule_is_stated_as_a_condition_on_the_phases(self):
+        self.assertRegex(
+            self.carve_out(),
+            r"only where phase 4 or phase 5 will run",
+            "Phase 0 states the worktree carve-out as an ecosystem rather than as "
+            "the property that makes it true, so every other path that skips both "
+            "phases has to be reasoned out again by each run",
+        )
+
+    def test_the_uncovered_ecosystem_path_is_covered(self):
+        """The case both deviations actually hit. A rule naming only actions
+        leaves it to the run, and both runs got it right and said so, which is
+        more maintainer attention than the fix costs."""
+        rule = self.carve_out()
+        start = rule.index("only where phase 4 or phase 5 will run")
+        table = rule[start : start + 2000]
+        self.assertIn(
+            "does not cover",
+            table,
+            "the carve-out never names the uncovered-ecosystem path, which is the "
+            "one this repo generates monthly and the one both deviations hit",
+        )
+        self.assertIn(
+            "--no-execute",
+            table,
+            "nor the flag path, which the arguments section already defines as Phases 0-3 and 6-7",
+        )
+
+    def test_the_flag_is_not_confused_with_the_permission_tier(self):
+        """`--no-execute` and `$MAY_EXECUTE` are different inputs and #111's own
+        text conflated them. `discover.py` sets `MAY_EXECUTE` from the author,
+        the cross-repository check and `push` -- it never sees the flag, so a
+        rule that reads the flag out of the variable is reading a value nothing
+        writes."""
+        rule = self.carve_out()
+        start = rule.index("only where phase 4 or phase 5 will run")
+        self.assertRegex(
+            rule[start : start + 2000],
+            r"the flag is yours|`discover\.py` never sees it|never sees it",
+            "the carve-out sources `--no-execute` from `$MAY_EXECUTE`, which "
+            "`discover.py` does not derive from the flag",
+        )
+
+    def test_the_outputs_table_does_not_keep_the_narrow_exception(self):
+        """The rule lives in two places -- the paragraph and the row that hands
+        each worktree to a later phase -- and a reader following the table alone
+        gets whichever one was not updated."""
+        for table in tables(dict(self.phases)[0]):
+            for row in table:
+                if "$SCRATCH/pr-<N>" in row or "$SCRATCH/base-<N>" in row:
+                    self.assertNotIn(
+                        "actions bump",
+                        row,
+                        "the Phase 0 outputs row still carves out the ecosystem "
+                        "rather than the condition, so the two statements of the "
+                        "same rule disagree",
+                    )
+
+
+class TestARedCheckCanBeStaleBecauseTheBaseMoved(SkillHarness):
+    """CI runs on `refs/pull/<N>/merge`, so the base can invalidate a result.
+
+    A fix landing on the default branch makes every check on the PR describe a
+    merge that no longer exists, and nothing on the PR re-triggers them.
+    Attribution cannot see it -- it compares the head against `pr-<N>^` and both
+    of those commits are unchanged -- so the row reads `attributable`, correctly,
+    about a merge that has been superseded.
+
+    Observed on this plugin's own #99: the fix merged to `main` as `09911c1` at
+    2026-09-03T17:43:31Z while the red `Lint & type-check` had started
+    2026-09-01T01:14:41Z, 2d 16h earlier. A report that stopped at Phase 6
+    carried a substantive Hold on a PR whose only blocker had been repaired.
+    Filed as #110.
+    """
+
+    def test_phase_6_names_the_trap(self):
+        self.assertRegex(
+            self.flat(6),
+            r"base\*? moved|base.{0,20}moved",
+            "Phase 6 never says a red check can be invalidated by the base, so a "
+            "run reads the attribution as the whole answer",
+        )
+
+    def test_the_comparison_is_a_timestamp_and_the_prose_says_why(self):
+        """The obvious signal is the merge ref, and it does not work: both
+        `refs/pull/<N>/merge` and `potentialMergeCommit` are recomputed lazily
+        and *querying* `mergeable` is what pokes them, so they name the current
+        base while the results still do not. Without the reason recorded, the
+        next reader reaches for the ref and measures nothing."""
+        self.assertRegex(
+            self.flat(6),
+            r"recomputed lazily",
+            "Phase 6 does not say why the merge ref is the wrong signal, so the "
+            "obvious replacement for the timestamp reads as an improvement",
+        )
+
+    def test_the_detection_is_in_the_script_not_only_the_prose(self):
+        """CONTRIBUTING: a trap a script refuses cannot be skipped, one in prose
+        is silently skipped. The comparison needs no local git, so nothing about
+        `ci_state.py` being network-only kept it out."""
+        code = self.reachable(6)
+        self.assertIn(
+            "base_drift",
+            code,
+            "the staleness check lives only in prose, which is the weakest of the "
+            "three levers and the one this repo shrank Phase 6 to get away from",
+        )
+        # Mutation-checked, and the results are worth recording because two of
+        # them are negative. Deleting `base_drift` and replacing the call with a
+        # constant leaves this green -- `render` still names the key, so the
+        # string survives. Asserting the query fields instead (`committedDate`,
+        # `startedAt`, `createdAt`) is no better: each occurs elsewhere in the
+        # same reachable code, so deleting any one from the query passes too.
+        #
+        # What it does catch is the case it exists for: `ci_state.py` at its
+        # pre-fix revision, prose written and script never touched. That is the
+        # forward-reference class this whole file is about. **Whether the
+        # mechanism still works is `test_ci_state.py`'s job** -- a constant in
+        # place of the call fails six cases there -- and adding assertions here
+        # that cannot fail would be coverage rather than a guard.
+
+    def test_the_verdict_vocabulary_carries_the_distinction(self):
+        """ "Red, and the base still explains it" and "red, but the base moved"
+        are different recommendations: the first owes a cause, the second owes a
+        commit and an action. Collapsing them is what Held #99."""
+        body = self.flat(7)
+        self.assertIn(
+            "hold, pending a re-run",
+            body,
+            "Phase 7 lists no verdict for a stale red, so the only word available "
+            "for one is Hold — which asserts a cause nothing established",
+        )
+        self.assertRegex(
+            body,
+            r"pending a re-run.{0,400}(wait|not a finding)",
+            "the fourth verdict is listed without saying how it differs from a "
+            "Hold, which is the whole reason it exists",
+        )
+
+    def test_reading_the_simulated_tree_is_separated_from_re_gating_it(self):
+        """#110 proposed that the whole check works under `--no-execute` "for any
+        gate that is itself read-only". Reading a tree is read-only; *running*
+        the bumped tool against it is execution, which is what `$MAY_EXECUTE`
+        gates. Recording the looser version would put a Phase 5 action inside a
+        flag that exists to forbid it."""
+        self.assertRegex(
+            self.flat(6),
+            r"re-running the repo's gate against it is not",
+            "Phase 6 offers the merge simulation without separating the read from "
+            "the re-gate, so a --no-execute run is invited to execute",
         )


### PR DESCRIPTION
Closes #110. Closes #111.

Both were raised by live runs of this plugin against this repository's own bump PRs.

## #110 — a red check can be stale because the base moved

CI runs on `refs/pull/<N>/merge`, so a fix landing on the default branch invalidates every result on the PR, with **no event on the PR to re-trigger them**. Attribution cannot see it: it compares the head against `pr-<N>^` and *both of those commits are unchanged*, so the row reads `attributable` — correctly — about a merge that no longer exists.

Observed on #99: the fix merged to `main` as `09911c1` at `2026-09-03T17:43:31Z`, while the red `Lint & type-check` had started `2026-09-01T01:14:41Z`, **2d 16h earlier**. A run stopping at Phase 6 reported a substantive Hold on a PR whose only blocker was already repaired.

### The comparison is a timestamp, not a ref

The issue proposed comparing the merge ref's base parent against the branch tip, via `git merge-tree`. **Measured, that does not detect it.** `refs/pull/<N>/merge` and `potentialMergeCommit` are recomputed *lazily*, and querying `mergeable` is what pokes them — so by the time either is read it names the current base while the check results still do not. Commit dates are not recomputed by being read.

So the check is: `baseRef`'s tip committed after a settled context started. No local `git`, which is what let it go into `ci_state.py` rather than staying prose as the issue proposed — CONTRIBUTING is explicit that a trap in prose is silently skipped.

Three states, as everywhere here. A settled context with no start time, or an unreadable base tip, is **underivable**, not "current". A *queued* context has no start time either and never will until it starts, so it is excluded — reading that as underivable would fire on every PR with a pending job.

Drift never sets `findings`: it qualifies rows, it does not invent one.

### Verified live, in both directions

| PR | base tip | checks started | result |
|---|---|---|---|
| this repo #99 (now) | `515653a` 18:39:15Z | 18:43:34Z | silent — correct |
| `cli/cli` #14196 | `e63f6149e` | 15d 20h earlier | fires, names all seven contexts |

### Verdict language

Phase 7 gains **`Hold, pending a re-run`** and two rows above the `attributable` row. "Red, and the base still explains it" owes the reader a cause; "red, but the base moved" owes a commit and an action.

Phase 6 also separates reading the simulated merge from re-gating it. The issue held that `merge-tree --write-tree` works under `--no-execute` "for any gate that is itself read-only" — half right: reading the written tree is read-only, but running the repo's gate against it executes the bumped tool, which is the whole of `$MAY_EXECUTE`.

## #111 — the worktree carve-out named the ecosystem, not the condition

Phase 0 said *an actions bump consumes neither worktree*. True, and not the reason: what makes them pointless is that **Phases 4 and 5 will not run**, equally true of an uncovered ecosystem, a `pull` tier, a non-bot author, `--no-execute`, and Phase 1 finding anything. Every input is on disk one command earlier.

`--no-execute` is **not** `$MAY_EXECUTE` — the issue's own text conflated them. `discover.py` derives `MAY_EXECUTE` from the author, the cross-repository check and `push`; it never sees the flag. Both inputs are now named.

## Guards

Three new tests went green under mutation and were fixed before shipping; each records what it failed to catch. Notably, Phase 7's *existing* attributable-row guard took the first row mentioning the word and returned — so the new rows, whose content is "do not report this as attributable", satisfied it on behalf of the row it was written for. It now selects on the verdict cell, checks every match, and was re-mutated against its original defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)