### PR TITLE
The pre-commit reference did not run as written (0.39.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dependabot-audit",
   "description": "Audit a Dependabot or Renovate PR and produce an evidence-backed merge recommendation. Verifies uv.lock, GitHub Actions and pre-commit hooks end to end; any other ecosystem gets the ecosystem-independent phases and a stated boundary. Read-only: it reports, it never merges.",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "author": {
     "name": "Richard Graham"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,83 @@ patch.
 
 ## [Unreleased]
 
+## [0.39.0] — 2026-09-04
+
+The first live replay of `/dependabot-audit 99` against 0.38.0, on the ecosystem
+0.38.0 added. **The audit reached the right verdict** — Merge as-is, high
+confidence, no follow-up, matching an answer derived independently beforehand —
+and handed back four deviations, every one of them a command
+`references/pre-commit.md` promised and did not supply.
+
+**Minor, not patch.** Phase 0 gains an assertion it did not make. The rest are
+fixes that make existing claims true, and on their own would be a patch.
+
+### Fixed — the reference did not run as written
+
+- **Phase 2 sent a bare package to `scripts/audit.py`**, which takes a lockfile
+  positional and sniffs the content; handed a name it exits `cannot read <name>`.
+  A false claim about this repo's own script, in prose written the previous day —
+  a docstring-as-claim defect, one file over. `changelog.py
+  --package` genuinely does work and is what the row now names, and the PyPI
+  currency read is supplied as a command because the cooldown subtraction needs a
+  publish time and had none.
+
+- **Phase 3 had no runnable command at all.** It said "same as `uv.lock`: OSV and
+  GHSA" — where that work is done by `audit.py`, which cannot run here. So the
+  phase most exposed to a silent empty answer was the one with nothing to run. It
+  now carries both queries, and the GHSA one is **unqualified by version**, with
+  the reason: a version-qualified query reads clean whether or not the package has
+  advisories.
+
+- **Phases 4 and 5 called `pre-commit` bare.** It is not on `PATH` on the machine
+  that ran the replay, and this repo's own `ci.yml` pip-installs it before use.
+  The invocation is now derived once (`$PC`, falling back to `uvx pre-commit`) with
+  the reminder that an absent binary is **exit 2, not a failing hook** — "could not
+  run" reported as "ran and found something" is the easiest place here to lose that
+  distinction, because a missing binary and a failing hook both exit non-zero.
+
+- **Phase 4 gave only the with-config half of a two-run comparison.** `SKILL.md`
+  requires two check-only runs to reconcile a defeated exclusion, and the
+  with-config run passes at both revs and says nothing. Both halves are now there,
+  with the measurement: the hook passes at either rev, while the tool alone
+  reformats **6 of 16** Markdown files at ruff 0.16.5 **and the identical 6 at
+  0.16.2**. The versions agreeing is what establishes that the *wrapper* changed
+  its selection rather than the tool changing its behaviour — and only that pair
+  can show it.
+
+### Added — Phase 0 asserts the fetch against the pin
+
+- **A bot rebased 18 seconds after Phase 0 pinned the head**, during the replay.
+  `discover.py` ran at 23:08:39Z, Dependabot rebased #99 at 23:08:57Z, and the next
+  read returned a different head **and a different base** (`515653a` → `4820d14`),
+  because the rebase moved the branch onto current `main`.
+
+  It was caught **by accident**: `git worktree add` printed an abbreviated SHA that
+  disagreed with `$HEAD_SHA`. The stale-worktree guard could not have caught it —
+  that one fires when `worktree add` *refuses*, and here the path was free and the
+  add succeeded at the wrong commit. Phase 0 now compares the fetched ref against
+  the pin and exits 1 naming both, and says to re-derive Phase 0 **whole**: patching
+  `$HEAD_SHA` alone leaves `$BASE_SHA` pre-rebase, which is the rewritten-base
+  failure arriving by another route.
+
+### Added — guards that execute the recipe
+
+- `integration/` now extracts the reference's one-liners **from the file and runs
+  them**. This is not redundant with the prose guards, and the proof is that the
+  first draft of the OSV query shipped with a mismatched bracket
+  (`{"queries":[… for v in …}`) that every reading looked past; running it back out
+  of the file caught it immediately. The GHSA guard runs twice — once on `ruff`,
+  expecting nothing, and once on a package known to have advisories — because a
+  query that has only ever returned empty establishes nothing about whether it can
+  return anything.
+
+### Note
+
+The replay's fifth deviation row proposed chasing a stale `gh` read, and **that
+diagnosis is disproved**: the timing shows the first read was correct when it was
+made. The row was marked `unproven` by the run itself, which is the hand-back rule
+working — and its *remedy* was right regardless of its cause, which is what landed.
+
 ## [0.38.0] — 2026-09-03
 
 Closes [#109](https://github.com/Machai-Kydoimos/dependabot-audit/issues/109),
@@ -4453,7 +4530,8 @@ gives the read-only subset a name.
 - Repo specifics are derived every run and never cached; only non-derivable
   landmines are persisted, via the Phase 8 learning loop.
 
-[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.38.0...HEAD
+[Unreleased]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.39.0...HEAD
+[0.39.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/Machai-Kydoimos/dependabot-audit/compare/v0.35.0...v0.36.0

--- a/integration/test_precommit_replay.py
+++ b/integration/test_precommit_replay.py
@@ -28,6 +28,7 @@ import io
 import json
 import os
 import pathlib
+import subprocess
 import sys
 import unittest
 from typing import Any
@@ -122,3 +123,80 @@ class TestTheRealBumpsStillReadTheSameWay(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@unittest.skipUnless(NETWORK, "set RUN_NETWORK_TESTS=1 to run (needs `gh` and the network)")
+class TestTheDocumentedCommandsActuallyRun(unittest.TestCase):
+    """The reference's one-liners, extracted from the file and executed.
+
+    Prose guards assert a command is *present*. That is not the same as it
+    running, and the difference is not hypothetical: the first draft of the OSV
+    query in `references/pre-commit.md` had a mismatched bracket
+    (`{"queries":[... for v in ...}`) and was caught only by running it back out
+    of the file. Every reading of it looked right.
+
+    This is the same lever `test_ruff_replay.py` uses and the same one
+    `test_audit.py` uses for the `--no-build` salvage: when the recipe is
+    executable, write the guard to run it.
+    """
+
+    REF = pathlib.Path(__file__).resolve().parent.parent / (
+        "skills/dependabot-audit/references/pre-commit.md"
+    )
+
+    def _line_after(self, marker: str, substitute: tuple[str, str]) -> str:
+        text = self.REF.read_text(encoding="utf-8")
+        self.assertIn(marker, text, f"the reference no longer contains `{marker[:40]}…`")
+        start = text.index(marker)
+        return text[start : text.index("\n", start)].replace(*substitute)
+
+    def _run(self, line: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S602
+            line, shell=True, capture_output=True, text=True, timeout=120, check=False
+        )
+
+    def test_the_pypi_currency_one_liner_runs(self):
+        """Phase 2's, and the cooldown subtraction depends on its timestamp."""
+        got = self._run(
+            self._line_after(
+                "python3 -c 'import json,sys,urllib.request as u; d=json.load", ("<pkg>", "ruff")
+            )
+        )
+        self.assertEqual(got.returncode, 0, got.stderr[:400])
+        self.assertRegex(got.stdout, r"latest=\d+\.\d+", got.stdout)
+        self.assertIn("published=", got.stdout)
+        self.assertIn("yanked=", got.stdout)
+
+    def test_the_osv_batch_one_liner_runs_over_a_gap(self):
+        got = self._run(
+            self._line_after(
+                "python3 -c 'import json,sys,urllib.request as u; vs=sys.argv",
+                ("<pkg> <every version in the gap>", "ruff 0.16.2 0.16.5"),
+            )
+        )
+        self.assertEqual(got.returncode, 0, got.stderr[:400])
+        self.assertEqual(len(got.stdout.strip().splitlines()), 2, "one row per version in the gap")
+        self.assertIn("advisory(ies)", got.stdout)
+
+    def test_the_ghsa_query_runs_and_discriminates(self):
+        """Run twice, and the second run is the point. A query that has only ever
+        returned empty proves nothing about whether it can return anything --
+        CONTRIBUTING's rule about a test that has only ever passed, one level out.
+        """
+        text = self.REF.read_text(encoding="utf-8")
+        start = text.index("gh api graphql -f query='{securityVulnerabilities")
+        end = text.index("```", start)
+        recipe = text[start:end].strip().rstrip("\\").strip()
+
+        clean = self._run(recipe.replace("<pkg>", "ruff"))
+        self.assertEqual(clean.returncode, 0, clean.stderr[:400])
+        self.assertEqual(clean.stdout.strip(), "", "ruff is expected to have none")
+
+        control = self._run(recipe.replace("<pkg>", "requests"))
+        self.assertEqual(control.returncode, 0, control.stderr[:400])
+        self.assertRegex(
+            control.stdout,
+            r"GHSA-\w+",
+            "the same query returns nothing for a package known to have "
+            "advisories, so a clean result from it establishes nothing",
+        )

--- a/skills/dependabot-audit/SKILL.md
+++ b/skills/dependabot-audit/SKILL.md
@@ -165,9 +165,39 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 
 git worktree prune          # a previous run's registrations, if $SCRATCH is gone
 git fetch origin "pull/<N>/head:pr-<N>" "$DEFAULT"
+
+# The fetch is the first thing that can disagree with the pin, so assert it here
+# rather than trusting it. Exit 1: the block ran and found something, and what it
+# found changes the shape of the audit.
+FETCHED=$(git rev-parse "pr-<N>") || { echo "pr-<N> did not resolve after the fetch" >&2; exit 2; }
+[ "$FETCHED" = "$HEAD_SHA" ] || {
+  echo "the head moved: discover.py pinned $HEAD_SHA, the fetch resolved $FETCHED" >&2
+  echo "re-run Phase 0 from the start — the pin, the base and the scope move together" >&2
+  exit 1; }
+
 git worktree add "$SCRATCH/pr-<N>" "pr-<N>"
 git worktree add --detach "$SCRATCH/base-<N>" "$BASE_SHA"   # Phase 4 measures here
 ```
+
+**That assertion is not defensive clutter, and the interval it guards is seconds.**
+A bot can rebase between `discover.py` reading the head and the fetch resolving it,
+and then every row of the report is about a commit that is no longer the PR.
+Measured on this plugin's own #99: `discover.py` ran at `23:08:39Z`, Dependabot
+rebased at `23:08:57Z`, and the run's next read returned a different head **and a
+different base** — `$BASE_SHA` moved with it, because the rebase moved the branch
+onto current `main`.
+
+**It was caught that time by accident**, which is the argument for the assertion.
+`git worktree add` prints an abbreviated SHA, a reader noticed it disagreed with
+`$HEAD_SHA`, and the audit recovered. Nothing in the procedure compared the two;
+the guard below fires only when `worktree add` *refuses*, which it does not do
+here — the path was free and the add succeeded, at the wrong commit.
+
+**Re-run Phase 0 whole, never just the pin.** The head, the base, the scope gate
+and the branch-point verdict are all derived from the same read, and a rebase
+moves more than one of them. Patching `$HEAD_SHA` alone leaves `$BASE_SHA` pointing
+at the pre-rebase base, which is the rewritten-base failure arriving by a different
+route.
 
 **`prune` first, and it is not defensive clutter.** `$SCRATCH` lives under
 `$TMPDIR`, so a reboot or a tmp sweep between two audits of the same PR deletes

--- a/skills/dependabot-audit/references/pre-commit.md
+++ b/skills/dependabot-audit/references/pre-commit.md
@@ -111,8 +111,34 @@ that is before you do**:
 
 | Hook `language` | Registry | Covered here |
 |---|---|---|
-| `python` | PyPI | **yes** — hand the package and version to `scripts/audit.py` and `scripts/changelog.py`, which verify it end to end |
+| `python` | PyPI | **yes** — `scripts/changelog.py --package` reads the gap end to end |
 | anything else | npm, rubygems, crates.io … | **no.** Report the boundary. Do not improvise a recipe from the shape of the PyPI one |
+
+**`scripts/audit.py` does not apply here, and this file used to say it did.** It
+takes a lockfile positional and sniffs the content; handed a package name it exits
+with `cannot read <name>`. A `pre-commit` bump has no lockfile, so the currency
+read is two commands rather than one script:
+
+```bash
+# Fresh call: nothing survives one, so re-derive $SCRATCH and re-source Phase 0.
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATCH:-${TMPDIR:-/tmp}/dbaudit-${REPO/\//-}-<N>}"
+. "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
+
+# The registry's true latest AND when it was published. Phase 2 compares that
+# against $CREATED_AT, never against now, so the timestamp is not optional —
+# it is what separates "the bot is behind" from "the bot is inside the cooldown".
+python3 -c 'import json,sys,urllib.request as u; d=json.load(u.urlopen("https://pypi.org/pypi/"+sys.argv[1]+"/json")); v=d["info"]["version"]; f=d["releases"][v][0]; print("latest="+v, "published="+f["upload_time_iso_8601"], "yanked="+str(f["yanked"]))' <pkg>
+
+# The gap's changelog, which IS scripted — `--package`, no lockfile needed.
+python3 "${SCRIPTS:?not in the handoff — re-run Phase 0}/changelog.py" \
+  --scratch "$SCRATCH" --package <pkg> --from <old version> --to <new version>
+```
+
+Measured on `ruff`, 2026-09-04: `latest=0.16.6 published=2026-09-03T16:56:40Z
+yanked=False`; and `changelog.py` resolved `astral-sh/ruff` from PyPI's metadata
+on its own, read all three rungs, and reported **266 of 307 commits unreconciled**
+against what the release notes claim. That reconciliation is the reason to run it
+rather than reading the notes.
 
 The script prints the language and says which of those two rows applies. This is
 the whole of #109's argument: for a Python hook, resolving the requirement puts
@@ -134,18 +160,59 @@ otherwise disagree on every single bump.
 
 ## Phase 3 — Known vulnerabilities
 
-Same as `uv.lock`, on the requirement rather than the tag: OSV and GHSA, queried
-for the **package the hook installs** at the version being adopted.
+OSV and GHSA, queried for the **package the hook installs** at the version being
+adopted — never for the `rev:`. `v0.16.5` is not a PyPI version of anything, so a
+query built from the tag returns an empty result that reads exactly like *no known
+vulnerabilities*. That is the failure this phase is most exposed to here, and it
+is silent.
 
-`v0.16.5` is not a PyPI version of anything, so a query built from the `rev:`
-returns an empty result that reads exactly like *no known vulnerabilities*. That
-is the failure this phase is most exposed to here, and it is silent.
+**`audit.py` does that batch for `uv.lock` and cannot do it here**, because it
+needs a lockfile. So the two queries are yours, and they are short:
+
+```bash
+# OSV, across the whole gap rather than only the version being adopted: a bump
+# that steps over an affected release still spent time on it, and Phase 7's table
+# asks whether the bump moves *into* the advisory or past it.
+python3 -c 'import json,sys,urllib.request as u; vs=sys.argv[2:]; q={"queries":[{"package":{"name":sys.argv[1],"ecosystem":"PyPI"},"version":v} for v in vs]}; r=json.load(u.urlopen(u.Request("https://api.osv.dev/v1/querybatch",data=json.dumps(q).encode(),headers={"Content-Type":"application/json"}))); [print(sys.argv[1],v,len(x.get("vulns") or []),"advisory(ies)") for v,x in zip(vs,r["results"])]' <pkg> <every version in the gap>
+
+# GHSA, and note it is UNQUALIFIED by version. A version-qualified query reads
+# clean whether or not the package has advisories, which is the reassuring
+# direction; ask for all of them and read the ranges yourself.
+gh api graphql -f query='{securityVulnerabilities(first:20, ecosystem:PIP, package:"<pkg>"){nodes{advisory{ghsaId severity}vulnerableVersionRange firstPatchedVersion{identifier}}}}' \
+  --jq '.data.securityVulnerabilities.nodes[] | .advisory.ghsaId+"  "+.advisory.severity+"  "+.vulnerableVersionRange'
+```
+
+**Both were run while writing this, and the GHSA one was run against a control.**
+`ruff` returns zero from each, at 0.16.2, 0.16.5 and 0.16.6. A check that has only
+ever returned empty proves nothing about whether it discriminates, so the same
+query was pointed at `requests`, which returns `GHSA-gc5v-m9x4-r6x2 MODERATE
+< 2.33.0` and two more. Point it at a package you know is affected before you
+trust a clean answer from it.
 
 Where the language is not `python`, the ecosystem is outside this plugin: report
 that the advisory check was not made, rather than making one whose result you
 cannot stand behind.
 
 ## Phase 4 — Behavior change
+
+**`pre-commit` is very often not on `PATH`, and this phase and the next both call
+it.** This repository's own `ci.yml` does `pip install pre-commit` first, so even
+here it is not assumed. Derive the invocation once, at the top of this phase, and
+reuse it in Phase 5:
+
+```bash
+PC=$(command -v pre-commit >/dev/null && echo "pre-commit" || echo "uvx pre-commit")
+$PC --version || { echo "no pre-commit and no uvx — Phases 4 and 5 cannot run" >&2; exit 2; }
+```
+
+`uvx pre-commit` fetches it on demand and needs no install. Measured here on
+2026-09-04: `command -v pre-commit` exits **1**, and `uvx pre-commit --version`
+prints `pre-commit 4.6.2`.
+
+**An absent `pre-commit` is exit 2, not a failing hook.** "Could not run" reported
+as "ran and found something" is the distinction this procedure is most careful
+about everywhere else, and the easiest one to lose here — a shell that cannot find
+the binary exits non-zero exactly like a hook that found a problem.
 
 **This is the phase, and the hook definition is where it lives.** Diff
 `.pre-commit-hooks.yaml` between the two revs — which is what the script did in
@@ -168,12 +235,42 @@ REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner); SCRATCH="${SCRATC
 . "$SCRATCH/phase0.env" || { echo "no handoff in $SCRATCH — re-run Phase 0" >&2; exit 2; }
 [ "${MAY_EXECUTE:-}" = yes ] || { echo "MAY_EXECUTE='${MAY_EXECUTE:-unset}' — this block runs the PR's code; not authorised" >&2; exit 2; }
 
-# Check mode, both revs, against the SAME tree. `--all-files` and never a commit:
-# the question is what the hook selects now, not what a commit happened to touch.
-git -C "$SCRATCH/base-<N>" ls-files | wc -l          # the denominator, stated
-( cd "$SCRATCH/base-<N>" && pre-commit run <hook id> --all-files )
-( cd "$SCRATCH/pr-<N>"   && pre-commit run <hook id> --all-files )
+# The denominator, stated — `report-template.md` requires a count attributed to a
+# class of file to come from a command, and this is the phase that tempts the split.
+git -C "$SCRATCH/pr-<N>" ls-files | wc -l
+git -C "$SCRATCH/pr-<N>" ls-files '*.md' | wc -l     # or whatever class the field selects
+
+# 1. WITH the repo's config, both revs, against the SAME tree. This is what
+#    actually happens on a commit.
+( cd "$SCRATCH/base-<N>" && $PC run <hook id> --all-files )
+( cd "$SCRATCH/pr-<N>"   && $PC run <hook id> --all-files )
+
+# 2. WITHOUT it — the tool alone, at each rev's pinned version, over the files the
+#    new `types_or`/`types`/`files` now selects. This is the pair that separates
+#    *the tool changed* from *the wrapper's selection changed*, and nothing else does.
+cd "$SCRATCH/pr-<N>"
+uvx <tool>@<old version> format --check $(git ls-files '*.md')
+uvx <tool>@<new version> format --check $(git ls-files '*.md')
 ```
+
+**Read the two runs against each other, not each on its own.** Measured on this
+repository at `ruff-pre-commit` v0.16.2 → v0.16.5:
+
+| Run | Result |
+|---|---|
+| hook **with** config, either rev | `ruff format … Passed` — 0 files rewritten |
+| tool **without** config, ruff 0.16.5 | `6 files would be reformatted, 10 already formatted` |
+| tool **without** config, ruff **0.16.2** | `6 files would be reformatted, 10 already formatted` |
+
+**The old and new tool versions agree exactly.** So the tool did not change what it
+does to a Markdown file; the *wrapper* changed which files it is handed. That is
+the finding, and only the second pair of rows can produce it — the first pair
+passes at both revs and says nothing.
+
+The 6 are removed by `exclude: ^integration/fixtures/` on the hook, which is why
+the run is green. **State the exclusion as the reason**, per `SKILL.md`'s Phase 4:
+a gate that would rewrite files the repo excludes has not been shown harmless, it
+has been shown *currently excluded*, and those are different claims.
 
 Report the difference between those two runs, by **file class and counted from a
 command** — `report-template.md` is explicit that a count attributed to a class of
@@ -186,7 +283,7 @@ shadows the root for files beneath it. That rule came from this exact bump.
 
 ## Phase 5 — Independent reproduction
 
-`pre-commit run --all-files` in `$SCRATCH/pr-<N>`, which is the repo's own gate
+`$PC run --all-files` in `$SCRATCH/pr-<N>` — `$PC` from Phase 4 — which is the repo's own gate
 and usually the whole of CI's lint job.
 
 **It is not hermetic, and the report must say so.** `pre-commit` builds each

--- a/tests/test_skill_prose.py
+++ b/tests/test_skill_prose.py
@@ -4322,3 +4322,138 @@ class TestACountedListMatchesWhatFollowsIt(SkillHarness):
             f"the carve-out says {stated.group(1)} paths and its table has "  # type: ignore[union-attr]
             f"{len(rows) - 2} rows",
         )
+
+
+class TestTheReferenceRunsAsWritten(SkillHarness):
+    """The 0.38.0 `pre-commit` reference did not run as written.
+
+    Found by the first live replay of `/dependabot-audit 99` against it, on
+    2026-09-04. The audit reached the right verdict and handed back four
+    deviations, every one of them a command the reference promised and did not
+    supply -- or, once, promised and could not have supplied:
+
+      Phase 2 said to hand the package and version to `audit.py`. It takes a
+              lockfile positional and sniffs the content; handed a name it exits
+              `cannot read <name>`. A false claim about this repo's own script.
+      Phase 3 said "OSV and GHSA" with **no runnable command at all**, pointing
+              at `uv.lock`'s method where the work is done by that same script.
+      Phase 2 gave no PyPI query, so the cooldown subtraction had no publish time.
+      Phases 4 and 5 called `pre-commit` bare. It is not on PATH here, and this
+              repo's own `ci.yml` pip-installs it first.
+
+    A reference that names a script which cannot take the input is the
+    unverified-verifier failure pointed inward: the run improvises, and an
+    improvised advisory query returns clean.
+    """
+
+    def ref(self) -> str:
+        return (PLUGIN / "references/pre-commit.md").read_text(encoding="utf-8")
+
+    def test_phase_2_does_not_send_a_package_to_the_lockfile_script(self):
+        body = self.flat(2)
+        self.assertNotRegex(
+            body,
+            r"hand the package and version to `scripts/audit\.py`",
+            "Phase 2 still routes a bare package to `audit.py`, which requires a "
+            "lockfile and exits naming the file it could not read",
+        )
+        self.assertRegex(
+            body,
+            r"audit\.py` does not apply here",
+            "and it must say so, because the obvious reading of 'same as uv.lock' "
+            "is that the lockfile script applies",
+        )
+
+    def test_phase_2_supplies_the_registry_query_it_asks_for(self):
+        """The cooldown is a subtraction against `$CREATED_AT`, so a currency
+        read with no publish time cannot reach the row it feeds."""
+        self.assertRegex(
+            self.flat(2),
+            r"pypi\.org/pypi/",
+            "Phase 2 tells the run to take the requirement to the registry and "
+            "gives it no way to do that, so the publish time is improvised",
+        )
+
+    def test_phase_3_supplies_a_runnable_advisory_query(self):
+        """It had none. `audit.py` does the OSV batch for `uv.lock` and cannot
+        run here, so 'same as uv.lock' resolved to nothing executable."""
+        section = next(sec for name, sec in self._handoffs(3) if name == "pre-commit.md")
+        self.assertIn("api.osv.dev", section, "Phase 3 has no OSV query")
+        self.assertIn("securityVulnerabilities", section, "Phase 3 has no GHSA query")
+
+    def test_the_ghsa_query_is_unqualified_by_version(self):
+        """A version-qualified GHSA query reads clean whether or not the package
+        has advisories -- the reassuring direction, and silent."""
+        section = next(sec for name, sec in self._handoffs(3) if name == "pre-commit.md")
+        self.assertRegex(
+            " ".join(section.split()).lower(),
+            r"unqualified",
+            "nothing warns that qualifying the GHSA query by version makes it "
+            "answer clean regardless",
+        )
+
+    def test_pre_commit_is_not_assumed_to_be_on_path(self):
+        """Measured: `command -v pre-commit` exits 1 here, and this repo's own
+        `ci.yml` pip-installs it before use. Both executing phases call it."""
+        for number in (4, 5):
+            section = next(sec for name, sec in self._handoffs(number) if name == "pre-commit.md")
+            self.assertNotRegex(
+                section,
+                r"^\s*\(?\s*cd [^\n]*&& pre-commit run|^\s*pre-commit run ",
+                f"Phase {number} calls `pre-commit` bare, which does not run where "
+                "it is not installed",
+            )
+            self.assertIn(
+                "$PC",
+                section,
+                f"Phase {number} does not use the derived invocation",
+            )
+
+    def test_phase_4_supplies_the_with_and_without_config_pair(self):
+        """`SKILL.md`'s Phase 4 requires two check-only runs to reconcile a
+        defeated exclusion. The reference asked for the comparison and gave only
+        the with-config half, which passes at both revs and says nothing."""
+        section = next(sec for name, sec in self._handoffs(4) if name == "pre-commit.md")
+        flat = " ".join(section.split()).lower()
+        self.assertIn("without", flat, "Phase 4 never names the without-config run")
+        self.assertRegex(
+            flat,
+            r"old and new tool versions agree",
+            "the pair is present but its reading is not: two identical results "
+            "are what establish that the *wrapper* changed and not the tool",
+        )
+
+
+class TestTheFetchIsAssertedAgainstThePin(SkillHarness):
+    """A bot rebased 18 seconds after Phase 0 pinned the head.
+
+    Measured on this plugin's own #99 during a live replay on 2026-09-04:
+    `discover.py` ran at 23:08:39Z, Dependabot rebased at 23:08:57Z, and the
+    next read returned a different head *and* a different base. Every row of a
+    report written from the first read would have described a commit that was no
+    longer the PR.
+
+    It was caught by accident -- `git worktree add` printed an abbreviated SHA a
+    reader noticed disagreed with `$HEAD_SHA`. The stale-worktree guard could not
+    have caught it: that one fires when `worktree add` **refuses**, and here the
+    path was free and the add succeeded at the wrong commit.
+    """
+
+    def test_phase_0_compares_the_fetched_ref_against_the_pin(self):
+        self.assertRegex(
+            self.reachable(0),
+            r"FETCHED=\$\(git rev-parse",
+            "Phase 0 fetches the PR ref and never checks it resolved to "
+            "`$HEAD_SHA`, so a rebase between the two reads is silent",
+        )
+
+    def test_the_remedy_is_to_re_derive_phase_0_whole(self):
+        """`$BASE_SHA` moves with the head on a rebase -- it did here, 515653a ->
+        4820d14. Patching the pin alone leaves the base pre-rebase, which is the
+        rewritten-base failure arriving by another route."""
+        self.assertRegex(
+            self.flat(0),
+            r"re-run phase 0 whole, never just the pin",
+            "Phase 0 does not say the whole derivation has to be repeated, so the "
+            "cheap-looking fix is to patch $HEAD_SHA and keep a stale $BASE_SHA",
+        )


### PR DESCRIPTION
The first live replay of `/dependabot-audit 99` against 0.38.0 — on the ecosystem 0.38.0 added.

## The replay

- [x] Replayed against `Machai-Kydoimos/dependabot-audit` **#99**, installed plugin **0.38.0**, `claude -p`, scoped permissions (allowlist + denylist, no `bypassPermissions`)

**43 turns · 8m 42s · $3.45 · `permission_denials: []`**

**The audit was right.** Verdict *Merge as-is, high confidence, no follow-up* — matching an answer derived independently before launching, including the non-obvious half: v0.16.6 exists but was published **after** the PR opened, so it is inside Dependabot's cooldown and the bot is waiting, not lagging.

It also did the three things 0.38.0 was for: classified `pre-commit`, reached `references/pre-commit.md`, and **invoked `precommit.py`** — the check that a change can ship and never be reached. It measured the blast radius rather than reading it off the hook (50 tracked files, 16 `.md`, and the 6 ruff would rewrite are exactly the 6 `exclude:` removes), and ran ruff at **both** pinned versions over the same files to prove the change was in the wrapper.

## What it handed back — four commands the reference promised and did not supply

| Deviation | Verified how |
|---|---|
| Phase 2 routes a bare package to `audit.py` | `python3 audit.py ruff` → `cannot read ruff: No such file or directory`. **A false claim about this repo's own script.** `changelog.py --package` does work |
| Phase 3 has **zero** runnable commands | 0 fenced blocks in the section; it points at `uv.lock`'s method, where the work is `audit.py`'s |
| Phases 4/5 call `pre-commit` bare | `command -v pre-commit` → exit 1 here; this repo's `ci.yml` pip-installs it first |
| Phase 4 gives only the with-config half | that half passes at both revs and says nothing |

The Phase 4 pair, now measured and in the file:

| Run | Result |
|---|---|
| hook **with** config, either rev | `ruff format … Passed` — 0 rewritten |
| tool **without** config, ruff 0.16.5 | 6 of 16 `.md` would be reformatted |
| tool **without** config, ruff **0.16.2** | **the identical 6** |

The versions agreeing is the finding: the tool did not change, the wrapper changed what it is handed.

## Phase 0 asserts the fetch against the pin

**Dependabot rebased #99 eighteen seconds after Phase 0 pinned the head**, mid-run:

| | |
|---|---|
| `discover.py` ran | `23:08:39Z` → head `246e413c9` |
| rebase landed | `23:08:57Z` |
| next read | `23:09:24Z` → head `fa7e6ac65`, **base also moved** `515653a` → `4820d14` |

It was caught **by accident** — `git worktree add` printed an abbreviated SHA that disagreed with `$HEAD_SHA`. The stale-worktree guard could not have caught it: that fires when `worktree add` *refuses*, and here the path was free and the add succeeded at the wrong commit. Phase 0 now asserts, and says to re-derive **whole** — patching `$HEAD_SHA` alone leaves `$BASE_SHA` pre-rebase.

## Guards that run the recipe, not just read it

`integration/` now extracts the one-liners from the reference and executes them. Not redundant with the prose guards, and here is the proof: **the first draft of the OSV query shipped with a mismatched bracket** that every reading looked past, and running it back out of the file caught it immediately. The GHSA guard runs against a control package too, since a query that has only ever returned empty establishes nothing.

Mutation-checked: 8 prose guards fail against the pre-fix files; both executable guards fail against the broken bracket and a narrowed query.

## One thing I disproved

The replay's fifth deviation guessed Phase 0's first read was ">1-day stale" and suggested chasing a `gh` HTTP cache. **The timing disproves it** — the read was correct when made. The run marked it `unproven` itself, which is the hand-back rule working; its *remedy* was right regardless of its cause, and that is what landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)