### PR TITLE
The shipped descriptions still claimed two ecosystems (0.38.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "dependabot-audit",
-      "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
+      "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock, GitHub Actions and pre-commit hooks end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
       "author": {
         "name": "Richard Graham"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dependabot-audit",
-  "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock and GitHub Actions end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
+  "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock, GitHub Actions and pre-commit hooks end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
   "version": "0.38.0",
   "author": {
     "name": "Richard Graham"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,15 @@ written.
   written for. It now selects on the verdict cell and checks every match.
   Mutation-checked afterwards against the defect it was written for.
 
+- **Both shipped plugin descriptions still claimed two ecosystems**, and the whole
+  suite passed. `plugin.json` and `marketplace.json` carry the text a user reads
+  in `/plugin` *before* installing, and they were read for their `name` and never
+  for what they claim — so the one statement of scope a user sees first was the
+  one nothing checked. `test_plugin_layout.py` now asserts the two manifests agree
+  word for word and that every covered ecosystem is named wherever scope is
+  stated, `SKILL.md`'s frontmatter included. It understated the plugin rather than
+  overstating it, which is why nobody would have reported it.
+
 - **Two new guards that went green under mutation, caught before they shipped.**
   One asserted a phrase over the whole of `render`'s output and was satisfied by a
   different `print` higher up; it now slices at the row. The other asserted the

--- a/tests/test_plugin_layout.py
+++ b/tests/test_plugin_layout.py
@@ -168,3 +168,63 @@ class TestTheChangelogIndexIsComplete(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheShippedDescriptionMatchesTheSkill(unittest.TestCase):
+    """Three files state this plugin's scope, and two of them are not prose.
+
+    `plugin.json` and `marketplace.json` carry the description a user reads in
+    `/plugin` before installing anything, and `SKILL.md`'s frontmatter carries
+    the one the model reads when deciding whether the skill applies. Nothing
+    connected them.
+
+    0.38.0 added `pre-commit` as a covered ecosystem and updated `SKILL.md`,
+    every phase's method table, the boundary sentence, both scripts' refusal
+    messages and the README -- and left both manifests saying "Verifies uv.lock
+    and GitHub Actions end to end". The whole suite passed, because the manifests
+    were read for their `name` and never for what they claim.
+
+    That is the worst place for the claim to rot: it is the only one a user sees
+    *before* installing, and it understates the plugin rather than overstating
+    it, so nobody reports it.
+    """
+
+    MARKETPLACE: ClassVar[pathlib.Path] = ROOT / ".claude-plugin/marketplace.json"
+    SKILL: ClassVar[pathlib.Path] = ROOT / "skills/dependabot-audit/SKILL.md"
+
+    # Every ecosystem name that must appear wherever the scope is stated. Adding
+    # one here is the whole cost of adding an ecosystem to this check.
+    COVERED: ClassVar[tuple[str, ...]] = ("uv.lock", "GitHub Actions", "pre-commit")
+
+    def _manifest_descriptions(self) -> dict[str, str]:
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        market = json.loads(self.MARKETPLACE.read_text(encoding="utf-8"))
+        entries = [p for p in market["plugins"] if p["name"] == manifest["name"]]
+        self.assertEqual(len(entries), 1, "the marketplace lists this plugin once")
+        return {
+            "plugin.json": manifest["description"],
+            "marketplace.json": entries[0]["description"],
+        }
+
+    def test_the_two_manifests_agree_word_for_word(self):
+        """They are copies, and a copy edited in one place is the ordinary way
+        this drifts. Neither is derived from the other at build time."""
+        got = self._manifest_descriptions()
+        self.assertEqual(
+            got["plugin.json"],
+            got["marketplace.json"],
+            "the installed description and the one shown before installing differ",
+        )
+
+    def test_every_covered_ecosystem_is_named_where_scope_is_stated(self):
+        stated = self._manifest_descriptions()
+        stated["SKILL.md frontmatter"] = self.SKILL.read_text(encoding="utf-8").split("---")[1]
+        for where, text in stated.items():
+            for ecosystem in self.COVERED:
+                with self.subTest(where=where, ecosystem=ecosystem):
+                    self.assertIn(
+                        ecosystem,
+                        text,
+                        f"{where} states this plugin's scope and does not name "
+                        f"`{ecosystem}`, which every phase has a method for",
+                    )


### PR DESCRIPTION
Found by reading `plugin.json` before cutting the release, **not by a test** — which is the finding.

`plugin.json` and `marketplace.json` carry the description a user reads in `/plugin` *before* installing anything. #114 added `pre-commit` and updated `SKILL.md`, every phase's method table, the boundary sentence, both scripts' refusal messages, `dependabot.yml` and the README. Both manifests still said *"Verifies uv.lock and GitHub Actions end to end"*, and 480 tests passed — they were read for their `name` and never for what they claim.

That is the worst place for the claim to rot: the only statement of scope a user sees **before** installing, and it *understates* the plugin rather than overstating it, so nobody would have reported it.

`test_plugin_layout.py` now asserts:

- the two manifests **agree word for word** — they are copies, and a copy edited in one place is the ordinary way this drifts;
- every covered ecosystem is named **wherever scope is stated**, `SKILL.md`'s frontmatter included.

Adding an ecosystem to the check is one string in `COVERED`.

Mutation-checked both directions — reverting either manifest alone fails two cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)