### PR TITLE
Verify pre-commit bumps end to end (0.38.0)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   # /dependabot-audit on them is the closest thing to a live test available
   # without `claude plugin eval`. That is a reason to keep the cadence low but
   # non-zero rather than to disable it.
+  #
+  # Until 0.38.0 only one of the two was verified end to end and the other hit
+  # Phase 1's boundary every month, so half of that exercise was a procedural
+  # Hold on evidence pointing the other way. `pre-commit` is a covered ecosystem
+  # now (#109), which is what makes the sentence above true of both entries.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,87 @@ patch.
 
 ## [0.38.0] — 2026-09-03
 
-Closes [#110](https://github.com/Machai-Kydoimos/dependabot-audit/issues/110) and
-[#111](https://github.com/Machai-Kydoimos/dependabot-audit/issues/111), both
+Closes [#109](https://github.com/Machai-Kydoimos/dependabot-audit/issues/109),
+[#110](https://github.com/Machai-Kydoimos/dependabot-audit/issues/110) and
+[#111](https://github.com/Machai-Kydoimos/dependabot-audit/issues/111), all three
 raised by live runs against this repository's own bump PRs.
 
-**Minor, not patch.** Phase 6 gains a question it did not ask, Phase 7 gains a
-fourth verdict, and Phase 0's worktree rule changes on which runs it fires.
+**Minor, not patch.** A third ecosystem is covered end to end, Phase 6 gains a
+question it did not ask, Phase 7 gains a fourth verdict, and Phase 0's worktree
+rule changes on which runs it fires.
 
-### Added
+### Added — `pre-commit` is a covered ecosystem (#109)
 
-- **Phase 6 now asks whether the base moved under the check results** (#110), and
+**Half of this plugin's only live exercise landed on the refusal path.**
+`.github/dependabot.yml` configures `github-actions` and `pre-commit` and says
+these PRs are "the only end-to-end exercise this plugin gets". One of the two was
+verified end to end; the other reached Phase 1's boundary every month and stopped.
+#98's report put it plainly — *"a Hold I would not defend on the merits, only on
+the procedure"* — and a gate that always says Hold is one the reader learns to
+discount.
+
+**What made it worth covering rather than documenting is that a `rev:` bump has
+real checkable content.** `scripts/precommit.py` derives three things no other
+phase could:
+
+- **the pin**, resolved to a commit and classified `immutable` / `mutable` /
+  `underivable`. A `rev:` is a git ref on someone else's repository — no artifact
+  hash, so this reports *immutability*, never integrity, exactly as
+  `references/actions.md` does for `uses:`;
+- **the requirement**, read from the hook repository's own packaging.
+  `mirrors-mypy` pins `mypy==2.3.1` in `setup.py`; `ruff-pre-commit` pins
+  `ruff==0.16.5` in `pyproject.toml`. *That* is the dependency, and pointing
+  Phases 2 and 3 at it puts them back on covered ground;
+- **the hook definition**, diffed field by field between the two revs.
+
+The third is the one that earns the script. Measured on `ruff-pre-commit`
+v0.16.2 → v0.16.5, which is this repo's #99:
+
+```
+!! ruff-format.types_or  [behavioural]
+     before: [python, pyi, jupyter]
+     after:  [python, pyi, jupyter, markdown]
+```
+
+One word in one list, and the hook began rewriting every Markdown file in the
+repository. **`ruff` itself did not change in any way its changelog reports**, so
+a per-package view of `ruff` returns *current* and *clean* — correctly, about the
+wrong artifact. Finding that by hand took a day.
+
+**Not a lockfile procedure with the names changed**, which is the objection the
+removal of npm, Cargo and Go was about. Where the claim cannot be made, it is
+refused rather than approximated:
+
+- a hook whose `language` is not `python` has its requirement derived and its
+  registry named as **not covered** — npm is the boundary again, one layer in;
+- `.pre-commit-hooks.yaml` is parsed by a deliberately small grammar that
+  **raises** on anything outside it, and the raw text is still handed to the
+  reader. A parser that skips what it does not recognise reports "no fields
+  changed" about a file it did not read — this plugin's own thesis one level
+  down. Verified against four live mirrors that disagree on every cosmetic
+  detail: two-space and four-space continuations, quoted keys, and a folded
+  scalar;
+- `install_requires` is read by **AST**, not regex, and a computed entry makes the
+  answer `underivable` rather than a partial list read as whole;
+- an unrecognised hook field counts as **behavioural**, deliberately: `pre-commit`
+  gains keys, and a new selector must not arrive as cosmetic because a list
+  predates it.
+
+`discover.py` classifies the ecosystem and gates its scope on `rev:` lines, the
+way it already does on `uses:`. The two line-based gates now share one
+implementation rather than a copy each. A diff also moving `args:`,
+`additional_dependencies:` or `repo:` is `beyond` — those change what the hook
+does, and `repo:` is not a bump at all.
+
+Both live PRs are the fixtures and they are complementary: #99 is a defect the
+verifier must catch, #98 a clean bump it must not flag. `integration/` replays
+both against the real repositories, because the hermetic fixtures are only
+evidence that the parser reads what was copied out of the files the day it was
+written.
+
+### Added — Phase 6 asks whether the base moved (#110)
+
+- **Phase 6 now asks whether the base moved under the check results**, and
   `ci_state.py` answers it. CI runs on `refs/pull/<N>/merge` — the base merged
   with the head — so a fix landing on the default branch invalidates every result
   on the PR, with **no event on the PR to re-trigger them**. Attribution cannot

--- a/README.md
+++ b/README.md
@@ -95,14 +95,24 @@ nothing hard-won is re-derived.
 
 ## Scope
 
-Two ecosystems, because together they are what a Python project's Dependabot
+Three ecosystems, because together they are what a Python project's Dependabot
 queue actually contains — on this plugin's own test repo the bot PRs split
-`uv: 11` / `github_actions: 10`:
+`uv: 11` / `github_actions: 10`, and on **this** repo they split
+`github_actions` / `pre-commit`:
 
 | | |
 |---|---|
 | **Python — `uv.lock`** | `scripts/audit.py`, end-to-end and tested against it: artifact hashes, PEP 740 build provenance, the registry's true latest, and the OSV batch |
 | **GitHub Actions** | no lockfile and no artifact hash, so Phase 1 becomes a pin question — is it a SHA or a movable tag, and which way has that tag moved. Every later phase has an actions method too: GHSA for advisories, scope analysis where a gate cannot be run, run history where nothing can be installed |
+| **`pre-commit`** | `scripts/precommit.py`. A `rev:` is a git ref on another repository, so it is a pin question again — and two more besides: what tool version that rev *installs*, which is declared in the hook repo's packaging and is not the tag, and whether the **hook's own definition** moved. The last is the one that pays |
+
+**The hook definition is why this one is here.** `ruff-pre-commit` v0.16.2 →
+v0.16.5 added one word to one list — `ruff-format`'s `types_or` gained
+`markdown` — and the hook began rewriting every Markdown file in the repository.
+`ruff` itself did not change in any way its changelog reports, so a per-package
+view of `ruff` returns *current* and *clean*, correctly, about the wrong
+artifact. That bump is this repository's own #99, and finding the cause by hand
+took a day; the script isolates it to the field in one call.
 
 **npm, Cargo and Go are out of scope** — not unimplemented, out of scope. Their
 recipes were removed rather than left as sketches, on this file's own rule: an
@@ -134,6 +144,7 @@ inside the procedure, so a run loads the recipe it needs and not the other one:
 | `SKILL.md` | always — the phases, their gates, the Phase 0 outputs, the verdict table |
 | `references/uv-lock.md` | when the PR is a `uv.lock` bump |
 | `references/actions.md` | when the PR is an actions bump |
+| `references/pre-commit.md` | when the PR is a `.pre-commit-config.yaml` bump |
 | `references/report-template.md` | always, at Phase 7 |
 
 There is no general "traps" reference. There was until 0.17.0, and measuring it
@@ -141,9 +152,9 @@ is what retired it: across two cold runs it was **never fetched**, because a
 phase that ends *"`traps.md` has the reasoning"* does not make a model go and
 read it, where a method table saying *"`references/actions.md` § Phase 1"* does.
 By then each of its sections had been absorbed anyway — into the scripts, into
-the two ecosystem files, or into `SKILL.md` itself.
+the ecosystem files, or into `SKILL.md` itself.
 
-The two ecosystem files are **sectioned by phase**, and that is a constraint
+The ecosystem files are **sectioned by phase**, and that is a constraint
 rather than tidiness: the prose suite attributes a command to the phase whose
 heading it sits under, which is the check that has caught three shipped
 forward-reference defects. It also asserts that every handoff *lands* — a phase
@@ -235,7 +246,7 @@ to detect. They fall into ten groups:
   `cked.txt`, reporting a path that never existed as deleted while the real
   deletion went unreported.
 - **Ecosystem coverage** — no phase from 1 to 6 may be written for only one of
-  the two supported ecosystems, Phase 3 must name an advisory source for actions,
+  the supported ecosystems, Phase 3 must name an advisory source for actions,
   and it must keep the measured case behind the OSV version trap. This group
   exists because *"not applicable" is an assertion too*: three places in this repo
   stated that GitHub Actions has no vulnerability database, and GHSA carries an

--- a/integration/test_precommit_replay.py
+++ b/integration/test_precommit_replay.py
@@ -1,0 +1,124 @@
+"""The live half of `precommit.py`, against the two bumps it was written for.
+
+The hermetic suite in `tests/test_precommit.py` drives the real parsing and
+comparison against **trimmed** fixtures, which is what makes it cheap and
+trustworthy on every commit. What it cannot establish is that the fixtures still
+resemble the files: `.pre-commit-hooks.yaml` is written by four different
+projects that agree on nothing cosmetic, and the grammar this parser accepts was
+derived by reading theirs.
+
+So this is the same two cases against the real repositories:
+
+    ruff-pre-commit  v0.16.2 -> v0.16.5   ruff-format.types_or gained `markdown`
+    mirrors-mypy     v2.3.0  -> v2.3.1    nothing moved
+
+Both are historical tags on public repositories, so this does not drift -- and
+both are this repository's own #99 and #98, the PRs #109 was filed from. The
+first is a real defect the verifier must catch and the second a clean bump it
+must not flag; a check that only ever fires proves as little as one that never
+does.
+
+    RUN_NETWORK_TESTS=1 python3 -m unittest discover -s integration -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import pathlib
+import sys
+import unittest
+from typing import Any
+from unittest import mock
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
+)
+
+from precommit import main
+
+NETWORK = os.environ.get("RUN_NETWORK_TESTS") == "1"
+
+
+@unittest.skipUnless(NETWORK, "set RUN_NETWORK_TESTS=1 to run (needs `gh` and the network)")
+class TestTheRealBumpsStillReadTheSameWay(unittest.TestCase):
+    def _audit(self, repo: str, old: str, new: str) -> tuple[int, dict[str, Any]]:
+        argv = [
+            "precommit.py", "--repo", repo, "--from", old, "--to", new, "--json",
+        ]  # fmt: skip
+        out = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(out):
+            try:
+                code: int | str | None = main()
+            except SystemExit as exc:
+                code = exc.code
+        return int(code or 0), json.loads(out.getvalue())
+
+    def test_the_ruff_wrapper_change_is_found_in_the_real_file(self):
+        """#99. One word, in one list, in a file nobody diffs.
+
+        Asserted on the real `.pre-commit-hooks.yaml` rather than the trimmed
+        fixture, because the fixture is only evidence that the parser reads what
+        was copied out of the file on the day it was written.
+        """
+        code, report = self._audit("astral-sh/ruff-pre-commit", "v0.16.2", "v0.16.5")
+        self.assertEqual(code, 1)
+        rows = [r for r in report["hooks"] if r["kind"] == "behavioural"]
+        self.assertEqual(
+            [(r["hook"], r["field"]) for r in rows],
+            [("ruff-format", "types_or")],
+            f"the live comparison no longer isolates the field: {report['hooks']}",
+        )
+        self.assertIn("markdown", rows[0]["after"])
+        self.assertNotIn("markdown", rows[0]["before"])
+
+    def test_the_tool_version_comes_from_the_hook_repos_packaging(self):
+        """`ruff-pre-commit` declares `ruff==0.16.5` in `pyproject.toml`. Phase 2
+        queries that, never the tag -- `v0.16.5` is not a PyPI version of
+        anything, and a query built from it comes back empty."""
+        _, report = self._audit("astral-sh/ruff-pre-commit", "v0.16.2", "v0.16.5")
+        got = report["requirement_to"]
+        self.assertEqual(got["source"], "pyproject.toml")
+        self.assertEqual([(s["name"], s["version"]) for s in got["specs"]], [("ruff", "0.16.5")])
+        self.assertEqual(report["language"], "python", "which is what makes it covered")
+
+    def test_the_mypy_mirror_bump_is_clean(self):
+        """#98, and the half that keeps the signal readable. This is the bump
+        whose report said "a Hold I would not defend on the merits, only on the
+        procedure" -- the procedure now has something to say about it."""
+        code, report = self._audit("pre-commit/mirrors-mypy", "v2.3.0", "v2.3.1")
+        self.assertEqual(code, 0, f"a clean bump was flagged: {report['hooks']}")
+        self.assertEqual(report["hooks"], [])
+        self.assertEqual(report["requirement_to"]["source"], "setup.py")
+        self.assertEqual(report["requirement_to"]["specs"][0]["version"], "2.3.1")
+
+    def test_the_quoting_only_release_is_not_a_change(self):
+        """`mirrors-mypy` restyled `name: mypy` to `name: 'mypy'` between v1.18.2
+        and v2.3.1. Read as a field change it is noise on the row a reader uses
+        to decide whether the wrapper moved at all."""
+        code, report = self._audit("pre-commit/mirrors-mypy", "v1.18.2", "v2.3.1")
+        self.assertEqual(code, 0, f"quoting was reported as a change: {report['hooks']}")
+
+    def test_the_parser_accepts_all_four_live_shapes(self):
+        """Two-space and four-space continuations, quoted keys, and a folded
+        scalar -- one from each of four mirrors that agree on nothing cosmetic.
+        `Unparsed` here means the grammar has fallen behind a real file, which is
+        the failure this test exists to notice."""
+        from precommit import parse_hooks, read_at
+
+        for repo, rev, expected in (
+            ("astral-sh/ruff-pre-commit", "v0.16.5", "ruff-format"),
+            ("pre-commit/mirrors-mypy", "v2.3.1", "mypy"),
+            ("pre-commit/mirrors-prettier", "v4.0.0-alpha.8", "prettier"),
+            ("psf/black-pre-commit-mirror", "25.1.0", "black-jupyter"),
+        ):
+            with self.subTest(repo=repo):
+                text = read_at(repo, ".pre-commit-hooks.yaml", rev)
+                self.assertIsNotNone(text, f"{repo}@{rev} has no hooks file")
+                self.assertIn(expected, parse_hooks(text or ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,6 @@ exclude = ["integration/fixtures"]
 # override then disappears with no warning, not even under
 # --warn-unused-configs (tested: errors went 25 -> 175). Adding a test file
 # means adding it here; forgetting is loud, which is the safer direction.
-module = ["test_audit", "test_changelog", "test_ci_state", "test_cleanup", "test_discover", "test_gate_diff", "test_plugin_layout", "test_skill_prose", "test_ruff_replay", "test_live_registry", "test_live_changelog_sources"]
+module = ["test_audit", "test_changelog", "test_ci_state", "test_cleanup", "test_discover", "test_gate_diff", "test_plugin_layout", "test_precommit", "test_skill_prose", "test_ruff_replay", "test_precommit_replay", "test_live_registry", "test_live_changelog_sources"]
 disallow_untyped_defs = false
 disallow_untyped_calls = false

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dependabot-audit
-description: Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation — verify lockfile artifact hashes against the registry, cross-check the true latest version, read changelogs for security and behavior changes, reproduce the repo's own checks in an isolated worktree, and report. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary rather than an improvised recipe. Use when the user asks to review, audit, check, or decide on a Dependabot or Renovate PR, a dependency bump, a lockfile PR, or asks "is this safe to merge".
+description: Audit an automated dependency-bump PR and produce an evidence-backed merge recommendation — verify lockfile artifact hashes against the registry, cross-check the true latest version, read changelogs for security and behavior changes, reproduce the repo's own checks in an isolated worktree, and report. Verifies uv.lock, GitHub Actions and pre-commit hooks end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary rather than an improvised recipe. Use when the user asks to review, audit, check, or decide on a Dependabot or Renovate PR, a dependency bump, a lockfile PR, or asks "is this safe to merge".
 disallowed-tools: Edit, Write, NotebookEdit
 ---
 
@@ -297,7 +297,7 @@ discarded unread rather than saved.
 | `$CREATED_AT` | when the PR was opened, ISO-8601. **Phase 2 compares release publish times against it** — the cooldown asks whether a release was three days old *then*, not now |
 | `$BRANCH_POINT` | `ok`, `rewritten`, `suspect` or `underivable` — **the tip-worktree block below gates on it**, and the table there says what each one means |
 | `$MAY_EXECUTE` | `yes` or `no` — **Phases 4 and 5 gate on it**, and the gate tests for `yes` so an unset value refuses. The classification below is what sets it |
-| `$ECOSYSTEM` | `uv.lock`, `github-actions`, `unsupported`, `unknown` or `underivable` — **which Phase 1, 3, 4 and 5 method applies**, derived from the files the bump changed rather than inferred from the PR |
+| `$ECOSYSTEM` | `uv.lock`, `github-actions`, `pre-commit`, `unsupported`, `unknown` or `underivable` — **which Phase 1, 3, 4 and 5 method applies**, derived from the files the bump changed rather than inferred from the PR |
 | `$SCOPE_GATE` | `clean`, `beyond` or `underivable` — **Phase 1's gate, already decided** from the bot's own commits. That is the invariant the gate is about, and it is why `$BOT_COMMITS` does not cross: the loop that consumed it is now the script's |
 | `$HUMAN_COMMITS` | every non-bot commit on the branch, merges included. Its files are a **finding to report**, never a Hold |
 
@@ -621,8 +621,10 @@ sectioned by phase, so read the section for this one:
 |---|---|
 | `uv.lock` | `references/uv-lock.md` § Phase 1 — `scripts/audit.py` verifies every pinned artifact's hash, size, URL and yank status against the live registry, plus PEP 740 build provenance |
 | GitHub Actions | `references/actions.md` § Phase 1 — no lockfile and no artifact hash, so the question becomes whether the pin is **immutable**: a 40-hex SHA, or a tag someone else can revoke. The scope gate keys on `uses:` lines, never on a count of files |
+| `pre-commit` | `references/pre-commit.md` § Phase 1 — a `rev:` is a git ref on another repository: no hash either, so immutability again. `scripts/precommit.py` also resolves what the rev *installs*, which is declared in the hook repo's packaging and is not the tag. The scope gate keys on `rev:` lines |
 
-**This plugin covers `uv.lock` and GitHub Actions, and nothing else.** For any
+**This plugin covers `uv.lock`, GitHub Actions and `pre-commit`, and nothing
+else.** For any
 other ecosystem, say so and stop. Do not improvise a procedure from the shape of
 the ones that are here: an unverified verifier reports green rather than erroring,
 which is why npm, Cargo and Go were removed rather than left as sketches.
@@ -659,6 +661,15 @@ was the true latest of both the mirror and the tool it pins, and the advisory
 databases were empty at every version, which is most of what a reader weighing a
 boundary Hold has to go on.
 
+**That particular bump is no longer on this path**: `pre-commit` became a covered
+ecosystem in 0.38.0, which is what the run was arguing for (#109). The rule
+survives its own example, because the next uncovered ecosystem arrives the same
+way — and the reason it was worth covering rather than leaving here is exactly
+the enumeration above. Phases 2 and 3 were reaching a real answer by hand every
+month, on the half of this repository's own bump traffic that landed on the
+boundary, and a monthly Hold nobody can act on trains the reader to discount the
+gate.
+
 ## Phase 2 — Currency
 
 *Requires from Phase 0: `$CREATED_AT`. Plus the Phase 1 script output.*
@@ -676,6 +687,15 @@ a moving major tag picks up new releases on its own, so a newer patch is not a
 gap. `references/actions.md` § Phase 2 has the `compare` that separates a tag
 that merely moved *ahead* from one that rolled **behind**, which is the case a
 bot cannot fix because it cannot propose a downgrade.
+
+**For `pre-commit` it is two questions, and the tag answers neither.** The
+`rev:` is a ref on the hook repository; the version that gets installed is
+declared inside that repository, and `scripts/precommit.py` has already resolved
+it. Ask the registry about **that**, never about the rev — `v0.16.5` is not a
+PyPI version of anything, so a query built from the tag returns an empty result
+that reads exactly like *current and clean*. `references/pre-commit.md` § Phase 2
+also says which registries this leaves covered: a `language: python` hook is
+PyPI and verified end to end, and anything else is the boundary again.
 
 Rule out the innocent explanations before reporting a gap: a yanked release; a
 **cooldown** (`cooldown:` in `dependabot.yml`, `minimumReleaseAge` in
@@ -792,6 +812,7 @@ contradiction. The method differs by ecosystem; the question does not.
 
 | Ecosystem | Method |
 |---|---|
+| `pre-commit` | `references/pre-commit.md` § Phase 3 — query the **package the hook installs**, never the `rev:`. `v0.16.5` is not a PyPI version of anything, so a query built from the tag comes back empty and reads exactly like *no known vulnerabilities* |
 | `uv.lock` | `references/uv-lock.md` § Phase 3 — the OSV batch is **already done** by the Phase 1 script, so read that result rather than re-querying; what remains is the ecosystem's own auditor — and the obvious invocation of it **executes the PR's code**, in a phase `--no-execute` runs |
 | GitHub Actions | `references/actions.md` § Phase 3 — GHSA carries an `actions` ecosystem, and the obvious port of the `uv.lock` query reports **clean on a known-compromised action** |
 
@@ -817,6 +838,7 @@ the section for it is below.
 
 | Ecosystem | Method |
 |---|---|
+| `pre-commit` | `references/pre-commit.md` § Phase 4 — **the hook definition is where the behaviour lives.** `scripts/precommit.py` diffs `.pre-commit-hooks.yaml` between the two revs field by field; then measure the blast radius in this repo, because the hook says what it now *selects* and not how much of this tree that is |
 | `uv.lock` | `references/uv-lock.md` § Phase 4 — **measure it.** `scripts/gate_diff.py` runs each gate at the locked, proposed and latest versions in `$SCRATCH/base-<N>` and compares what each run *did to the files* |
 | GitHub Actions | `references/actions.md` § Phase 4 — an action cannot be run locally at two versions, so the method is reading the release notes **and then establishing whether this repo's workflows are in the change's scope at all** |
 
@@ -874,6 +896,7 @@ else — and "no reproduction available" is a result to report, not a phase to s
 | Ecosystem | Method |
 |---|---|
 | `uv.lock` | `references/uv-lock.md` § Phase 5 — install **frozen** and run the repo's own gates and suite in `$SCRATCH/pr-<N>` |
+| `pre-commit` | `references/pre-commit.md` § Phase 5 — `pre-commit run --all-files` in `$SCRATCH/pr-<N>`, which is usually the whole of CI's lint job. **Not hermetic**: it installs each hook's environment from the network at run time, so say what that green is worth beside a frozen install |
 | GitHub Actions | `references/actions.md` § Phase 5 — nothing to install and no way to run an action off GitHub's runners, so the substitute is **evidence that this pin has already run**: the history of the workflow the bump changed |
 
 Phase 0 built the worktree and proved it points at `$HEAD_SHA`, so the user's

--- a/skills/dependabot-audit/references/pre-commit.md
+++ b/skills/dependabot-audit/references/pre-commit.md
@@ -1,0 +1,210 @@
+# pre-commit
+
+The per-phase method for a `.pre-commit-config.yaml` bump. `SKILL.md` carries each
+phase's *question*, its gate, and the outputs it consumes; this file carries how
+to answer it for this ecosystem, and nothing else.
+
+Sectioned by phase deliberately, and the headings are load-bearing: the prose
+suite attributes a bash block to the phase whose heading it sits under, and that
+is the check which has caught three shipped forward-reference defects. A section
+retitled out of that shape takes its guard with it.
+
+**A `rev:` is a git ref on somebody else's repository, and it is neither a hash
+nor a version.** That single fact reshapes three phases:
+
+- there is no artifact to verify, so Phase 1 asks whether the pin is *immutable*
+  rather than whether it is *intact* — the same substitution `references/actions.md`
+  makes for `uses:`;
+- the version that gets installed is declared **inside the hook repository**, not
+  in the config, so Phases 2 and 3 must be pointed at that and not at the tag;
+- the hook's own definition can change between two revs while the tool it wraps
+  does not change at all — and that is where the defect this ecosystem was added
+  for actually lived.
+
+`scripts/precommit.py` answers all three in one call. Run it; the reasons are the
+same as everywhere else here, and one of them is specific to this ecosystem: the
+comparison it makes is against **someone else's YAML**, which is the input shape
+least entitled to be assumed well-formed.
+
+## The measurement this ecosystem exists for
+
+`ruff-pre-commit` v0.16.2 → v0.16.5, on this plugin's own repository (#99):
+
+```
+!! ruff-format.types_or  [behavioural]
+     before: [python, pyi, jupyter]
+     after:  [python, pyi, jupyter, markdown]
+```
+
+One word, in one list, in a file nobody diffs. The hook began rewriting every
+Markdown file in the repository and CI went red. **`ruff` itself did not change in
+any way its changelog reports** — the release notes for 0.16.3 through 0.16.5 say
+nothing about this, because the change is not in `ruff`, it is in the wrapper that
+invokes it. A per-package currency check of `ruff` returns *current*; an advisory
+query returns *clean*; both are correct and both are answering about the wrong
+artifact.
+
+That is the failure mode. Everything below exists to make it visible in one
+command instead of a day.
+
+## Phase 1 — Scope and provenance
+
+**Phase 0 already derived the gate.** `discover.py` classifies a bump touching
+`.pre-commit-config.yaml` as `ECOSYSTEM=pre-commit` and reads the diff's *lines*,
+exactly as it does for `uses:`: every changed line must be a `rev:` line or a
+comment. Read `$SCOPE_GATE`; do not re-derive one here.
+
+The rule is deliberately narrow. A diff that also moves `args:`,
+`additional_dependencies:` or `repo:` is **`beyond`** — those change what the hook
+does, and a version bump may not do that quietly. `repo:` in particular repoints
+the hook at a different repository, which is not a bump at all.
+
+**There is no artifact hash, and the report must not imply one.** What the script
+establishes is *immutability*, in three states:
+
+| `rev:` | Pin | What it means |
+|---|---|---|
+| a 40-hex SHA | **immutable** | nobody can repoint it. This is what `pre-commit autoupdate --freeze` writes |
+| a tag or branch | **mutable** | what was audited is what runs *today*. Not a Hold: the pin was mutable before this PR and the bump did not make it so |
+| resolves to nothing | **underivable** | exit 2. A pin naming nothing is not a pin, and this is a finding about the config rather than the bump |
+
+Nearly every config in the wild is the middle row, because `autoupdate` writes
+tags by default. So it is reported and it does **not** set the exit code — a
+signal that fires on every run is one the reader stops reading, which is the same
+reasoning `references/actions.md` reaches for a `uses:` tag pin.
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# The hook repo and both revs come out of the diff, which is one file and a
+# handful of lines. Read them; do not take the versions off the PR title, which
+# a grouped bump does not name.
+git diff -U3 "$BASE_SHA...pr-<N>" -- '**/.pre-commit-config.yaml'
+
+P="${SCRIPTS:?not in the handoff — re-run Phase 0}/precommit.py"
+python3 "$P" --repo <owner>/<name> --from <old rev> --to <new rev> \
+  --hook <every hook id this repo actually enables>
+```
+
+**Exit 2 means it could not run; exit 1 means it ran and found something.** Never
+read one as the other.
+
+`--hook` narrows the comparison to the hooks the audited repo enables, and it is
+worth passing. `ruff-pre-commit` ships three hooks and a repo typically runs two;
+a report naming a field that moved on a hook nobody runs is noise in the row a
+reader uses to size the blast radius.
+
+## Phase 2 — Currency
+
+**Two questions, and a bot PR answers neither.** The `rev:` and the tool version
+are different things, and a bump can be current in one and stale in the other.
+
+1. **Is this the newest rev of the hook repository?** `gh api repos/<o>/<n>/tags`.
+2. **Is the tool version it installs the newest of the tool?** This is the one
+   that matters, and the script has already derived it — `installs at to` names
+   the package and version out of the hook repo's own packaging.
+
+Take answer 2 to the registry the tool actually lives in, and **check which one
+that is before you do**:
+
+| Hook `language` | Registry | Covered here |
+|---|---|---|
+| `python` | PyPI | **yes** — hand the package and version to `scripts/audit.py` and `scripts/changelog.py`, which verify it end to end |
+| anything else | npm, rubygems, crates.io … | **no.** Report the boundary. Do not improvise a recipe from the shape of the PyPI one |
+
+The script prints the language and says which of those two rows applies. This is
+the whole of #109's argument: for a Python hook, resolving the requirement puts
+Phases 2 and 3 back on **covered** ground rather than the hand-run footing a
+boundary Hold leaves them on. For a node hook it does not, and saying so is the
+point of naming it.
+
+**Where the two answers disagree, say which one you checked.** A mirror can lag
+the tool it mirrors by days. `mirrors-mypy` and `ruff-pre-commit` both release
+within hours, so the gap is usually zero — and "usually zero" is a reason to read
+the number, not to assume it.
+
+**A tag that looks like a version is making a claim.** The script compares it
+against the packaging pin and reports a disagreement as a finding, because a
+reader takes `rev: v0.16.5` to mean the tool is 0.16.5 and nothing enforces that.
+It makes the comparison only where the tag is shaped like a dotted version: a
+branch pin, a SHA pin, or a mirror whose tags do not track the tool would
+otherwise disagree on every single bump.
+
+## Phase 3 — Known vulnerabilities
+
+Same as `uv.lock`, on the requirement rather than the tag: OSV and GHSA, queried
+for the **package the hook installs** at the version being adopted.
+
+`v0.16.5` is not a PyPI version of anything, so a query built from the `rev:`
+returns an empty result that reads exactly like *no known vulnerabilities*. That
+is the failure this phase is most exposed to here, and it is silent.
+
+Where the language is not `python`, the ecosystem is outside this plugin: report
+that the advisory check was not made, rather than making one whose result you
+cannot stand behind.
+
+## Phase 4 — Behavior change
+
+**This is the phase, and the hook definition is where it lives.** Diff
+`.pre-commit-hooks.yaml` between the two revs — which is what the script did in
+Phase 1, so read its output rather than re-fetching.
+
+A field is **behavioural** when it changes which files the hook touches or what it
+runs on them: `entry`, `args`, `language`, `files`, `exclude`, `types`,
+`types_or`, `exclude_types`, `additional_dependencies`, `pass_filenames`,
+`stages`, `always_run`, `require_serial`. A field the script does not recognise
+counts as behavioural too, deliberately: `pre-commit` gains keys, and a new
+selector must not arrive as cosmetic because a list predates it.
+
+**The hook says what it now selects. It does not say how much of this repo that
+is** — and the report needs the second. That measurement is in the audited tree,
+so it takes `$MAY_EXECUTE` like the rest of Phase 4:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+[ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
+
+# Check mode, both revs, against the SAME tree. `--all-files` and never a commit:
+# the question is what the hook selects now, not what a commit happened to touch.
+git -C "$SCRATCH/base-<N>" ls-files | wc -l          # the denominator, stated
+( cd "$SCRATCH/base-<N>" && pre-commit run <hook id> --all-files )
+( cd "$SCRATCH/pr-<N>"   && pre-commit run <hook id> --all-files )
+```
+
+Report the difference between those two runs, by **file class and counted from a
+command** — `report-template.md` is explicit that a count attributed to a class of
+file has to come from one, and this is the phase that tempts the split.
+
+**A gate that rewrites files the repo excludes has defeated the exclusion**, and
+`SKILL.md`'s Phase 4 says what is owed then: two check-only runs, one at the
+nearest config and one forced to the root manifest, because a nested config
+shadows the root for files beneath it. That rule came from this exact bump.
+
+## Phase 5 — Independent reproduction
+
+`pre-commit run --all-files` in `$SCRATCH/pr-<N>`, which is the repo's own gate
+and usually the whole of CI's lint job.
+
+**It is not hermetic, and the report must say so.** `pre-commit` builds each
+hook's environment by installing from the network at run time, so a green run
+proves the hook works *with what the registry served just now*. That is weaker
+than `uv.lock`'s frozen install and stronger than nothing; name the distinction
+rather than letting "the gate passed" carry the same weight in both ecosystems.
+
+Two failure shapes worth separating in the report, because they have different
+verdicts:
+
+| Result | Reading |
+|---|---|
+| the hook **fails** on files it also failed on at the base | pre-existing. A real finding and a different one; not a Hold on this bump |
+| the hook **fails** on files that passed at the base | the behaviour change from Phase 4, measured. This is the Hold |
+| `pre-commit` cannot build the environment at all | **exit 2 territory** — could not run. Do not report it as the hook failing |
+
+The third row is the one that gets misread, and it is common: a hook whose
+`language: node` needs a node toolchain the machine may not have. "Could not run"
+reported as "ran and found something" is the distinction this whole procedure is
+most careful about everywhere else.

--- a/skills/dependabot-audit/scripts/audit.py
+++ b/skills/dependabot-audit/scripts/audit.py
@@ -417,7 +417,7 @@ class UnsupportedLockfile(ValueError):
 
 
 # Signatures for the lockfiles this plugin does **not** audit. Since 0.8.0 the
-# supported surface is `uv.lock` and GitHub Actions, so this message is the edge
+# supported surface is `uv.lock`, GitHub Actions and `pre-commit`, so this is the edge
 # of the tool and the first thing anyone arriving with a different lockfile
 # sees. Pointed at a real `Cargo.lock` it used to say `unexpected AttributeError
 # ... This is a bug, not a finding` — every part of that right except the
@@ -442,7 +442,8 @@ PNPM_LOCK = re.compile(r"^lockfileVersion: ", re.MULTILINE)
 def _boundary(path: str, what: str) -> str:
     return (
         f"{path} is {what}.\n"
-        "       This plugin audits uv.lock and GitHub Actions, and nothing else.\n"
+        "       This plugin audits uv.lock, GitHub Actions and pre-commit, and\n"
+        "       nothing else.\n"
         "       npm, Cargo and Go recipes were removed rather than left as sketches:\n"
         "       an unverified verifier reports green instead of erroring. Report what\n"
         "       the ecosystem-independent phases established and say what was not\n"

--- a/skills/dependabot-audit/scripts/discover.py
+++ b/skills/dependabot-audit/scripts/discover.py
@@ -68,6 +68,11 @@ UNDERIVABLE = "underivable"
 MANIFESTS = frozenset({"uv.lock", "pyproject.toml"})
 WORKFLOW_DIRS = (".github/workflows/", ".github/actions/")
 
+# Matched on the basename: `pre-commit` does not require the file at the repo
+# root, and one per package is ordinary. A full-path match misses those and the
+# bump falls back to `unknown`, which reports as a scope finding.
+PRE_COMMIT_CONFIG = ".pre-commit-config.yaml"
+
 # Named rather than lumped into "unknown": a Cargo bump is a **boundary**, and
 # reporting it as a scope finding says the bump reached into source when what
 # happened is that this plugin has no rule for it. An improvised recipe returned
@@ -93,6 +98,14 @@ FILES_CAP = 300
 # version comment. That is the invariant." Not the number of files — a grouped
 # bump moves several actions and an action is pinned in every workflow using it.
 USES_LINE = re.compile(r"^\s*-?\s*uses:\s*\S+\s*(#.*)?$")
+
+# `pre-commit`'s equivalent, and the gate is the same shape: a bump may move the
+# pin and nothing else. `\S+` covers the quoted forms and the `# frozen: <sha>`
+# comment `pre-commit autoupdate --freeze` writes.
+#
+# Deliberately not `repo:`. Repointing a hook at a different repository is not a
+# version bump, and it is exactly what this gate should refuse to wave through.
+REV_LINE = re.compile(r"^\s*rev:\s*\S+\s*(#.*)?$")
 
 # The trailing version comment is not always trailing. A compiler that emits
 # workflows records the pins it wrote in a header block, so a correct bump
@@ -407,7 +420,8 @@ def _ecosystem(names: list[str]) -> tuple[str, str]:
         if base in UNSUPPORTED_LOCKFILES:
             return "unsupported", (
                 f"the diff carries a {base} ({UNSUPPORTED_LOCKFILES[base]}). This plugin "
-                "verifies uv.lock and GitHub Actions end to end and nothing else — report "
+                "verifies uv.lock, GitHub Actions and pre-commit end to end and nothing "
+                "else — report "
                 "that boundary, and do not improvise a recipe from the shape of the ones "
                 "that are here"
             )
@@ -415,7 +429,66 @@ def _ecosystem(names: list[str]) -> tuple[str, str]:
         return "uv.lock", ""
     if all(filename.startswith(WORKFLOW_DIRS) for filename in names):
         return "github-actions", ""
+    # After both, and the order is the answer to a real case: a repo that pins
+    # its tools in `uv.lock` *and* runs them through pre-commit gets the
+    # ecosystem with the artifact hashes, which is the stronger Phase 1 method.
+    if any(filename.rsplit("/", 1)[-1] == PRE_COMMIT_CONFIG for filename in names):
+        return "pre-commit", ""
     return "unknown", ""
+
+
+# The two ecosystems whose pin is a *line* rather than a file. Both gates are the
+# same shape and differ only in which line is allowed, so they share `_line_gate`
+# below: an action is `uses:`, a pre-commit hook is `rev:`.
+PIN_LINE = {"github-actions": ("`uses:`", USES_LINE), "pre-commit": ("`rev:`", REV_LINE)}
+
+
+def _line_gate(
+    files: list[dict[str, Any]], ecosystem: str, common: dict[str, Any]
+) -> dict[str, Any]:
+    """Phase 1's gate for an ecosystem pinned by a line, not by a file.
+
+    The lockfile rule reads names; this one reads *lines*, so this is the only
+    shape that needs the patch — and a withheld patch is therefore only
+    underivable here.
+    """
+    what, pattern = PIN_LINE[ecosystem]
+    withheld = [entry.get("filename") or "" for entry in files if entry.get("patch") is None]
+    if withheld:
+        return {
+            "verdict": UNDERIVABLE,
+            "ecosystem": ecosystem,
+            "beyond": [],
+            "why": (
+                f"the API withheld the patch for {', '.join(sorted(withheld))} — binary, "
+                "or past its size limit. No lines to read is not 'no lines beyond the pin'"
+            ),
+            **common,
+        }
+    beyond = []
+    comments = 0
+    for entry in files:
+        for line in _changed_lines(entry.get("patch") or ""):
+            if pattern.match(line):
+                continue
+            if COMMENT_LINE.match(line):
+                comments += 1
+                continue
+            beyond.append(f"{entry.get('filename')}: {line.strip()}")
+    return {
+        **common,
+        "verdict": "beyond" if beyond else "clean",
+        "ecosystem": ecosystem,
+        "beyond": beyond,
+        # After the spread: `common` carries the 0 every other branch wants, and a
+        # key repeated in a literal takes its last value.
+        "comment_lines": comments,
+        "why": (
+            f"a changed line is neither a {what} pin nor a comment"
+            if beyond
+            else f"every changed line across every file is a {what} line or a comment"
+        ),
+    }
 
 
 def scope(files: list[dict[str, Any]] | None, source: str) -> dict[str, Any]:
@@ -464,46 +537,8 @@ def scope(files: list[dict[str, Any]] | None, source: str) -> dict[str, Any]:
             **common,
         }
 
-    if ecosystem == "github-actions":
-        # The lockfile rule reads names; this one reads *lines*, so this is the
-        # only branch that needs the patch — and a withheld patch is therefore
-        # only underivable here.
-        withheld = [entry.get("filename") or "" for entry in files if entry.get("patch") is None]
-        if withheld:
-            return {
-                "verdict": UNDERIVABLE,
-                "ecosystem": ecosystem,
-                "beyond": [],
-                "why": (
-                    f"the API withheld the patch for {', '.join(sorted(withheld))} — binary, "
-                    "or past its size limit. No lines to read is not 'no lines beyond the pin'"
-                ),
-                **common,
-            }
-        beyond = []
-        comments = 0
-        for entry in files:
-            for line in _changed_lines(entry.get("patch") or ""):
-                if USES_LINE.match(line):
-                    continue
-                if COMMENT_LINE.match(line):
-                    comments += 1
-                    continue
-                beyond.append(f"{entry.get('filename')}: {line.strip()}")
-        return {
-            **common,
-            "verdict": "beyond" if beyond else "clean",
-            "ecosystem": ecosystem,
-            "beyond": beyond,
-            # After the spread: `common` carries the 0 every other branch wants,
-            # and a key repeated in a literal takes its last value.
-            "comment_lines": comments,
-            "why": (
-                "a changed line is neither a `uses:` pin nor a comment"
-                if beyond
-                else "every changed line across every file is a `uses:` line or a comment"
-            ),
-        }
+    if ecosystem in PIN_LINE:
+        return _line_gate(files, ecosystem, common)
 
     beyond = [n for n in names if n.rsplit("/", 1)[-1] not in MANIFESTS]
     if not beyond:

--- a/skills/dependabot-audit/scripts/precommit.py
+++ b/skills/dependabot-audit/scripts/precommit.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Phases 1-4 for a `pre-commit` bump: what a `rev:` actually pins, and what moved.
+
+A hook `rev:` is a git ref on **someone else's repository**, and that is the whole
+difficulty. It is not a hash, so there is no artifact to verify; and it is not the
+tool's version either, so a per-package currency check answers a question nobody
+asked. Three things have to be derived before any other phase has an input:
+
+  pin          what the `rev:` resolves to, and whether it is immutable. A 40-hex
+               SHA is; a tag is not, and `pre-commit autoupdate` writes tags. Same
+               question `references/actions.md` asks of a `uses:` pin
+  requirement  the tool version the hook repo *installs* at that rev, read from
+               its packaging metadata. `mirrors-mypy` pins `mypy==2.3.1` in
+               `setup.py`; `ruff-pre-commit` pins `ruff==0.16.5` in
+               `pyproject.toml`. THIS is the dependency, and it is what Phases 2
+               and 3 query -- which puts them back on covered ground
+  hooks        `.pre-commit-hooks.yaml` at both revs, diffed field by field
+
+**The third is the one that earns this script.** Measured on `ruff-pre-commit`
+v0.16.2 -> v0.16.5: `ruff-format`'s `types_or` gained `markdown`, so the hook began
+rewriting every Markdown file in the repository. `ruff` itself did not change in
+any way a changelog reports, and no per-package view of `ruff` could have surfaced
+it -- the defect lived entirely in the wrapper. That bump went red in CI on this
+repo, and the cause was one word in a list.
+
+Not a lockfile procedure with the names changed. There is no artifact hash here
+and this script does not pretend otherwise: `pin` reports immutability, never
+integrity. Phase 1's boundary language applies to the difference, and
+`references/pre-commit.md` says which claims survive it.
+
+Exit status: 0 = nothing to report, 1 = a behavioural field moved or the rev and
+the requirement disagree, 2 = could not run. A cosmetic field moving is reported
+and is not a finding; a mutable pin is reported and is not one either, because
+every `pre-commit` pin is a tag and a signal that fires on every run is one
+nobody reads.
+
+    precommit.py --repo OWNER/NAME --from REV --to REV [--hook ID]... [--json]
+
+Requires Python 3.11+ (tomllib), `gh`, and network access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from typing import Any, NoReturn
+
+TIMEOUT = 60
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+
+# A tag shaped like a dotted version, which is a tag making a claim about one.
+VERSIONISH = re.compile(r"^\d+(\.\d+)+")
+
+
+def _pyproject(text: str) -> list[str]:
+    return [str(d) for d in (tomllib.loads(text).get("project") or {}).get("dependencies") or []]
+
+
+# Where a hook repo records the tool version it installs, **in the order tried**,
+# and the order is load-bearing: a repo carrying both gets the modern one. Both
+# shapes are live -- `ruff-pre-commit` ships the first, every `pre-commit/
+# mirrors-*` repo ships the second.
+#
+# A tuple of (filename, parser) rather than a tuple of names beside a hardcoded
+# sequence of reads. The earlier version was the latter, and flipping the
+# constant changed nothing: it looked like it drove the lookup and only fed an
+# error message. A mutation run is what showed that, by passing.
+PACKAGING: tuple[tuple[str, Any], ...] = ()
+
+HOOKS_FILE = ".pre-commit-hooks.yaml"
+
+# Fields that change **what runs**. Everything else is presentation.
+#
+# An unknown field counts as behavioural, deliberately: `pre-commit` gains keys,
+# and a new one that selects files or alters the command must not arrive as
+# cosmetic because this list predates it. The safe direction is the noisy one.
+BEHAVIOURAL = frozenset({
+    "entry", "args", "language", "language_version", "files", "exclude",
+    "types", "types_or", "exclude_types", "additional_dependencies",
+    "pass_filenames", "always_run", "require_serial", "stages", "verbose",
+})  # fmt: skip
+
+COSMETIC = frozenset({"id", "name", "description", "alias", "minimum_pre_commit_version"})
+
+
+class Unparsed(Exception):
+    """The hooks file used YAML this parser does not cover.
+
+    Raised rather than guessed. A parser that skips what it does not recognise
+    reports "no fields changed" about a file it did not read, which is the
+    unverified-verifier failure this plugin exists to argue against -- one level
+    down, in a parser rather than a procedure.
+    """
+
+
+def fail(what: str) -> NoReturn:
+    """Exit 2. Reserved for "could not run", never for "ran and found something"."""
+    print(f"error: {what}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _gh(args: list[str]) -> tuple[int, str]:
+    """Run `gh`; return (exit code, stdout). The code is the signal.
+
+    `gh` writes an API error body to **stdout** and exits non-zero, so a capture
+    that reads stdout alone succeeds and holds an error document. Every caller
+    checks the code.
+    """
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["gh", *args],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=TIMEOUT,
+            check=False,
+        )
+    except FileNotFoundError:
+        fail("`gh` is not on PATH")
+    except subprocess.TimeoutExpired:
+        return 1, ""
+    return proc.returncode, proc.stdout
+
+
+def read_at(repo: str, path: str, rev: str) -> str | None:
+    """One file's bytes at one rev, or None when it is not there.
+
+    `Accept: application/vnd.github.raw` rather than the base64 `content` field:
+    a file over the contents endpoint's inline limit returns *no* `content` at
+    all, and a decoder handed the empty string produces the empty file rather
+    than an error.
+    """
+    code, out = _gh([
+        "api", f"repos/{repo}/contents/{path}?ref={rev}",
+        "-H", "Accept: application/vnd.github.raw",
+    ])  # fmt: skip
+    return None if code else out
+
+
+def resolve(repo: str, rev: str) -> dict[str, Any]:
+    """What a `rev:` points at, and whether anyone can move it.
+
+    Three states. `immutable` is a 40-hex SHA written into the config, which is
+    what `pre-commit autoupdate --freeze` produces; `mutable` is a tag or branch,
+    which is what it writes by default and what every ordinary config carries;
+    `underivable` is a ref that would not resolve, which is a finding of its own
+    -- a pin naming nothing is not a pin.
+    """
+    code, out = _gh(["api", f"repos/{repo}/commits/{rev}", "--jq", ".sha"])
+    sha = out.strip()
+    if code or not SHA.match(sha):
+        return {"rev": rev, "sha": "", "pin": "underivable",
+                "why": f"`{rev}` did not resolve to a commit on {repo}"}  # fmt: skip
+    if SHA.match(rev):
+        return {"rev": rev, "sha": sha, "pin": "immutable",
+                "why": "the config pins a commit SHA, which nobody can repoint"}  # fmt: skip
+    return {"rev": rev, "sha": sha, "pin": "mutable",
+            "why": f"`{rev}` is a name, and a name can be repointed at another commit"}  # fmt: skip
+
+
+def requirement(
+    repo: str, rev: str, hooks: dict[str, dict[str, str]] | None = None
+) -> dict[str, Any]:
+    """The tool version the hook repo installs at this rev.
+
+    Read from packaging metadata and never from the tag. They agree by convention
+    and the convention is not enforced: the tag is what the config says, the
+    requirement is what `pre-commit` will install, and a Phase 2 currency check
+    run against the wrong one of those is answering about a different artifact.
+    """
+    for name, parse in PACKAGING:
+        text = read_at(repo, name, rev)
+        if text is None:
+            continue
+        try:
+            found = parse(text)
+        except (SyntaxError, tomllib.TOMLDecodeError) as exc:
+            return {"source": name, "specs": [], "state": "underivable",
+                    "why": f"{name} did not parse: {exc}"}  # fmt: skip
+        if found:
+            return _specs(name, found)
+
+    # Last, and it is a different kind of answer. A node mirror carries no Python
+    # packaging at all and pins its tool in the hook's own
+    # `additional_dependencies`, npm-style. Deriving it is right; calling it
+    # covered is not, which is what `language` is reported for.
+    if hooks is not None:
+        pinned = [
+            item
+            for hook in hooks.values()
+            for item in _flow(hook.get("additional_dependencies", ""))
+        ]
+        if pinned:
+            return _specs(f"{HOOKS_FILE}:additional_dependencies", pinned)
+
+    return {
+        "source": "", "specs": [], "state": "underivable",
+        "why": f"no {' or '.join(n for n, _ in PACKAGING)} at {rev} declared a dependency, and no "
+               "hook pinned one in `additional_dependencies` — the tool version this "
+               "hook installs was not established, so a currency or advisory check "
+               "would be about the tag alone",
+    }  # fmt: skip
+
+
+def _install_requires(source: str) -> list[str] | None:
+    """`install_requires=[...]` out of a `setup.py`, by AST and not by regex.
+
+    Every `pre-commit/mirrors-*` repo is this file and nothing else, so the
+    keyword is reachable without executing anything. A regex over the same text
+    matches the string in a comment as readily as the argument.
+    """
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        for kw in node.keywords:
+            if kw.arg != "install_requires" or not isinstance(kw.value, ast.List):
+                continue
+            out = [e.value for e in kw.value.elts if isinstance(e, ast.Constant)]
+            if len(out) != len(kw.value.elts):
+                return None  # a computed entry: not established, not empty
+            return [str(v) for v in out]
+    return None
+
+
+PACKAGING = (("pyproject.toml", _pyproject), ("setup.py", _install_requires))
+
+
+def _flow(value: str) -> list[str]:
+    """The entries of an inline `[a, b]`, or nothing. Never a partial read."""
+    inner = value.strip()
+    if not (inner.startswith("[") and inner.endswith("]")):
+        return []
+    return [_scalar(item) for item in inner[1:-1].split(",") if item.strip()]
+
+
+def _specs(source: str, raw: list[str]) -> dict[str, Any]:
+    """Split `name==version` requirements, keeping anything that is not one.
+
+    A requirement pinned with `>=` or a marker is reported as `loose` rather than
+    dropped: it means the installed version is not decided by this rev at all,
+    which changes what Phase 2 can claim and is the opposite of a missing answer.
+    """
+    specs = []
+    for item in raw:
+        # `==` is PyPI's and `@` is npm's. Both are read; only the first is on
+        # ground this plugin covers, which is why `language` travels with them.
+        got = re.match(r"^\s*(@?[A-Za-z0-9._/-]+?)\s*(?:==|@)\s*([^\s;]+)\s*$", item)
+        specs.append(
+            {"raw": item, "name": got.group(1), "version": got.group(2)}
+            if got
+            else {"raw": item, "name": "", "version": ""}
+        )
+    exact = [s for s in specs if s["version"]]
+    return {
+        "source": source,
+        "specs": specs,
+        "state": "derived" if exact else "loose",
+        "why": (
+            f"{source} pins " + ", ".join(f"{s['name']} {s['version']}" for s in exact)
+            if exact
+            else f"{source} declares {raw}, none of them an `==` pin — the version "
+            "installed is not decided by this rev"
+        ),
+    }
+
+
+def parse_hooks(text: str) -> dict[str, dict[str, str]]:
+    """`.pre-commit-hooks.yaml` -> {hook id: {field: normalised value}}.
+
+    A deliberately small grammar, and it **raises** on anything outside it rather
+    than skipping. Covers what the real files use, verified against four live
+    mirrors that disagree on every cosmetic detail:
+
+        - id: x            two-space continuation      (ruff-pre-commit)
+        -   id: x          four-space continuation     (mirrors-mypy)
+        'types_or': [a]    quoted keys                 (mirrors-mypy, mirrors-prettier)
+        description:       a folded scalar on the      (black-pre-commit-mirror)
+          "..."           following line
+
+    Values are kept as **strings**, normalised for whitespace and one layer of
+    matching outer quotes, and never interpreted. Comparing two of them answers
+    "did this field move", which is the whole question -- and it cannot misread a
+    flow sequence, because it never reads one.
+    """
+    items: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    column: int | None = None
+    pending: str | None = None
+    for number, raw in enumerate(text.splitlines(), 1):
+        line = raw.split(" #")[0].rstrip() if " #" in raw else raw.rstrip()
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        body = line.lstrip()
+        if body.startswith("- "):
+            after = body.lstrip("- ")
+            # Where the item's *content* starts, which is the column its later
+            # fields line up on. `- id:` and `-   id:` both occur in the wild and
+            # the difference is only how far this is from the dash.
+            column = indent + len(body) - len(after)
+            current, pending = {}, None
+            items.append(current)
+        elif current is None or column is None:
+            raise Unparsed(f"line {number}: content before any `- ` item")
+        elif indent > column:
+            if not pending:
+                raise Unparsed(f"line {number}: indented under `{body[:24]}` with no folded key")
+            current[pending] = _scalar(f"{current[pending]} {body}")
+            continue
+        elif indent < column:
+            raise Unparsed(f"line {number}: dedent to {indent} inside an item opening at {column}")
+        else:
+            after = body
+        key, value = _field(after, number)
+        current[key] = value
+        pending = key if not value else None
+
+    hooks: dict[str, dict[str, str]] = {}
+    for number, item in enumerate(items, 1):
+        if "id" not in item:
+            raise Unparsed(f"item {number} has no `id`, so nothing can be compared against it")
+        hooks[item["id"]] = item
+    return hooks
+
+
+def _field(text: str, number: int) -> tuple[str, str]:
+    key, sep, value = text.partition(":")
+    if not sep:
+        raise Unparsed(f"line {number}: `{text}` is not `key: value`")
+    return _scalar(key), _scalar(value)
+
+
+def _scalar(text: str) -> str:
+    """Collapse whitespace, then strip one layer of matching outer quotes.
+
+    The quote strip is what stops `name: mypy` -> `name: 'mypy'` being reported as
+    a behaviour change; `mirrors-mypy` made exactly that edit between v1.18.2 and
+    v2.3.1. One layer only, and only when both ends match, so a value that is
+    genuinely quoted-inside-quoted survives visibly.
+    """
+    out = " ".join(text.split())
+    if len(out) > 1 and out[0] == out[-1] and out[0] in "\"'":
+        out = out[1:-1]
+    return out
+
+
+def compare(before: dict[str, dict[str, str]], after: dict[str, dict[str, str]],
+            wanted: list[str]) -> list[dict[str, Any]]:  # fmt: skip
+    """Field-level differences per hook, ranked by whether they change what runs."""
+    ids = [h for h in dict.fromkeys([*before, *after]) if not wanted or h in wanted]
+    rows = []
+    for hook in ids:
+        old, new = before.get(hook), after.get(hook)
+        if old is None or new is None:
+            rows.append({
+                "hook": hook, "field": "", "before": "", "after": "",
+                "kind": "behavioural",
+                "note": "the hook was added" if old is None else "THE HOOK WAS REMOVED",
+            })  # fmt: skip
+            continue
+        for field in dict.fromkeys([*old, *new]):
+            was, now = old.get(field, ""), new.get(field, "")
+            if was == now:
+                continue
+            rows.append({
+                "hook": hook, "field": field, "before": was, "after": now,
+                "kind": "cosmetic" if field in COSMETIC else "behavioural",
+                "note": "",
+            })  # fmt: skip
+    return rows
+
+
+def audit(repo: str, old_rev: str, new_rev: str, wanted: list[str]) -> dict[str, Any]:
+    report: dict[str, Any] = {
+        "repo": repo,
+        "from": resolve(repo, old_rev),
+        "to": resolve(repo, new_rev),
+        "hooks": [],
+        "hooks_state": "derived",
+        "why": "",
+        "language": "",
+    }
+    # Hooks first, because the requirement may have to come out of them: a node
+    # mirror carries no Python packaging and pins its tool in the hook itself.
+    parsed: dict[str, dict[str, dict[str, str]]] = {}
+    texts = {}
+    for end, rev in (("from", old_rev), ("to", new_rev)):
+        got = read_at(repo, HOOKS_FILE, rev)
+        if got is None:
+            report["hooks_state"] = "underivable"
+            report["why"] = f"no {HOOKS_FILE} at {rev} — nothing to compare"
+            break
+        texts[end] = got
+    if report["hooks_state"] == "derived":
+        try:
+            parsed = {end: parse_hooks(text) for end, text in texts.items()}
+            report["hooks"] = compare(parsed["from"], parsed["to"], wanted)
+        except Unparsed as exc:
+            # The raw text still reaches the reader. A refusal that also withholds
+            # the evidence turns a degraded answer into no answer.
+            parsed = {}
+            report["hooks_state"] = "underivable"
+            report["why"] = f"{HOOKS_FILE} used YAML this parser does not cover — {exc}"
+            report["raw"] = texts
+
+    for end, rev in (("from", old_rev), ("to", new_rev)):
+        report[f"requirement_{end}"] = requirement(repo, rev, parsed.get(end))
+    # Which registry the requirement lives in, and therefore whether Phases 2 and
+    # 3 are on covered ground for it. `language: python` is PyPI, which
+    # `audit.py` and `changelog.py` verify end to end; anything else is the
+    # boundary again, one layer in, and has to be reported as one.
+    languages = {h.get("language", "") for h in (parsed.get("to") or {}).values()}
+    report["language"] = ", ".join(sorted(x for x in languages if x))
+    return report
+
+
+def findings(report: dict[str, Any]) -> list[str]:
+    """What makes this exit 1. Deliberately short, and deliberately not "changed"."""
+    out = [
+        f"{r['hook']}.{r['field'] or '(hook)'}: {r['before'] or '(absent)'} -> "
+        f"{r['after'] or '(absent)'}"
+        for r in report["hooks"]
+        if r["kind"] == "behavioural"
+    ]
+    # The tag and the packaging pin are two different claims about one bump, and
+    # nothing enforces that they agree. Where they disagree, what `pre-commit`
+    # installs is not what the config appears to say.
+    for end in ("from", "to"):
+        # `removeprefix` and not `lstrip("v")`, which strips every leading `v`.
+        rev = report[end]["rev"].removeprefix("v")
+        exact = [s for s in report[f"requirement_{end}"]["specs"] if s["version"]]
+        # Only where the tag *claims* a version. A branch name, a SHA pin, or a
+        # mirror whose tags do not track the tool at all would otherwise disagree
+        # on every bump, and a check that fires every time is one nobody reads.
+        # The failure this catches is narrower and real: a tag that looks like it
+        # names the version while the repo installs a different one, which a
+        # reader takes at face value because it looks authoritative.
+        if exact and VERSIONISH.match(rev) and not any(s["version"] == rev for s in exact):
+            out.append(
+                f"rev `{report[end]['rev']}` does not match what it installs "
+                f"({', '.join(s['name'] + ' ' + s['version'] for s in exact)})"
+            )
+    return out
+
+
+def render(report: dict[str, Any]) -> None:
+    print(f"hook repo: {report['repo']}")
+    for end in ("from", "to"):
+        p = report[end]
+        print(f"  {end:<5} {p['rev']:<22} {p['sha'][:9] or '(unresolved)'}  {p['pin'].upper()}")
+        print(f"        {p['why']}")
+    print()
+    for end in ("from", "to"):
+        r = report[f"requirement_{end}"]
+        print(f"  installs at {end:<5} [{r['state']}] {r['why']}")
+    if report["language"]:
+        covered = report["language"] == "python"
+        where = "PyPI, which Phases 2 and 3 verify end to end" if covered else "NOT PyPI"
+        print(f"\n  hook language: {report['language']} — {where}")
+        if not covered:
+            print("     The requirement above is derived and its registry is not one this")
+            print("     plugin covers. Report that boundary rather than querying it by hand:")
+            print("     an improvised recipe returns a clean answer, which is the failure")
+            print("     Phase 1's boundary language exists for.")
+    if report["from"]["pin"] == "mutable" or report["to"]["pin"] == "mutable":
+        print("\n  -- The pin is a name, not a SHA. Report that what was audited is what")
+        print("     runs today; it is NOT a Hold on this bump, which did not make it so.")
+        print("     `pre-commit autoupdate --freeze` writes the SHA form.")
+
+    print(f"\n=== hook definitions: {report['hooks_state'].upper()}")
+    if report["hooks_state"] != "derived":
+        print(f"    {report['why']}")
+        print("    UNDERIVABLE, not 'nothing changed'. The raw file is in --json;")
+        print("    read it rather than reporting an unmade comparison as clean.")
+    elif not report["hooks"]:
+        print("    no field moved on any hook compared")
+    else:
+        for row in report["hooks"]:
+            mark = "!!" if row["kind"] == "behavioural" else "--"
+            if row["note"]:
+                print(f"  {mark} {row['hook']}: {row['note']}")
+                continue
+            print(f"  {mark} {row['hook']}.{row['field']}  [{row['kind']}]")
+            print(f"       before: {row['before'] or '(absent)'}")
+            print(f"       after:  {row['after'] or '(absent)'}")
+        print("\n  A behavioural field decides WHICH FILES the hook touches or WHAT it")
+        print("  runs on them. Measure the blast radius in the audited repo — the hook")
+        print("  says what it now selects, not how much of this repo that is.")
+
+    found = findings(report)
+    print(f"\nRESULT: {'NEEDS REVIEW' if found else 'CLEAN'} — {len(found)} finding(s)")
+    for line in found:
+        print(f"  - {line}")
+    print("This is Phases 1 and 4 for the wrapper. The tool it pins is a separate")
+    print("audit: hand the requirement above to Phase 2 and Phase 3.")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="OWNER/NAME of the hook repository")
+    parser.add_argument("--from", dest="old", required=True, help="the rev being replaced")
+    parser.add_argument("--to", dest="new", required=True, help="the rev proposed")
+    parser.add_argument(
+        "--hook",
+        action="append",
+        default=[],
+        help="hook id to compare; repeatable. Default: every hook in the file",
+    )
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if args.repo.count("/") != 1 or not all(args.repo.split("/")):
+        fail(f"--repo must be OWNER/NAME, got `{args.repo}`")
+    report = audit(args.repo, args.old, args.new, args.hook)
+    for end in ("from", "to"):
+        if report[end]["pin"] == "underivable":
+            fail(report[end]["why"])
+    if args.json:
+        report["findings"] = findings(report)
+        print(json.dumps(report, indent=2))
+    else:
+        render(report)
+    return 1 if findings(report) else 0
+
+
+def cli() -> NoReturn:
+    """Entry point. Anything unforeseen becomes exit 2, never exit 1.
+
+    Exit 1 means a field moved. An unhandled exception exits 1 too, so without
+    this a crash reports as a behaviour change on someone else's repository.
+    """
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:
+        fail(f"{type(exc).__name__}: {exc}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -87,6 +87,23 @@ def uses_bump(action: str = "actions/checkout") -> str:
     )
 
 
+def rev_bump(old: str = "v0.16.2", new: str = "v0.16.5") -> str:
+    """The whole content of an ordinary `pre-commit` bump's diff.
+
+    Copied from this repo's own #99, which is the shape Dependabot's `pre-commit`
+    ecosystem emits: one `rev:` line, in one file, with context either side.
+    """
+    return (
+        "@@ -14,7 +14,7 @@\n"
+        " repos:\n"
+        "   - repo: https://github.com/astral-sh/ruff-pre-commit\n"
+        f"-    rev: {old}\n"
+        f"+    rev: {new}\n"
+        "     hooks:\n"
+        "       - id: ruff-check\n"
+    )
+
+
 class DiscoverHarness(unittest.TestCase):
     def _fake(
         self,
@@ -823,3 +840,117 @@ class TestThePhase1ScopeGateIsDerivedRatherThanJudged(DiscoverHarness):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAPreCommitBumpIsClassifiedAndGated(DiscoverHarness):
+    """`.pre-commit-config.yaml` reached Phase 1 as `unknown` / `beyond`.
+
+    Reported that way it says the bump *reached into source*, which is a finding
+    about the PR. What had actually happened is that the plugin had no rule for
+    the ecosystem -- the same confusion `UNSUPPORTED_LOCKFILES` exists to prevent
+    one file type along, and the reason a Cargo bump is named rather than lumped
+    in with `unknown`.
+
+    This repo generates one such PR a month by construction: `.github/dependabot.yml`
+    configures `github-actions` and `pre-commit`, and says these PRs are "the only
+    end-to-end exercise this plugin gets". Half of that exercise landed on the
+    refusal path. Filed as #109, and both live PRs are the fixtures -- #99 is a
+    real defect the gate must not swallow, #98 a clean bump it must not flag.
+    """
+
+    BOT_SHA = "1" * 40
+
+    def _bot_pr(self, files: list[dict[str, Any]], **kw: Any) -> Any:
+        fake, _ = self._fake(
+            commits=[commit(self.BOT_SHA, BOT)],
+            commit_files={self.BOT_SHA: files},
+            **kw,
+        )
+        return fake
+
+    def test_a_config_only_bump_is_the_pre_commit_ecosystem(self):
+        fake = self._bot_pr([changed(".pre-commit-config.yaml", rev_bump())])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["ecosystem"], "pre-commit")
+
+    def test_a_lone_rev_line_is_clean_scope(self):
+        """#99's actual diff. Before this it was `beyond` over an empty list,
+        which is the one verdict a reader cannot act on -- it reaches the report
+        as "this bump reaches past the manifest" naming nothing."""
+        fake = self._bot_pr([changed(".pre-commit-config.yaml", rev_bump())])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "clean")
+        self.assertEqual(report["scope"]["beyond"], [])
+
+    def test_a_changed_arg_is_beyond_the_pin(self):
+        """The gate reads *lines*, like the actions one and unlike the lockfile
+        one. A bump that also edits `args:` or `additional_dependencies:` changes
+        what the hook does, and that is not something a version bump may do
+        quietly."""
+        patch = (
+            "@@ -14,8 +14,8 @@\n"
+            "   - repo: https://github.com/astral-sh/ruff-pre-commit\n"
+            "-    rev: v0.16.2\n"
+            "+    rev: v0.16.5\n"
+            "     hooks:\n"
+            "       - id: ruff-check\n"
+            "-        args: [--fix]\n"
+            "+        args: [--fix, --unsafe-fixes]\n"
+        )
+        fake = self._bot_pr([changed(".pre-commit-config.yaml", patch)])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "beyond")
+        self.assertTrue(
+            any("args" in row for row in report["scope"]["beyond"]),
+            f"the changed args line must be named: {report['scope']['beyond']}",
+        )
+
+    def test_a_withheld_patch_is_underivable_not_clean(self):
+        """Same asymmetry as the actions branch, and for the same reason: this
+        gate reads lines, so no lines to read is not "no lines beyond the pin"."""
+        fake = self._bot_pr([changed(".pre-commit-config.yaml")])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+
+    def test_a_config_beside_source_still_fires_the_gate(self):
+        source = "@@ -1,2 +1,2 @@\n-x = 1\n+x = 2\n"
+        fake = self._bot_pr(
+            [changed(".pre-commit-config.yaml", rev_bump()), changed("src/app/core.py", source)]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "beyond")
+        self.assertTrue(
+            any("src/app/core.py" in row for row in report["scope"]["beyond"]),
+            f"the source line must be named: {report['scope']['beyond']}",
+        )
+
+    def test_source_with_a_withheld_patch_is_underivable_not_beyond(self):
+        """The distinction the line gates exist for, and it is not pedantry.
+
+        This gate reads lines, so a file whose patch the API withheld has *no
+        lines to read* -- which is neither "clean" nor "this bump reached into
+        source". Answering `beyond` would be a claim about content nobody saw,
+        in the report's language for the most serious finding it has.
+        """
+        fake = self._bot_pr(
+            [changed(".pre-commit-config.yaml", rev_bump()), changed("src/app/core.py")]
+        )
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["verdict"], "underivable")
+        self.assertIn("src/app/core.py", report["scope"]["why"])
+
+    def test_a_lockfile_beside_the_config_is_still_the_lockfile_ecosystem(self):
+        """Ordering matters and the lockfile wins. A repo that pins its tools in
+        `uv.lock` *and* runs them through pre-commit gets the ecosystem with the
+        artifact hashes, which is the stronger of the two Phase 1 methods."""
+        fake = self._bot_pr([changed("uv.lock"), changed(".pre-commit-config.yaml", rev_bump())])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["ecosystem"], "uv.lock")
+
+    def test_a_nested_config_is_found_by_basename(self):
+        """`pre-commit` does not require the file at the root, and a repo with
+        one per package is ordinary. Matching the full path misses it and the
+        bump falls back to `unknown`."""
+        fake = self._bot_pr([changed("tools/lint/.pre-commit-config.yaml", rev_bump())])
+        report = self._json(fake)
+        self.assertEqual(report["scope"]["ecosystem"], "pre-commit")

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -321,6 +321,40 @@ class TestTheParserRefusesRatherThanGuesses(PreCommitHarness):
         with self.assertRaises(Unparsed):
             parse_hooks("- id: x\n  files:\n    - a\n    - b\n")
 
+    def test_a_comment_is_stripped_without_eating_a_value(self):
+        """`" #"` and not `"#"`, which is the YAML rule rather than a guess: an
+        inline comment must be preceded by whitespace.
+
+        It matters on `entry`, which is behavioural and is the field that caught
+        `mirrors-prettier` dropping `--list-different`. A strip that ate part of
+        a command would invent a behaviour change on one side of the comparison
+        and hide one on the other, and both are silent.
+        """
+        for name, text, expected in (
+            ("inline comment", "- id: x\n  entry: black  # go fast\n", "black"),
+            ("hash inside a value", "- id: x\n  entry: sed -e 's/#a/b/'\n", "sed -e 's/#a/b/'"),
+            ("hash with no space", "- id: x\n  entry: black --p#q\n", "black --p#q"),
+        ):
+            with self.subTest(name):
+                self.assertEqual(parse_hooks(text)["x"]["entry"], expected)
+
+    def test_a_standalone_comment_line_is_skipped(self):
+        """`ruff-pre-commit` carries one (`# Legacy alias`). Read as content it is
+        a line with no colon, which the parser refuses -- so the whole file would
+        become underivable over a comment.
+
+        Both positions, because they take different branches: an *indented*
+        comment is emptied by the inline strip and caught as blank, while one at
+        column 0 with no space before the `#` survives that strip and needs the
+        `startswith` check. Mutating either alone leaves the other passing.
+        """
+        for name, text in (
+            ("indented", "- id: x\n  # a note\n  language: python\n"),
+            ("column 0", "# a note\n- id: x\n  language: python\n"),
+        ):
+            with self.subTest(name):
+                self.assertEqual(parse_hooks(text)["x"], {"id": "x", "language": "python"})
+
     def test_a_dedent_inside_an_item_raises(self):
         """A line less indented than the item it sits in is not a field of that
         item, and treating it as one silently attaches a value to the wrong hook.

--- a/tests/test_precommit.py
+++ b/tests/test_precommit.py
@@ -1,0 +1,465 @@
+"""Regression tests for precommit.py.
+
+No network: `_gh` is the single seam every call goes through, so the fakes below
+drive the real resolution, parsing and comparison and only the subprocess is
+replaced.
+
+Every case corresponds to a defect that shipped or to a failure the phase exists
+to detect. The anchor case is this repo's own #99 — `ruff-pre-commit` v0.16.2 ->
+v0.16.5, where `ruff-format`'s `types_or` gained `markdown` and the hook began
+rewriting every Markdown file in the repository. `ruff` itself did not change in
+any way a changelog reports, so **no per-package view of the tool could have
+found it**: the defect lived entirely in the wrapper, which is the thing this
+script reads and nothing else here did.
+
+The fixtures are the real files, trimmed. Four live mirrors were parsed while
+writing the parser and they disagree on every cosmetic detail — two-space and
+four-space continuations, quoted and bare keys, and one folded scalar — so those
+shapes are cases here rather than assumptions.
+
+    python3 -m unittest discover -s tests -v
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import pathlib
+import sys
+import unittest
+from typing import Any
+from unittest import mock
+
+sys.path.insert(
+    0, str(pathlib.Path(__file__).resolve().parent.parent / "skills/dependabot-audit/scripts")
+)
+
+from precommit import Unparsed, cli, main, parse_hooks
+
+OLD_SHA = "a" * 40
+NEW_SHA = "b" * 40
+
+# `ruff-pre-commit`, trimmed to the two hooks that matter. Two-space continuation.
+RUFF_OLD = """\
+- id: ruff-check
+  name: ruff check
+  entry: ruff check --force-exclude
+  language: python
+  types_or: [python, pyi, jupyter]
+- id: ruff-format
+  name: ruff format
+  entry: ruff format --force-exclude
+  language: python
+  types_or: [python, pyi, jupyter]
+"""
+RUFF_NEW = RUFF_OLD.replace(
+    "  types_or: [python, pyi, jupyter]\n", "  types_or: [python, pyi, jupyter, markdown]\n"
+).replace(
+    "[python, pyi, jupyter, markdown]\n- id: ruff-format",
+    "[python, pyi, jupyter]\n- id: ruff-format",
+)
+
+# `mirrors-mypy`: four-space continuation, quoted keys, and the quoting of `name`
+# is the only thing that moved between v1.18.2 and v2.3.1.
+MYPY_OLD = """\
+-   id: mypy
+    name: mypy
+    description: ''
+    entry: mypy
+    language: python
+    'types_or': [python, pyi]
+    args: ["--ignore-missing-imports"]
+"""
+MYPY_NEW = MYPY_OLD.replace("    name: mypy\n", "    name: 'mypy'\n")
+
+PYPROJECT = '[project]\nname = "ruff-pre-commit"\ndependencies = [\n    "ruff==%s",\n]\n'
+SETUP_PY = (
+    "from setuptools import setup\nsetup(\n    name='pre_commit_placeholder_package',\n"
+    "    version='0.0.0',\n    install_requires=['mypy==%s'],\n)\n"
+)
+
+
+class PreCommitHarness(unittest.TestCase):
+    def _fake_gh(
+        self,
+        *,
+        hooks: dict[str, str] | None = None,
+        pyproject: dict[str, str] | None = None,
+        setup: dict[str, str] | None = None,
+        shas: dict[str, str] | None = None,
+    ) -> Any:
+        """A `_gh` dispatching on the call shape. Each mapping is rev -> content.
+
+        A rev absent from a mapping is a **404**, which is the ordinary case for
+        `pyproject.toml` on a mirror repo and for `setup.py` on a first-party
+        one. Modelling it as an exit code rather than an empty string matters:
+        `gh` writes the API error body to stdout, so a caller reading stdout
+        alone gets a JSON error document that is not empty.
+        """
+        hooks, pyproject = hooks or {}, pyproject or {}
+        setup = setup or {}
+        shas = shas or {"v1": OLD_SHA, "v2": NEW_SHA}
+
+        def fake(args: list[str]) -> tuple[int, str]:
+            joined = " ".join(args)
+            if "/commits/" in joined:
+                rev = joined.split("/commits/")[1].split(" ")[0]
+                return (0, shas[rev]) if rev in shas else (1, '{"message":"No commit found"}')
+            path, _, rev = joined.split("/contents/")[1].partition("?ref=")
+            rev = rev.split(" ")[0]
+            table = {
+                ".pre-commit-hooks.yaml": hooks,
+                "pyproject.toml": pyproject,
+                "setup.py": setup,
+            }[path]
+            return (0, table[rev]) if rev in table else (1, '{"message":"Not Found"}')
+
+        return fake
+
+    def _run(
+        self, fake: Any, argv: list[str] | None = None, entry: Any = None
+    ) -> tuple[Any, str, str]:
+        full = [
+            "precommit.py", "--repo", "o/r", "--from", "v1", "--to", "v2",
+            *(argv or []),
+        ]  # fmt: skip
+        out, err = io.StringIO(), io.StringIO()
+        with (
+            mock.patch("precommit._gh", fake),
+            mock.patch.object(sys, "argv", full),
+            contextlib.redirect_stdout(out),
+            contextlib.redirect_stderr(err),
+        ):
+            try:
+                code: int | str | None = (entry or main)()
+            except SystemExit as exc:
+                code = exc.code
+        return code, out.getvalue(), err.getvalue()
+
+    def _json(self, fake: Any, argv: list[str] | None = None) -> dict[str, Any]:
+        _, out, _ = self._run(fake, [*(argv or []), "--json"])
+        loaded: dict[str, Any] = json.loads(out)
+        return loaded
+
+
+class TestTheWrapperIsWhereTheDefectWas(PreCommitHarness):
+    """#99, the case this whole ecosystem was added for.
+
+    `ruff-pre-commit` v0.16.2 -> v0.16.5 moved one word in one list, and the hook
+    began reformatting Markdown. CI went red on this repository. The bump reads
+    as a routine patch bump of a formatter, and every per-package check of `ruff`
+    agrees with that reading, because `ruff` is not what changed.
+    """
+
+    def _ruff(self, new: str = RUFF_NEW) -> Any:
+        return self._fake_gh(
+            hooks={"v1": RUFF_OLD, "v2": new},
+            pyproject={"v1": PYPROJECT % "0.16.2", "v2": PYPROJECT % "0.16.5"},
+        )
+
+    def test_a_widened_types_or_is_a_behavioural_finding(self):
+        report = self._json(self._ruff())
+        rows = [r for r in report["hooks"] if r["kind"] == "behavioural"]
+        self.assertEqual(len(rows), 1, f"expected exactly the one field: {report['hooks']}")
+        self.assertEqual((rows[0]["hook"], rows[0]["field"]), ("ruff-format", "types_or"))
+        self.assertIn("markdown", rows[0]["after"])
+        self.assertNotIn("markdown", rows[0]["before"])
+
+    def test_it_exits_one_so_the_caller_cannot_miss_it(self):
+        code, _, _ = self._run(self._ruff())
+        self.assertEqual(code, 1)
+
+    def test_the_sibling_hook_is_not_swept_in(self):
+        """`ruff-check` did not change, and a diff that reported the whole file
+        would say it did. The field-level comparison is what makes the row
+        actionable rather than a pointer at a 30-line file."""
+        report = self._json(self._ruff())
+        self.assertEqual([r["hook"] for r in report["hooks"]], ["ruff-format"])
+
+    def test_an_unchanged_bump_is_clean_and_exits_zero(self):
+        """#98, the other live fixture. A gate that fires on every bump is one
+        the reader stops reading, so the negative case is load-bearing."""
+        code, out, _ = self._run(self._ruff(new=RUFF_OLD))
+        self.assertEqual(code, 0)
+        self.assertIn("CLEAN", out)
+
+    def test_only_the_named_hook_is_compared_when_asked(self):
+        report = self._json(self._ruff(), ["--hook", "ruff-check"])
+        self.assertEqual(report["hooks"], [], "the repo does not use ruff-format here")
+
+
+class TestTheRevIsNotTheDependency(PreCommitHarness):
+    """A `rev:` is a git ref on someone else's repo, not a version.
+
+    Phase 2 asking PyPI about `v2.3.1` because the tag says so is asking about
+    the wrong artifact -- the version that gets installed is declared in the hook
+    repo's packaging, and nothing enforces that the two agree.
+    """
+
+    def test_a_mirror_pins_the_tool_in_setup_py(self):
+        report = self._json(
+            self._fake_gh(
+                hooks={"v1": MYPY_OLD, "v2": MYPY_NEW},
+                setup={"v1": SETUP_PY % "2.3.0", "v2": SETUP_PY % "2.3.1"},
+            )
+        )
+        got = report["requirement_to"]
+        self.assertEqual(got["state"], "derived")
+        self.assertEqual(got["source"], "setup.py")
+        self.assertEqual([(s["name"], s["version"]) for s in got["specs"]], [("mypy", "2.3.1")])
+
+    def test_pyproject_is_preferred_where_both_exist(self):
+        report = self._json(
+            self._fake_gh(
+                hooks={"v1": RUFF_OLD, "v2": RUFF_OLD},
+                pyproject={"v1": PYPROJECT % "0.16.2", "v2": PYPROJECT % "0.16.5"},
+                setup={"v1": SETUP_PY % "9.9.9", "v2": SETUP_PY % "9.9.9"},
+            )
+        )
+        self.assertEqual(report["requirement_to"]["source"], "pyproject.toml")
+        self.assertEqual(report["requirement_to"]["specs"][0]["version"], "0.16.5")
+
+    def test_a_tag_disagreeing_with_the_pin_is_a_finding(self):
+        """Nothing enforces the convention. Where they differ, what `pre-commit`
+        installs is not what the config appears to say, and a Phase 2 check run
+        against the tag is about a version nobody will get."""
+        code, out, _ = self._run(
+            self._fake_gh(
+                hooks={"v0.16.2": RUFF_OLD, "v0.16.4": RUFF_OLD},
+                pyproject={"v0.16.2": PYPROJECT % "0.16.2", "v0.16.4": PYPROJECT % "0.16.5"},
+                shas={"v0.16.2": OLD_SHA, "v0.16.4": NEW_SHA},
+            ),
+            ["--from", "v0.16.2", "--to", "v0.16.4"],
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("does not match what it installs", out)
+
+    def test_a_rev_that_does_not_claim_a_version_is_not_compared(self):
+        """The false-positive class, found by three tests failing at once. A
+        branch pin, a SHA pin, or a mirror whose tags do not track the tool would
+        disagree with the packaging on *every* bump -- so the comparison is made
+        only where the tag is shaped like the version it appears to name.
+        """
+        code, out, _ = self._run(
+            self._fake_gh(
+                hooks={"main": RUFF_OLD, "next": RUFF_OLD},
+                pyproject={"main": PYPROJECT % "0.16.2", "next": PYPROJECT % "0.16.5"},
+                shas={"main": OLD_SHA, "next": NEW_SHA},
+            ),
+            ["--from", "main", "--to", "next"],
+        )
+        self.assertEqual(code, 0)
+        self.assertNotIn("does not match", out)
+
+    def test_a_computed_install_requires_is_underivable_not_empty(self):
+        """`install_requires=['mypy==' + VERSION]` is a list whose entries are
+        not constants. Reading the constants that *are* there would report a
+        shorter requirement list as though it were the whole one -- the same
+        shape as a capped file list read as complete. Nothing is executed to find
+        out, so the honest answer is that it was not established."""
+        # A *mixed* list, and that is what makes this discriminate. With every
+        # entry computed the partial read is also empty, so both the right answer
+        # and the wrong one arrive as `underivable` and the case proves nothing.
+        # One constant beside one computed entry is where returning the constants
+        # reports a shorter requirement list as though it were the whole one --
+        # the same shape as a capped file list read as complete.
+        computed = (
+            "from setuptools import setup\nV = '2.3.1'\n"
+            "setup(install_requires=['types-requests==1.0', 'mypy==' + V])\n"
+        )
+        report = self._json(
+            self._fake_gh(
+                hooks={"v1": MYPY_OLD, "v2": MYPY_OLD}, setup={"v1": computed, "v2": computed}
+            )
+        )
+        self.assertEqual(report["requirement_to"]["state"], "underivable")
+
+    def test_no_packaging_at_all_is_underivable_rather_than_absent(self):
+        report = self._json(self._fake_gh(hooks={"v1": MYPY_OLD, "v2": MYPY_OLD}))
+        self.assertEqual(report["requirement_to"]["state"], "underivable")
+
+    def test_a_node_mirror_derives_its_pin_and_says_it_is_not_pypi(self):
+        """`mirrors-prettier` carries no Python packaging and pins `prettier` in
+        the hook's own `additional_dependencies`. Deriving it is right; calling
+        it covered is not -- npm is the boundary again, one layer in."""
+        node = (
+            "-   id: prettier\n    entry: prettier --write\n    language: node\n"
+            '    additional_dependencies: ["prettier@3.1.0"]\n'
+        )
+        code, out, _ = self._run(self._fake_gh(hooks={"v1": node, "v2": node}))
+        self.assertEqual(code, 0)
+        self.assertIn("NOT PyPI", out)
+        report = self._json(self._fake_gh(hooks={"v1": node, "v2": node}))
+        self.assertEqual(report["requirement_to"]["specs"][0]["name"], "prettier")
+        self.assertEqual(report["language"], "node")
+
+
+class TestTheParserRefusesRatherThanGuesses(PreCommitHarness):
+    """A parser that skips what it does not recognise reports "no fields changed"
+    about a file it did not read.
+
+    That is this plugin's own thesis one level down -- the unverified verifier
+    reporting green -- so the grammar is small and everything outside it raises.
+    """
+
+    def test_the_four_live_shapes_all_parse(self):
+        """Two-space and four-space continuations, quoted keys, and a folded
+        scalar. All four were read off real mirrors while writing this."""
+        folded = (
+            "- id: black\n  name: black\n  language: python\n"
+            "- id: black-jupyter\n  description:\n"
+            '    "Black: the formatter (with Jupyter support)"\n  language: python\n'
+        )
+        self.assertEqual(sorted(parse_hooks(RUFF_OLD)), ["ruff-check", "ruff-format"])
+        self.assertEqual(parse_hooks(MYPY_OLD)["mypy"]["types_or"], "[python, pyi]")
+        got = parse_hooks(folded)
+        self.assertEqual(got["black-jupyter"]["description"],
+                         "Black: the formatter (with Jupyter support)")  # fmt: skip
+
+    def test_a_nested_block_raises_rather_than_being_skipped(self):
+        with self.assertRaises(Unparsed):
+            parse_hooks("- id: x\n  files:\n    - a\n    - b\n")
+
+    def test_a_dedent_inside_an_item_raises(self):
+        """A line less indented than the item it sits in is not a field of that
+        item, and treating it as one silently attaches a value to the wrong hook.
+        Found by a mutation run: replacing this raise with `continue` left every
+        other case green."""
+        with self.assertRaises(Unparsed):
+            parse_hooks("- id: x\n  language: python\n language: node\n")
+
+    def test_a_line_that_is_not_a_field_raises(self):
+        """A block sequence takes a path worth knowing: `    - a` under `files:`
+        begins with `- `, so it is read as a *new item* rather than as content,
+        and is refused twice over -- once for having no colon and again for
+        having no `id`. Mutating either raise alone leaves the file refused,
+        which is the right outcome and the reason this case is here rather than
+        a claim about which branch fires.
+        """
+        with self.assertRaises(Unparsed):
+            parse_hooks("- id: x\n  files:\n    - a\n")
+
+    def test_an_item_without_an_id_raises(self):
+        """Every comparison is keyed on `id`. An item without one would compare
+        against nothing and read as unchanged."""
+        with self.assertRaises(Unparsed):
+            parse_hooks("- name: no-id-here\n  language: python\n")
+
+    def test_an_unparsable_file_is_underivable_and_keeps_the_raw_text(self):
+        """Both halves matter. `underivable` stops it reading as "nothing
+        changed"; the raw text stops the refusal from also withholding the
+        evidence, which turns a degraded answer into no answer."""
+        report = self._json(
+            self._fake_gh(hooks={"v1": RUFF_OLD, "v2": "- id: x\n  files:\n    - a\n"})
+        )
+        self.assertEqual(report["hooks_state"], "underivable")
+        self.assertIn("raw", report)
+        self.assertIn("files:", report["raw"]["to"])
+
+    def test_a_missing_hooks_file_is_underivable_not_clean(self):
+        report = self._json(self._fake_gh(hooks={"v1": RUFF_OLD}))
+        self.assertEqual(report["hooks_state"], "underivable")
+
+    def test_quoting_alone_is_not_a_change(self):
+        """`mirrors-mypy` restyled `name: mypy` to `name: 'mypy'` between
+        v1.18.2 and v2.3.1. Reported as a field change it is noise on the row a
+        reader uses to decide whether the wrapper moved."""
+        report = self._json(
+            self._fake_gh(
+                hooks={"v1": MYPY_OLD, "v2": MYPY_NEW},
+                setup={"v1": SETUP_PY % "2.3.0", "v2": SETUP_PY % "2.3.1"},
+            )
+        )
+        self.assertEqual(report["hooks"], [])
+
+
+class TestTheRankingErrsNoisy(PreCommitHarness):
+    """Which fields make this exit 1, and which direction an unknown one goes."""
+
+    def test_an_unknown_field_counts_as_behavioural(self):
+        """`pre-commit` gains keys. A new one that selects files must not arrive
+        as cosmetic because this list predates it, so the default is the noisy
+        direction and not the quiet one."""
+        report = self._json(
+            self._fake_gh(
+                hooks={
+                    "v1": "- id: x\n  language: python\n",
+                    "v2": "- id: x\n  language: python\n  some_future_selector: [md]\n",
+                }
+            )
+        )
+        self.assertEqual([r["kind"] for r in report["hooks"]], ["behavioural"])
+
+    def test_a_cosmetic_field_is_reported_and_is_not_a_finding(self):
+        code, out, _ = self._run(
+            self._fake_gh(
+                hooks={
+                    "v1": "- id: x\n  language: python\n  description: old\n",
+                    "v2": "- id: x\n  language: python\n  description: new\n",
+                }
+            )
+        )
+        self.assertEqual(code, 0, "a description is not a behaviour change")
+        self.assertIn("cosmetic", out, "and it is still shown")
+
+    def test_a_removed_hook_is_behavioural(self):
+        code, out, _ = self._run(
+            self._fake_gh(hooks={"v1": RUFF_OLD, "v2": "- id: ruff-check\n  language: python\n"})
+        )
+        self.assertEqual(code, 1)
+        self.assertIn("THE HOOK WAS REMOVED", out)
+
+
+class TestThePinIsAnImmutabilityClaimAndNotAnIntegrityOne(PreCommitHarness):
+    """There is no artifact hash here, and the report must not imply one."""
+
+    def test_a_tag_is_mutable_and_that_is_not_a_finding(self):
+        """Every ordinary `pre-commit` config pins tags -- `autoupdate` writes
+        them. A signal that fires on every run is one nobody reads, so it is
+        reported and does not set the exit code. The actions reference reaches
+        the same conclusion about `uses:` for the same reason."""
+        code, out, _ = self._run(
+            self._fake_gh(
+                hooks={"v1": RUFF_OLD, "v2": RUFF_OLD},
+                pyproject={"v1": PYPROJECT % "0.16.2", "v2": PYPROJECT % "0.16.5"},
+            )
+        )
+        self.assertEqual(code, 0)
+        self.assertIn("MUTABLE", out)
+        self.assertIn("NOT a Hold", out)
+
+    def test_a_sha_pin_is_recognised_as_immutable(self):
+        fake = self._fake_gh(
+            hooks={OLD_SHA: RUFF_OLD, NEW_SHA: RUFF_OLD}, shas={OLD_SHA: OLD_SHA, NEW_SHA: NEW_SHA}
+        )
+        report = self._json(fake, ["--from", OLD_SHA, "--to", NEW_SHA])
+        self.assertEqual(report["from"]["pin"], "immutable")
+        self.assertEqual(report["to"]["pin"], "immutable")
+
+
+class TestFailureIsNotAFinding(PreCommitHarness):
+    """Exit 1 means a field moved. Everything that could not run exits 2.
+
+    The same guard the other scripts here carry, and for the same reason: this
+    script's inputs are API responses and someone else's YAML, which is the shape
+    least entitled to be assumed well-formed.
+    """
+
+    def test_an_unresolvable_rev_exits_two(self):
+        code, _, err = self._run(self._fake_gh(hooks={"v1": RUFF_OLD}, shas={"v1": OLD_SHA}))
+        self.assertEqual(code, 2, "a rev naming nothing is not a behaviour change")
+        self.assertIn("did not resolve", err)
+
+    def test_an_unexpected_exception_exits_two_not_one(self):
+        def boom(_args: list[str]) -> tuple[int, str]:
+            raise RuntimeError("network on fire")
+
+        code, _, err = self._run(boom, entry=cli)
+        self.assertEqual(code, 2)
+        self.assertIn("RuntimeError", err)
+
+    def test_a_malformed_repo_argument_exits_two(self):
+        code, _, err = self._run(self._fake_gh(), ["--repo", "not-a-slug"])
+        self.assertEqual(code, 2)
+        self.assertIn("OWNER/NAME", err)

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -575,8 +575,11 @@ class TestEveryHandoffLands(SkillHarness):
     # the phase is per-ecosystem and always was: a vendored crate is read out of
     # a wheel's SBOM, a moving major tag out of a `compare`. Both had a home in
     # `actions.md` and only one had one anywhere.
+    # `pre-commit.md` joined in 0.38.0 (#109). Adding it here rather than writing
+    # a second guard is the point of this list existing: the next ecosystem is
+    # one string, and every phase is then checked in both directions for free.
     SPLIT_PHASES = (1, 2, 3, 4, 5)
-    ECOSYSTEMS = ("uv-lock.md", "actions.md")
+    ECOSYSTEMS = ("uv-lock.md", "actions.md", "pre-commit.md")
 
     def test_every_split_phase_names_both_ecosystem_references(self):
         for number in self.SPLIT_PHASES:
@@ -4206,4 +4209,84 @@ class TestARedCheckCanBeStaleBecauseTheBaseMoved(SkillHarness):
             r"re-running the repo's gate against it is not",
             "Phase 6 offers the merge simulation without separating the read from "
             "the re-gate, so a --no-execute run is invited to execute",
+        )
+
+
+class TestPreCommitIsACoveredEcosystem(SkillHarness):
+    """Half of this repo's only live exercise landed on the refusal path.
+
+    `.github/dependabot.yml` configures `github-actions` and `pre-commit` and says
+    these PRs are "the only end-to-end exercise this plugin gets". One of the two
+    was verified end to end; the other reached Phase 1's boundary every month and
+    stopped, so the report was a procedural Hold on evidence that pointed the
+    other way. #98's own report put it as "a Hold I would not defend on the
+    merits, only on the procedure" -- and a gate that always says Hold is one the
+    reader learns to discount.
+
+    What made it worth covering rather than documenting is that a `rev:` bump has
+    real checkable content, and #99 is the proof: `ruff-format`'s `types_or`
+    gained `markdown`, the hook began rewriting every Markdown file in the repo,
+    and `ruff` itself did not change in any way its changelog reports. Filed as
+    #109.
+    """
+
+    def test_the_boundary_statement_names_all_three(self):
+        """Stated in one sentence, in one place, and it is the sentence a run
+        quotes when it refuses. Left at two, a `pre-commit` bump reads its own
+        ecosystem in the list of what is *not* covered."""
+        self.assertRegex(
+            self.flat(1),
+            r"covers `uv\.lock`, github actions and `pre-commit`, and nothing\s*else",
+            "Phase 1's boundary sentence does not name pre-commit, so the phase "
+            "that now has a method for it still says it has none",
+        )
+
+    # No guard here for "every phase names the reference, and the reference has
+    # that section". `TestEveryEcosystemHandoffLands` already asserts both
+    # directions for every entry in its `ECOSYSTEMS` list, and `pre-commit.md`
+    # was added to that list rather than duplicated into a second check.
+
+    def test_phase_2_says_to_query_the_package_and_not_the_rev(self):
+        """The silent failure specific to this ecosystem. `v0.16.5` is not a PyPI
+        version of anything, so a currency or advisory query built from the tag
+        comes back empty -- and empty reads exactly like *current and clean*."""
+        self.assertRegex(
+            self.flat(2),
+            r"not a pypi version of anything",
+            "Phase 2 does not warn that a query built from the `rev:` returns an "
+            "empty result that reads as a clean answer",
+        )
+
+    def test_the_stale_boundary_example_is_corrected(self):
+        """Phase 1 illustrated the boundary rule with a `pre-commit` bump. Left
+        alone it now contradicts the covered-ecosystem table four paragraphs
+        above it, and a reader resolving that contradiction has to guess which
+        half is current."""
+        body = self.flat(1)
+        self.assertRegex(
+            body,
+            r"no longer on this path|became a covered ecosystem",
+            "Phase 1 still offers a `pre-commit` bump as its example of an "
+            "uncovered ecosystem, which the same phase now says is covered",
+        )
+
+    def test_the_reference_is_reachable_and_names_its_script(self):
+        code = self.reachable(1)
+        self.assertIn(
+            "precommit.py",
+            code,
+            "Phase 1 never invokes the verifier, so the ecosystem has a reference "
+            "and no mechanism -- which is the shape the Cargo warning is about",
+        )
+
+    def test_phase_4_keeps_the_blast_radius_in_the_audited_tree(self):
+        """The hook definition says what the hook now *selects*; it does not say
+        how much of this repository that is. #104 was a count attributed to a
+        class of file that came from splitting a tool's summary line, and this is
+        the phase that tempts exactly that split."""
+        self.assertRegex(
+            self.flat(4),
+            r"not how much of this (repo|tree)",
+            "Phase 4 does not say the selection change has to be measured in the "
+            "audited tree, so the hook's own field reads as the blast radius",
         )


### PR DESCRIPTION
Closes #109.

`.github/dependabot.yml` configures two ecosystems and says these PRs are *"the only end-to-end exercise this plugin gets"*. One of the two was verified end to end; the other reached Phase 1's boundary every month and stopped. #98's own report put it as **"a Hold I would not defend on the merits, only on the procedure"** — everything checkable pointed the other way. A gate that always says Hold is one the reader learns to discount, and it is the same gate that would refuse a genuinely bad bump.

## What a `rev:` actually is

A git ref on somebody else's repository. Not a hash, so there is no artifact to verify; not a version either, so a per-package currency check answers a question nobody asked. `scripts/precommit.py` derives three things:

| | |
|---|---|
| **the pin** | resolved to a commit, classified immutable / mutable / underivable. Reports *immutability*, never integrity — as `actions.md` does for `uses:` |
| **the requirement** | read from the hook repo's own packaging. `mirrors-mypy` pins `mypy==2.3.1` in `setup.py`; `ruff-pre-commit` pins `ruff==0.16.5` in `pyproject.toml`. *That* is the dependency, and pointing Phases 2 and 3 at it puts them on covered ground |
| **the hook definition** | `.pre-commit-hooks.yaml`, diffed field by field |

## The third is what earns the script

Measured on `ruff-pre-commit` v0.16.2 → v0.16.5, which is this repo's #99:

```
!! ruff-format.types_or  [behavioural]
     before: [python, pyi, jupyter]
     after:  [python, pyi, jupyter, markdown]
```

One word, one list, and the hook began rewriting every Markdown file in the repository. **`ruff` itself did not change in any way its changelog reports** — the defect lived entirely in the wrapper — so a per-package view of `ruff` returns *current* and *clean*, correctly, about the wrong artifact. Finding that by hand took a day.

## Where the claim cannot be made, it is refused

The objection that removed npm, Cargo and Go is that an unverified verifier reports green rather than erroring. So:

- a hook whose `language` is not `python` gets its requirement derived **and its registry named as not covered**. npm is the boundary again, one layer in — saying so is the point of deriving it.
- `.pre-commit-hooks.yaml` is parsed by a small grammar that **raises** on anything outside it, and the raw text still reaches the reader: a refusal that also withholds the evidence turns a degraded answer into no answer. Verified against four live mirrors that agree on nothing cosmetic — two- and four-space continuations, quoted keys, one folded scalar.
- `install_requires` is read by **AST, not regex**; a computed entry is `underivable`, not a partial list read as whole.
- an unrecognised hook field counts as **behavioural**. `pre-commit` gains keys, and a new selector must not arrive as cosmetic because a list predates it.
- the tag-versus-pin check fires only where the tag is shaped like a dotted version. Three tests failing at once found the false-positive class.

## Verification

Both live PRs are the fixtures, and they are complementary:

| Fixture | Expected | Got |
|---|---|---|
| #99 `ruff-pre-commit` v0.16.2→v0.16.5 | catches it | exit 1, isolated to `ruff-format.types_or` |
| #98 `mirrors-mypy` v2.3.0→v2.3.1 | must not flag | exit 0, resolves `mypy 2.3.1` from `setup.py` |
| `mirrors-mypy` v1.18.2→v2.3.1 (quoting only) | must not flag | exit 0 |
| `mirrors-prettier` v3.1.0→v4.0.0-alpha.8 | boundary | exit 1, `entry` lost `--list-different`; registry named **NOT PyPI** |

`integration/test_precommit_replay.py` replays these against the real repositories, because the hermetic fixtures are only evidence that the parser reads what was copied out of the files on the day it was written.

Every new test was mutation-checked. Three gaps were found and closed that way, and **two surviving mutations are recorded as such** rather than papered over: one is caught by a second guard, the other described a defect that does not exist. `PACKAGING` was restructured because a mutation flipping it changed nothing — it looked like it drove the lookup order and only fed an error message.

`test_skill_prose.py` gains `pre-commit.md` to the existing `ECOSYSTEMS` list rather than a second guard, which then checks all five phases in both directions for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)