### PR TITLE
Two gaps reading the 0.38.0 sprint afterwards (0.38.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,15 @@ written.
   written for. It now selects on the verdict cell and checks every match.
   Mutation-checked afterwards against the defect it was written for.
 
+- **`SECURITY.md` did not list the ecosystem this version added**, and it is the
+  one with the broadest execution surface. `pre-commit run` **builds each hook's
+  environment at run time** — installing from PyPI or npm and then executing the
+  hook over your files, at the `rev:` the PR proposes, from a repository neither
+  the user nor this plugin controls. There is no `--no-build` equivalent; what
+  narrows it is `--hook <id>`, and the fact that Phases 1 and 4 answer *what
+  changed* from the network without running anything. The per-phase table gains
+  the row too, because "a frozen install" did not describe it.
+
 - **Phase 0's new worktree table said "Four paths" over five rows**, in the same
   edit that added the table. Every guard written for that change asserted what the
   rule *says* and none could count, so `test_skill_prose.py` gains one that reads

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,13 @@ written.
   written for. It now selects on the verdict cell and checks every match.
   Mutation-checked afterwards against the defect it was written for.
 
+- **Phase 0's new worktree table said "Four paths" over five rows**, in the same
+  edit that added the table. Every guard written for that change asserted what the
+  rule *says* and none could count, so `test_skill_prose.py` gains one that reads
+  the stated number and the table it sits above — a number beside the thing it
+  counts is the cheapest prose defect to make, and the tables here are already
+  parsed.
+
 - **Both shipped plugin descriptions still claimed two ecosystems**, and the whole
   suite passed. `plugin.json` and `marketplace.json` carry the text a user reads
   in `/plugin` *before* installing, and they were read for their `name` and never

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,6 +26,7 @@ is the largest thing it does that cannot be undone.
 |---|---|
 | 4 | the repo's gates, at a version taken from the diff under audit, through a shell |
 | 5 | a frozen install (npm lifecycle scripts, sdist builds, `build.rs`) and the PR's own test suite, from the PR's tree |
+| 4, 5 | for a `pre-commit` bump: **the hook itself**, at the `rev:` the PR proposes — see the row below, because it is not a frozen install |
 
 Phases 0–3 and 6–8 are network reads and `git` queries and execute nothing.
 
@@ -39,9 +40,20 @@ removed.
 | Ecosystem | What an install runs | How to narrow it |
 |---|---|---|
 | **PyPI / uv** | any sdist in the resolution builds, running `setup.py` or the PEP 517 backend | `uv sync --locked --no-build --no-install-project` |
+| **pre-commit** | `pre-commit run` **builds each hook's environment at run time**, installing from PyPI or npm and then executing the hook over your files — at the `rev:` the PR proposes, from a repository neither you nor this plugin controls | nothing equivalent to `--no-build`. Narrow the *blast radius* instead: `--hook <id>` runs one hook, and Phases 1 and 4 read the hook definition over the network without running anything |
 | npm | `preinstall` / `install` / `postinstall` scripts — the standard supply-chain vector | `npm ci --ignore-scripts` |
 | Cargo | every crate's `build.rs` | **nothing** — there is no flag |
 | Go | nothing at install time; `go build` does not run third-party build hooks | not needed |
+
+**The `pre-commit` row is the one to read twice, because it is not a removed
+recipe — it is a supported ecosystem.** A `rev:` bump proposes new code on a third
+party's repository, and running the hook is what executes it. Two things follow.
+Phases 1 and 4 answer *what changed* from the network alone, so the highest-yield
+question here — did the hook's definition move — is settled **before** anything
+runs. And Phase 5 is where it does run, behind `$MAY_EXECUTE` with the rest.
+
+A hook whose `language` is not `python` also drags in that language's toolchain
+and its own registry; the plugin reports that boundary rather than crossing it.
 
 This is the half of a removed recipe that fails *safe*. A warning that is ignored
 costs nothing; a verification that is wrong reports green.

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -186,8 +186,8 @@ path argument, and clears `pr-<N>` and `base-<N>` together.
 
 **Create the worktrees only where Phase 4 or Phase 5 will run.** They are the two
 phases that need a tree; every other read here reaches the PR through
-`git show` at a ref. Four paths run neither, and the condition is the phases
-rather than any one of the four:
+`git show` at a ref. Five paths run neither, and the condition is the phases
+rather than any one of the five:
 
 | Condition | Already on disk as | Why neither phase runs |
 |---|---|---|

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -4290,3 +4290,35 @@ class TestPreCommitIsACoveredEcosystem(SkillHarness):
             "Phase 4 does not say the selection change has to be measured in the "
             "audited tree, so the hook's own field reads as the blast radius",
         )
+
+
+class TestACountedListMatchesWhatFollowsIt(SkillHarness):
+    """Phase 0's worktree rule said "Four paths run neither" above a five-row
+    table, in the same edit that added the table.
+
+    Caught by reading, after the guards for that change were written and
+    mutation-checked -- because every one of them asserted what the rule *says*
+    and none could count. A number stated beside the thing it counts is the
+    cheapest kind of prose defect to make and the easiest to check
+    mechanically, and this repo has the material to check it: the tables are
+    already parsed.
+    """
+
+    WORDS: ClassVar[dict[str, int]] = {
+        "two": 2, "three": 3, "four": 4, "five": 5, "six": 6, "seven": 7, "eight": 8,
+    }  # fmt: skip
+
+    def test_the_worktree_carve_out_counts_its_own_table(self):
+        body = dict(self.phases)[0]
+        start = body.index("Create the worktrees only where")
+        passage = body[start : start + 2400]
+        stated = re.search(r"\b(two|three|four|five|six|seven|eight)\b paths", passage.lower())
+        self.assertIsNotNone(stated, "the carve-out no longer states a count of paths")
+        rows = next(t for t in tables(passage) if "Condition" in t[0])
+        # minus the header and the `|---|` separator
+        self.assertEqual(
+            self.WORDS[stated.group(1)],  # type: ignore[union-attr]
+            len(rows) - 2,
+            f"the carve-out says {stated.group(1)} paths and its table has "  # type: ignore[union-attr]
+            f"{len(rows) - 2} rows",
+        )


### PR DESCRIPTION
Both found by **reading the sprint back**, not by any guard written for it.

## `SECURITY.md` did not list the ecosystem this version added

The more serious of the two. `SECURITY.md` enumerates what a frozen install executes per ecosystem — including three that were *removed* from scope, deliberately, because "the hazard is true whatever you are looking at". #114 added `pre-commit` as a **supported** ecosystem and did not add it to that table, so the one entry a reader most needs was the one missing.

It is also the broadest surface here, and it is **not a frozen install**:

> `pre-commit run` builds each hook's environment at run time, installing from PyPI or npm and then executing the hook over your files — at the `rev:` the PR proposes, from a repository neither you nor this plugin controls.

There is no `--no-build` equivalent. What narrows it is `--hook <id>`, plus the shape of the procedure: **Phases 1 and 4 answer *what changed* over the network without running anything**, so the highest-yield question — did the hook's definition move — is settled before Phase 5 runs it behind `$MAY_EXECUTE`. The per-phase table gains a row too, because "a frozen install" did not describe it.

## The worktree carve-out said four paths over five rows

Introduced by the #111 fix in this same version. The lead sentence said *"Four paths run neither"* above a five-row table, while the closing paragraph of the same passage said *"one of five conditions"* and *"the same in all five"* — the passage disagreed with itself twice, in the edit that was about stating a rule once instead of five times.

Every guard written for that change asserts what the rule *says*; none could count. `test_skill_prose.py` now reads the stated number and counts the table beneath it — the cheapest kind of prose defect to make, and one of the few that can be checked mechanically, since the tables are already parsed here.

Mutation-checked both ways:

| Mutation | Result |
|---|---|
| restore `Four paths` | fails |
| delete a table row, leave the count at five | fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)